### PR TITLE
test: improve Cortex-M QEMU preflight coverage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(simple_h264_enc_i VERSION 0.1.0 LANGUAGES C)
 
 option(SH264E_BUILD_TOOLS "Build command-line tools" ON)
 option(SH264E_BUILD_TESTS "Build tests" ON)
+option(SH264E_BUILD_QEMU_TESTS "Build Cortex-M QEMU firmware tests when the toolchain is usable" ON)
 
 add_library(simple_h264_enc_i STATIC
     src/sh264e.c
@@ -130,6 +131,30 @@ if(SH264E_BUILD_TESTS)
     find_program(SH264E_FFMPEG ffmpeg)
     find_program(SH264E_ARM_NONE_EABI_GCC arm-none-eabi-gcc)
     find_program(SH264E_QEMU_SYSTEM_ARM qemu-system-arm)
+    set(SH264E_CAN_BUILD_QEMU_TESTS OFF)
+    if(SH264E_BUILD_QEMU_TESTS AND SH264E_ARM_NONE_EABI_GCC AND SH264E_QEMU_SYSTEM_ARM)
+        set(SH264E_ARM_STDLIB_PROBE ${CMAKE_CURRENT_BINARY_DIR}/sh264e_arm_stdlib_probe.c)
+        file(WRITE ${SH264E_ARM_STDLIB_PROBE}
+            "#include <stdlib.h>\nint main(void) { return 0; }\n"
+        )
+        execute_process(
+            COMMAND ${SH264E_ARM_NONE_EABI_GCC}
+                -x c
+                -c
+                ${SH264E_ARM_STDLIB_PROBE}
+                -o ${CMAKE_CURRENT_BINARY_DIR}/sh264e_arm_stdlib_probe.o
+            RESULT_VARIABLE SH264E_ARM_STDLIB_PROBE_RESULT
+            OUTPUT_QUIET
+            ERROR_QUIET
+        )
+        if(SH264E_ARM_STDLIB_PROBE_RESULT EQUAL 0)
+            set(SH264E_CAN_BUILD_QEMU_TESTS ON)
+        else()
+            message(STATUS "Skipping QEMU firmware tests: arm-none-eabi-gcc cannot compile <stdlib.h>")
+        endif()
+    elseif(SH264E_BUILD_QEMU_TESTS)
+        message(STATUS "Skipping QEMU firmware tests: arm-none-eabi-gcc or qemu-system-arm was not found")
+    endif()
     if(Python3_Interpreter_FOUND AND SH264E_FFPROBE AND SH264E_FFMPEG AND SH264E_BUILD_TOOLS)
         add_test(
             NAME sh264e_ffmpeg_integration
@@ -145,8 +170,12 @@ if(SH264E_BUILD_TESTS)
         )
     endif()
 
-    if(SH264E_ARM_NONE_EABI_GCC AND SH264E_QEMU_SYSTEM_ARM)
+    if(SH264E_CAN_BUILD_QEMU_TESTS)
         function(sh264e_add_qemu_firmware TARGET_NAME SOURCE CPU MACHINE)
+            set(extra_compile_options "")
+            foreach(def IN LISTS ARGN)
+                list(APPEND extra_compile_options -D${def})
+            endforeach()
             set(ELF_PATH ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}.elf)
             add_custom_command(
                 OUTPUT ${ELF_PATH}
@@ -158,6 +187,7 @@ if(SH264E_BUILD_TESTS)
                     -fno-builtin
                     -ffunction-sections
                     -fdata-sections
+                    ${extra_compile_options}
                     -I${CMAKE_CURRENT_SOURCE_DIR}/include
                     -T${CMAKE_CURRENT_SOURCE_DIR}/tests/qemu_cortexm.ld
                     -nostdlib
@@ -213,6 +243,26 @@ if(SH264E_BUILD_TESTS)
             tests/qemu_scaler_bench.c
             cortex-m4
             mps2-an386
+        )
+        sh264e_add_qemu_firmware(
+            sh264e_qemu_scaler_bench_m4_portable
+            tests/qemu_scaler_bench.c
+            cortex-m4
+            mps2-an386
+            SH264E_DISABLE_ARM_DSP
+        )
+        sh264e_add_qemu_firmware(
+            sh264e_qemu_scaler_bench_m7
+            tests/qemu_scaler_bench.c
+            cortex-m7
+            mps2-an500
+        )
+        sh264e_add_qemu_firmware(
+            sh264e_qemu_scaler_bench_m7_portable
+            tests/qemu_scaler_bench.c
+            cortex-m7
+            mps2-an500
+            SH264E_DISABLE_ARM_DSP
         )
     endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ The test suite covers:
 * SPS/PPS/IDR Annex B NALU sequence
 * library boundary check for forbidden file I/O calls
 * ffmpeg/ffprobe integration when those tools are available
-* Cortex-M QEMU scaler smoke test when `arm-none-eabi-gcc` and `qemu-system-arm` are available
-* Cortex-M QEMU scaler benchmark firmware correctness when those tools are available
+* Cortex-M QEMU scaler smoke tests when `arm-none-eabi-gcc` and `qemu-system-arm` are available and usable
+* Cortex-M QEMU scaler benchmark firmware correctness for default DSP-capable and portable C variants when those tools are available and usable
 
 ## CLI Example
 
@@ -123,7 +123,18 @@ Encode a baseline JPEG memory-input path through the library wrapper:
 
 The JPEG path uses NanoJPEG inside the core library. The tool only reads the JPEG file; the library API accepts a caller-provided JPEG byte buffer and emits H.264 into a caller-provided output buffer.
 
-For Cortex-M validation, CMake builds QEMU smoke firmware for M3/M4/M7 when the ARM bare-metal toolchain is available. The M4 benchmark firmware records DWT cycle counts in `sh264e_bench_cycles` for real-board measurement.
+For Cortex-M validation, CMake builds QEMU smoke firmware for M3/M4/M7 when the ARM bare-metal toolchain and QEMU are available. CMake first probes whether `arm-none-eabi-gcc` can compile the library's standard-header usage; if the toolchain is only partially installed, QEMU firmware tests are skipped instead of breaking the host build.
+
+The QEMU benchmark preflight targets are:
+
+| Target | CPU / machine | Variant | Purpose |
+| --- | --- | --- | --- |
+| `sh264e_qemu_scaler_bench_m4` | `cortex-m4` / `mps2-an386` | default DSP-capable build | firmware boot, semihosting exit, checksum, cycle counter plumbing |
+| `sh264e_qemu_scaler_bench_m4_portable` | `cortex-m4` / `mps2-an386` | `SH264E_DISABLE_ARM_DSP` | portable C comparison preflight |
+| `sh264e_qemu_scaler_bench_m7` | `cortex-m7` / `mps2-an500` | default DSP-capable build | M7 benchmark preflight |
+| `sh264e_qemu_scaler_bench_m7_portable` | `cortex-m7` / `mps2-an500` | `SH264E_DISABLE_ARM_DSP` | M7 portable C comparison preflight |
+
+QEMU validates firmware build/run behavior and stable nonzero `sh264e_bench_checksum`. Treat `sh264e_bench_cycles` from QEMU as a preflight signal only; final tuning-quality cycle counts still need real Cortex-M hardware with documented CPU, clock, compiler flags, cache state, and memory placement.
 
 Validate with ffmpeg:
 


### PR DESCRIPTION
## Summary

- add `SH264E_BUILD_QEMU_TESTS` and a CMake probe so incomplete bare-metal toolchains skip QEMU firmware tests instead of breaking host builds
- keep existing M4 benchmark preflight and add M4 portable, M7 default, and M7 portable benchmark firmware targets
- document QEMU preflight targets and the boundary between QEMU correctness signals and real-board cycle measurements

Refs #6

## Validation

- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `ctest --test-dir build -R qemu --output-on-failure`

Note: this environment has `qemu-system-arm`, but its `arm-none-eabi-gcc` installation cannot compile `<stdlib.h>`. The new probe reports that and skips QEMU firmware tests; the qemu-filtered CTest run therefore finds no QEMU tests here. A complete ARM bare-metal toolchain is still needed to execute the QEMU firmware targets.
