### PR TITLE
jpeg: track NanoJPEG allocation peaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
         COMPILE_OPTIONS "-Wno-conversion;-Wno-shadow"
     )
 endif()
+set_property(SOURCE src/nanojpeg.c APPEND PROPERTY COMPILE_DEFINITIONS NJ_USE_LIBC=0)
 
 if(SH264E_BUILD_TOOLS)
     add_executable(sh264e_encode_file
@@ -193,6 +194,7 @@ if(SH264E_BUILD_TESTS)
                     -fno-builtin
                     -ffunction-sections
                     -fdata-sections
+                    -DNJ_USE_LIBC=0
                     ${extra_compile_options}
                     -I${CMAKE_CURRENT_SOURCE_DIR}/include
                     -T${CMAKE_CURRENT_SOURCE_DIR}/tests/qemu_cortexm.ld

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Encode a baseline JPEG memory-input path through the library wrapper:
 ```
 
 The JPEG path uses NanoJPEG inside the core library. The tool only reads the JPEG file; the library API accepts a caller-provided JPEG byte buffer and emits H.264 into a caller-provided output buffer.
+The tool prints current and peak NanoJPEG allocation bytes reported by `sh264e_jpeg_get_last_allocation_stats`; these bytes cover decoded JPEG component planes and exclude caller-owned input, slice-work, and H.264 output buffers.
 
 For Cortex-M validation, CMake builds QEMU smoke firmware for M3/M4/M7 when the ARM bare-metal toolchain and QEMU are available. CMake first probes whether `arm-none-eabi-gcc` can compile the library's standard-header usage; if the toolchain is only partially installed, QEMU firmware tests are skipped instead of breaking the host build.
 
@@ -175,6 +176,7 @@ Resize entry points:
 JPEG pipeline entry points:
 
 * `sh264e_jpeg_get_slice_buffer_size`
+* `sh264e_jpeg_get_last_allocation_stats`
 * `sh264e_encode_jpeg_idr`
 
 Frame-mode convenience entry points:

--- a/SPACE_REDUCTION.md
+++ b/SPACE_REDUCTION.md
@@ -153,13 +153,19 @@ Possible approach:
 
 This gives a concrete memory budget for each source size and subsampling pattern.
 
-Example report format:
+Measured with `sh264e_encode_jpeg` after routing NanoJPEG through the library allocation shim:
 
 | Pipeline | Source | Peak bytes | Notes |
 | --- | --- | ---: | --- |
-| JPEG RGB path | 1280x720 4:2:0 | TBD | current behavior |
-| JPEG component path | 1280x720 4:2:0 | TBD | after Phase 1 |
-| JPEG component path | 2560x1440 4:2:0 | TBD | after Phase 1 |
+| JPEG RGB path | 1280x720 4:2:0 | N/A | removed from library encode path |
+| JPEG component path | 1280x720 4:2:0 | 1,382,400 | generated `yuvj420p` fixture |
+| JPEG component path | 1280x720 4:2:2 | 1,843,200 | generated `yuvj422p` fixture |
+| JPEG component path | 1280x720 4:4:4 | 2,764,800 | generated `yuvj444p` fixture |
+| JPEG component path | 2560x1440 4:2:0 | 5,529,600 | generated `yuvj420p` fixture |
+
+The public `sh264e_jpeg_get_last_allocation_stats` query reports the current
+and peak NanoJPEG allocation bytes from the last JPEG encode. Current bytes
+should return to zero after the encode path calls `njDone`.
 
 ### Validation
 

--- a/include/sh264e.h
+++ b/include/sh264e.h
@@ -58,6 +58,11 @@ typedef struct sh264e_slice_t {
     ptrdiff_t stride[3];
 } sh264e_slice_t;
 
+typedef struct sh264e_jpeg_allocation_stats_t {
+    size_t current_bytes;
+    size_t peak_bytes;
+} sh264e_jpeg_allocation_stats_t;
+
 typedef struct sh264e_encoder_t sh264e_encoder_t;
 
 sh264e_status_t sh264e_encoder_create(const sh264e_config_t *config,
@@ -103,6 +108,8 @@ sh264e_status_t sh264e_resize_make_slice(const sh264e_frame_t *src_frame,
                                          sh264e_slice_t *out_slice);
 
 sh264e_status_t sh264e_jpeg_get_slice_buffer_size(size_t *out_size);
+
+sh264e_status_t sh264e_jpeg_get_last_allocation_stats(sh264e_jpeg_allocation_stats_t *out_stats);
 
 sh264e_status_t sh264e_encode_jpeg_idr(sh264e_encoder_t *encoder,
                                        const uint8_t *jpeg_data,

--- a/src/nanojpeg.c
+++ b/src/nanojpeg.c
@@ -305,6 +305,9 @@ int main(int argc, char* argv[]) {
     extern void njFreeMem(void* block);
     extern void njFillMem(void* block, unsigned char byte, int size);
     extern void njCopyMem(void* dest, const void* src, int size);
+    #ifndef NULL
+        #define NULL ((void*)0)
+    #endif
 #endif
 
 typedef struct _nj_code {

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -68,6 +68,10 @@ typedef struct sh264e_jpeg_component_t {
     ptrdiff_t stride;
 } sh264e_jpeg_component_t;
 
+typedef struct sh264e_jpeg_alloc_header_t {
+    size_t size;
+} sh264e_jpeg_alloc_header_t;
+
 void njInit(void);
 int njDecodeComponents(const void *jpeg, const int size);
 int njGetWidth(void);
@@ -78,6 +82,10 @@ int njGetComponentWidth(int index);
 int njGetComponentHeight(int index);
 int njGetComponentStride(int index);
 void njDone(void);
+
+static size_t sh264e_jpeg_alloc_current_bytes;
+static size_t sh264e_jpeg_alloc_peak_bytes;
+static size_t sh264e_jpeg_alloc_limit = (size_t)-1;
 
 static void reset_progressive_state(sh264e_encoder_t *encoder);
 
@@ -99,6 +107,82 @@ static const uint8_t k_cbp_intra_code_num[48] = {
 };
 
 static const int k_dequant_dc_scale[6] = {10, 11, 13, 14, 16, 18};
+
+static void jpeg_allocation_stats_reset(void)
+{
+    sh264e_jpeg_alloc_current_bytes = 0u;
+    sh264e_jpeg_alloc_peak_bytes = 0u;
+}
+
+void sh264e_jpeg_set_test_allocation_limit(size_t max_bytes)
+{
+    sh264e_jpeg_alloc_limit = max_bytes;
+}
+
+void *njAllocMem(int size)
+{
+    const size_t requested = (size > 0) ? (size_t)size : 0u;
+    sh264e_jpeg_alloc_header_t *header;
+    void *raw;
+
+    if (requested == 0u || requested > ((size_t)-1) - sizeof(*header)) {
+        return NULL;
+    }
+    if (sh264e_jpeg_alloc_current_bytes > ((size_t)-1) - requested) {
+        return NULL;
+    }
+    if (sh264e_jpeg_alloc_limit != (size_t)-1) {
+        if (sh264e_jpeg_alloc_current_bytes >= sh264e_jpeg_alloc_limit ||
+            requested > sh264e_jpeg_alloc_limit - sh264e_jpeg_alloc_current_bytes) {
+            return NULL;
+        }
+    }
+
+    raw = malloc(sizeof(*header) + requested);
+    if (raw == NULL) {
+        return NULL;
+    }
+
+    header = (sh264e_jpeg_alloc_header_t *)raw;
+    header->size = requested;
+    sh264e_jpeg_alloc_current_bytes += requested;
+    if (sh264e_jpeg_alloc_current_bytes > sh264e_jpeg_alloc_peak_bytes) {
+        sh264e_jpeg_alloc_peak_bytes = sh264e_jpeg_alloc_current_bytes;
+    }
+
+    return (void *)(header + 1);
+}
+
+void njFreeMem(void *block)
+{
+    sh264e_jpeg_alloc_header_t *header;
+
+    if (block == NULL) {
+        return;
+    }
+
+    header = ((sh264e_jpeg_alloc_header_t *)block) - 1;
+    if (sh264e_jpeg_alloc_current_bytes >= header->size) {
+        sh264e_jpeg_alloc_current_bytes -= header->size;
+    } else {
+        sh264e_jpeg_alloc_current_bytes = 0u;
+    }
+    free(header);
+}
+
+void njFillMem(void *block, unsigned char byte, int size)
+{
+    if (block != NULL && size > 0) {
+        memset(block, byte, (size_t)size);
+    }
+}
+
+void njCopyMem(void *dest, const void *src, int size)
+{
+    if (dest != NULL && src != NULL && size > 0) {
+        memcpy(dest, src, (size_t)size);
+    }
+}
 
 static sh264e_status_t validate_config(const sh264e_config_t *config)
 {
@@ -1359,6 +1443,16 @@ sh264e_status_t sh264e_jpeg_get_slice_buffer_size(size_t *out_size)
     return SH264E_OK;
 }
 
+sh264e_status_t sh264e_jpeg_get_last_allocation_stats(sh264e_jpeg_allocation_stats_t *out_stats)
+{
+    if (out_stats == NULL) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+    out_stats->current_bytes = sh264e_jpeg_alloc_current_bytes;
+    out_stats->peak_bytes = sh264e_jpeg_alloc_peak_bytes;
+    return SH264E_OK;
+}
+
 sh264e_status_t sh264e_encode_jpeg_idr(sh264e_encoder_t *encoder,
                                        const uint8_t *jpeg_data,
                                        size_t jpeg_size,
@@ -1397,6 +1491,7 @@ sh264e_status_t sh264e_encode_jpeg_idr(sh264e_encoder_t *encoder,
         return SH264E_ERR_BUFFER_TOO_SMALL;
     }
 
+    jpeg_allocation_stats_reset();
     njInit();
     status = map_jpeg_result(njDecodeComponents(jpeg_data, (int)jpeg_size));
     if (status != SH264E_OK) {

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -13,10 +13,16 @@ def run(cmd):
     subprocess.run(cmd, check=True)
 
 
-def run_expect_fail(cmd):
-    result = subprocess.run(cmd)
+def run_capture(cmd):
+    return subprocess.run(cmd, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def run_expect_fail(cmd, stderr_contains=None):
+    result = subprocess.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if result.returncode == 0:
         raise RuntimeError(f"expected command to fail: {cmd}")
+    if stderr_contains is not None and stderr_contains not in result.stderr:
+        raise RuntimeError(f"expected stderr to contain {stderr_contains!r}; got {result.stderr!r}")
 
 
 def make_i420(path):
@@ -154,6 +160,18 @@ def make_color_jpeg(args, path, pix_fmt):
     validate_image_pix_fmt(args.ffprobe, path, pix_fmt)
 
 
+def encode_jpeg(args, fmt, jpeg_input, bitstream):
+    result = run_capture([args.jpeg_encoder, "--format", fmt, str(jpeg_input), str(bitstream)])
+    if "jpeg current allocation bytes: 0" not in result.stdout:
+        raise RuntimeError(f"JPEG encoder did not release tracked allocations: {result.stdout!r}")
+    for line in result.stdout.splitlines():
+        if line.startswith("jpeg peak allocation bytes:"):
+            if int(line.rsplit(" ", 1)[1]) == 0:
+                raise RuntimeError(f"JPEG encoder reported zero peak allocation bytes: {result.stdout!r}")
+            return
+    raise RuntimeError(f"JPEG encoder did not report peak allocation bytes: {result.stdout!r}")
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--encoder", required=True)
@@ -236,9 +254,19 @@ def main():
     for pix_fmt in ("yuvj420p", "yuvj422p", "yuvj444p"):
         jpeg_input = workdir / f"input_720p_{pix_fmt}.jpg"
         make_color_jpeg(args, jpeg_input, pix_fmt)
+        if pix_fmt == "yuvj420p":
+            run_expect_fail([
+                args.jpeg_encoder,
+                "--test-allocation-limit",
+                "1",
+                "--format",
+                "i420",
+                str(jpeg_input),
+                str(workdir / "output_jpeg_alloc_fail.h264"),
+            ], stderr_contains="allocation failed")
         for fmt in ("i420", "nv12"):
             jpeg_output = workdir / f"output_jpeg_{pix_fmt}_{fmt}.h264"
-            run([args.jpeg_encoder, "--format", fmt, str(jpeg_input), str(jpeg_output)])
+            encode_jpeg(args, fmt, jpeg_input, jpeg_output)
             validate_bitstream(args.ffprobe, args.ffmpeg, jpeg_output)
 
     grayscale_jpeg_input = workdir / "input_gray_720p.jpg"
@@ -263,7 +291,7 @@ def main():
     # color subsampling fixtures assert exact JPEG component layout.
     for fmt in ("i420", "nv12"):
         grayscale_jpeg_output = workdir / f"output_jpeg_gray_{fmt}.h264"
-        run([args.jpeg_encoder, "--format", fmt, str(grayscale_jpeg_input), str(grayscale_jpeg_output)])
+        encode_jpeg(args, fmt, grayscale_jpeg_input, grayscale_jpeg_output)
         validate_bitstream(args.ffprobe, args.ffmpeg, grayscale_jpeg_output)
 
 

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -163,6 +163,7 @@ int main(void)
     uint8_t *slice_output = NULL;
     uint8_t *small_input = NULL;
     uint8_t *resize_work = NULL;
+    sh264e_jpeg_allocation_stats_t jpeg_alloc_stats;
     int ok = 1;
 
     memset(&config, 0, sizeof(config));
@@ -196,6 +197,18 @@ int main(void)
     }
     if (header_capacity == 0u || slice_capacity == 0u) {
         fprintf(stderr, "progressive max output size returned zero\n");
+        ok = 0;
+    }
+    ok &= expect_status("null JPEG allocation stats",
+                        sh264e_jpeg_get_last_allocation_stats(NULL),
+                        SH264E_ERR_INVALID_ARGUMENT);
+    jpeg_alloc_stats.current_bytes = 123u;
+    jpeg_alloc_stats.peak_bytes = 456u;
+    ok &= expect_status("initial JPEG allocation stats",
+                        sh264e_jpeg_get_last_allocation_stats(&jpeg_alloc_stats),
+                        SH264E_OK);
+    if (jpeg_alloc_stats.current_bytes != 0u || jpeg_alloc_stats.peak_bytes != 0u) {
+        fprintf(stderr, "initial JPEG allocation stats should be zero\n");
         ok = 0;
     }
 

--- a/tools/sh264e_encode_jpeg.c
+++ b/tools/sh264e_encode_jpeg.c
@@ -4,9 +4,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+void sh264e_jpeg_set_test_allocation_limit(size_t max_bytes);
+
 static void usage(const char *argv0)
 {
-    fprintf(stderr, "usage: %s --format i420|nv12 input.jpg output.h264\n", argv0);
+    fprintf(stderr, "usage: %s [--test-allocation-limit BYTES] --format i420|nv12 input.jpg output.h264\n",
+            argv0);
 }
 
 static int parse_format(const char *text, sh264e_pixfmt_t *pixfmt)
@@ -20,6 +23,22 @@ static int parse_format(const char *text, sh264e_pixfmt_t *pixfmt)
         return 1;
     }
     return 0;
+}
+
+static int parse_size(const char *text, size_t *out_size)
+{
+    char *end = NULL;
+    unsigned long value;
+
+    if (text == NULL || *text == '\0' || out_size == NULL) {
+        return 0;
+    }
+    value = strtoul(text, &end, 10);
+    if (end == text || *end != '\0') {
+        return 0;
+    }
+    *out_size = (size_t)value;
+    return 1;
 }
 
 static int read_file(const char *path, uint8_t **out_data, size_t *out_size)
@@ -86,14 +105,25 @@ int main(int argc, char **argv)
     size_t work_size = 0;
     size_t output_capacity = 0;
     size_t output_size = 0;
+    size_t allocation_limit = (size_t)-1;
+    int argi = 1;
     int rc = 1;
 
-    if (argc != 5 || strcmp(argv[1], "--format") != 0 || !parse_format(argv[2], &pixfmt)) {
+    if (argc >= 4 && strcmp(argv[argi], "--test-allocation-limit") == 0) {
+        if (!parse_size(argv[argi + 1], &allocation_limit)) {
+            usage(argv[0]);
+            return 2;
+        }
+        argi += 2;
+    }
+
+    if (argc - argi != 4 || strcmp(argv[argi], "--format") != 0 ||
+        !parse_format(argv[argi + 1], &pixfmt)) {
         usage(argv[0]);
         return 2;
     }
-    input_path = argv[3];
-    output_path = argv[4];
+    input_path = argv[argi + 2];
+    output_path = argv[argi + 3];
 
     if (!read_file(input_path, &jpeg_data, &jpeg_size)) {
         fprintf(stderr, "failed to read JPEG input: %s\n", input_path);
@@ -130,6 +160,9 @@ int main(int argc, char **argv)
         goto done;
     }
 
+    if (allocation_limit != (size_t)-1) {
+        sh264e_jpeg_set_test_allocation_limit(allocation_limit);
+    }
     status = sh264e_encode_jpeg_idr(encoder, jpeg_data, jpeg_size,
                                     work, work_size,
                                     output_buf, output_capacity, &output_size);
@@ -148,6 +181,17 @@ int main(int argc, char **argv)
         goto done;
     }
 
+    {
+        sh264e_jpeg_allocation_stats_t stats;
+        status = sh264e_jpeg_get_last_allocation_stats(&stats);
+        if (status != SH264E_OK) {
+            fprintf(stderr, "sh264e_jpeg_get_last_allocation_stats failed: %s\n",
+                    sh264e_status_string(status));
+            goto done;
+        }
+        printf("jpeg current allocation bytes: %zu\n", stats.current_bytes);
+        printf("jpeg peak allocation bytes: %zu\n", stats.peak_bytes);
+    }
     printf("encoded JPEG input to progressive IDR frame\n");
     rc = 0;
 


### PR DESCRIPTION
## Summary

- compile NanoJPEG in `NJ_USE_LIBC=0` mode and provide allocation/memory primitives from the library integration layer
- track current and peak NanoJPEG allocation bytes for JPEG encode and expose `sh264e_jpeg_get_last_allocation_stats`
- make `sh264e_encode_jpeg` print current/peak JPEG allocation bytes for measurement runs
- add integration coverage for nonzero peak reporting, full release back to zero current bytes, and allocation-failure mapping to `SH264E_ERR_ALLOCATION_FAILED`
- update memory notes with measured component-plane peak bytes

Refs #3

## Validation

- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `ctest --test-dir build -R qemu --output-on-failure`

QEMU note: this environment still skips QEMU firmware tests because `arm-none-eabi-gcc` cannot compile `<stdlib.h>`, so the qemu-filtered CTest run finds no tests.

## Measured JPEG Peaks

- 1280x720 4:2:0 component path: 1,382,400 bytes
- 1280x720 4:2:2 component path: 1,843,200 bytes
- 1280x720 4:4:4 component path: 2,764,800 bytes
- 2560x1440 4:2:0 component path: 5,529,600 bytes
