### PR TITLE
docs: design JPEG MCU row streaming path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ if(SH264E_BUILD_TESTS)
     find_package(Python3 COMPONENTS Interpreter)
     find_program(SH264E_FFPROBE ffprobe)
     find_program(SH264E_FFMPEG ffmpeg)
+    find_program(SH264E_CJPEG cjpeg)
     find_program(SH264E_ARM_NONE_EABI_GCC arm-none-eabi-gcc)
     find_program(SH264E_QEMU_SYSTEM_ARM qemu-system-arm)
     set(SH264E_CAN_BUILD_QEMU_TESTS OFF)
@@ -163,17 +164,23 @@ if(SH264E_BUILD_TESTS)
         message(STATUS "Skipping QEMU firmware tests: arm-none-eabi-gcc or qemu-system-arm was not found")
     endif()
     if(Python3_Interpreter_FOUND AND SH264E_FFPROBE AND SH264E_FFMPEG AND SH264E_BUILD_TOOLS)
+        set(SH264E_FFMPEG_INTEGRATION_ARGS
+            --encoder $<TARGET_FILE:sh264e_encode_file>
+            --progressive-encoder $<TARGET_FILE:sh264e_encode_file_progressive>
+            --resize-encoder $<TARGET_FILE:sh264e_resize_encode_progressive>
+            --jpeg-encoder $<TARGET_FILE:sh264e_encode_jpeg>
+            --ffprobe ${SH264E_FFPROBE}
+            --ffmpeg ${SH264E_FFMPEG}
+            --workdir ${CMAKE_CURRENT_BINARY_DIR}/integration
+        )
+        if(SH264E_CJPEG)
+            list(APPEND SH264E_FFMPEG_INTEGRATION_ARGS --cjpeg ${SH264E_CJPEG})
+        endif()
         add_test(
             NAME sh264e_ffmpeg_integration
             COMMAND ${Python3_EXECUTABLE}
                 ${CMAKE_CURRENT_SOURCE_DIR}/tests/run_ffmpeg_integration.py
-                --encoder $<TARGET_FILE:sh264e_encode_file>
-                --progressive-encoder $<TARGET_FILE:sh264e_encode_file_progressive>
-                --resize-encoder $<TARGET_FILE:sh264e_resize_encode_progressive>
-                --jpeg-encoder $<TARGET_FILE:sh264e_encode_jpeg>
-                --ffprobe ${SH264E_FFPROBE}
-                --ffmpeg ${SH264E_FFMPEG}
-                --workdir ${CMAKE_CURRENT_BINARY_DIR}/integration
+                ${SH264E_FFMPEG_INTEGRATION_ARGS}
         )
     endif()
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Encode a baseline JPEG memory-input path through the library wrapper:
 
 The JPEG path uses NanoJPEG inside the core library. The tool only reads the JPEG file; the library API accepts a caller-provided JPEG byte buffer and emits H.264 into a caller-provided output buffer.
 The tool sizes a caller-provided JPEG decoder arena with `sh264e_jpeg_get_work_size`, passes that arena to `sh264e_encode_jpeg_idr_with_arena`, and prints the arena requirement plus current and peak NanoJPEG allocation bytes reported by `sh264e_jpeg_get_last_allocation_stats`. The allocation stats cover decoded JPEG component planes and exclude caller-owned input, arena overhead, slice-work, and H.264 output buffers.
-The hidden `--streaming-prototype` flag exercises the experimental MCU-row streaming path for a 1280x720 4:2:0 JPEG to I420 output without making it the default encoder path.
+The hidden `--streaming-prototype` flag exercises the experimental MCU-row streaming path for 1280x720 4:2:0, 4:2:2, and 4:4:4 JPEG inputs to I420 output without making it the default encoder path.
 
 For Cortex-M validation, CMake builds QEMU smoke firmware for M3/M4/M7 when the ARM bare-metal toolchain and QEMU are available. CMake first probes whether `arm-none-eabi-gcc` can compile the library's standard-header usage; if the toolchain is only partially installed, QEMU firmware tests are skipped instead of breaking the host build.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ include/  public C API
 src/      encoder library implementation
 tools/    command-line validation/example tools
 tests/    CTest validation
-docs/     design specification
+docs/     design specifications and follow-on design notes
 ```
 
 ## Build

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Encode a baseline JPEG memory-input path through the library wrapper:
 
 The JPEG path uses NanoJPEG inside the core library. The tool only reads the JPEG file; the library API accepts a caller-provided JPEG byte buffer and emits H.264 into a caller-provided output buffer.
 The tool sizes a caller-provided JPEG decoder arena with `sh264e_jpeg_get_work_size`, passes that arena to `sh264e_encode_jpeg_idr_with_arena`, and prints the arena requirement plus current and peak NanoJPEG allocation bytes reported by `sh264e_jpeg_get_last_allocation_stats`. The allocation stats cover decoded JPEG component planes and exclude caller-owned input, arena overhead, slice-work, and H.264 output buffers.
+The hidden `--streaming-prototype` flag exercises the experimental MCU-row streaming path for a 1280x720 4:2:0 JPEG to I420 output without making it the default encoder path.
 
 For Cortex-M validation, CMake builds QEMU smoke firmware for M3/M4/M7 when the ARM bare-metal toolchain and QEMU are available. CMake first probes whether `arm-none-eabi-gcc` can compile the library's standard-header usage; if the toolchain is only partially installed, QEMU firmware tests are skipped instead of breaking the host build.
 

--- a/SPACE_REDUCTION.md
+++ b/SPACE_REDUCTION.md
@@ -257,8 +257,8 @@ Approximate component-cache targets from the design note:
 | Source | Full component planes | Approx streaming cache |
 | --- | ---: | ---: |
 | 1280x720 4:2:0 | 1,382,400 | 61,440 |
-| 1280x720 4:2:2 | 1,843,200 | 61,440 |
-| 1280x720 4:4:4 | 2,764,800 | 61,440 |
+| 1280x720 4:2:2 | 1,843,200 | 81,920 |
+| 1280x720 4:4:4 | 2,764,800 | 122,880 |
 | 5120x2880 4:2:0 | not yet measured | 368,640 |
 | 5120x2880 4:4:4 | not yet measured | 614,400 |
 
@@ -273,10 +273,10 @@ encoder slice work buffer, and the H.264 output buffer.
   non-power-of-two sampling, and non-interleaved multi-scan JPEGs.
 * Preserve restart marker handling by resetting DC predictors and bitstream
   state at the same MCU intervals as the current full-plane path.
-* Validate a 1280x720 4:2:0 fixture first with
+* Validate 1280x720 4:2:0, 4:2:2, and 4:4:4 fixtures with
   `sh264e_encode_jpeg --streaming-prototype`, including a `cjpeg`-generated
   DRI/RST restart-marker fixture when `cjpeg` is available, then expand to
-  4:2:2, 4:4:4, and grayscale before making it the default JPEG path.
+  grayscale before making it the default JPEG path.
 
 ### Risks
 

--- a/SPACE_REDUCTION.md
+++ b/SPACE_REDUCTION.md
@@ -220,7 +220,8 @@ Implemented API:
 
 ### Plan
 
-Longer term, avoid full decoded component planes.
+Longer term, avoid full decoded component planes. The detailed design note is
+tracked in `docs/JPEG_MCU_ROW_STREAMING.md`.
 
 Decode JPEG MCU rows into a rolling source-row cache:
 
@@ -233,7 +234,11 @@ JPEG bitstream
 -> H.264 slice encode
 ```
 
-This is a larger decoder refactor and should not be the immediate next step.
+This is a larger decoder refactor and should not replace the component-plane
+path until a narrow prototype is validated. The first slice should keep the
+current baseline JPEG scope, decode one MCU row at a time into component row
+rings, and feed the existing progressive H.264 slice encoder when enough source
+rows are available for the next 16-row luma output slice.
 
 ### Expected Benefit
 
@@ -246,6 +251,30 @@ For bilinear scaling, each output row needs at most two source rows per componen
 * vertical scaling ratio
 * restart marker boundaries
 * IDCT block output lifetime
+
+Approximate component-cache targets from the design note:
+
+| Source | Full component planes | Approx streaming cache |
+| --- | ---: | ---: |
+| 1280x720 4:2:0 | 1,382,400 | 30,720 |
+| 1280x720 4:2:2 | 1,843,200 | 61,440 |
+| 1280x720 4:4:4 | 2,764,800 | 61,440 |
+| 5120x2880 4:2:0 | not yet measured | 368,640 |
+| 5120x2880 4:4:4 | not yet measured | 614,400 |
+
+These estimates exclude caller-owned JPEG input, the existing 61,440-byte
+encoder slice work buffer, and the H.264 output buffer.
+
+### First Prototype Boundary
+
+* Keep the public API unchanged until the internal row-window contract is proven.
+* Support baseline sequential grayscale or three-component YCbCr JPEGs.
+* Reject progressive/lossless JPEG, arithmetic coding, CMYK/other color spaces,
+  non-power-of-two sampling, and non-interleaved multi-scan JPEGs.
+* Preserve restart marker handling by resetting DC predictors and bitstream
+  state at the same MCU intervals as the current full-plane path.
+* Validate a 1280x720 4:2:0 fixture first, then expand to 4:2:2, 4:4:4, and
+  grayscale before making it the default JPEG path.
 
 ### Risks
 

--- a/SPACE_REDUCTION.md
+++ b/SPACE_REDUCTION.md
@@ -277,6 +277,9 @@ encoder slice work buffer, and the H.264 output buffer.
   `sh264e_encode_jpeg --streaming-prototype`, including a `cjpeg`-generated
   DRI/RST restart-marker fixture when `cjpeg` is available, then expand to
   grayscale before making it the default JPEG path.
+* Keep the row-window bridge hidden for this prototype. Promotion to the
+  production/default JPEG path should wait for dynamic source-size cache sizing,
+  caller-provided arena integration, NV12 output, and grayscale coverage.
 
 ### Risks
 

--- a/SPACE_REDUCTION.md
+++ b/SPACE_REDUCTION.md
@@ -274,8 +274,9 @@ encoder slice work buffer, and the H.264 output buffer.
 * Preserve restart marker handling by resetting DC predictors and bitstream
   state at the same MCU intervals as the current full-plane path.
 * Validate a 1280x720 4:2:0 fixture first with
-  `sh264e_encode_jpeg --streaming-prototype`, then expand to 4:2:2, 4:4:4,
-  and grayscale before making it the default JPEG path.
+  `sh264e_encode_jpeg --streaming-prototype`, including a `cjpeg`-generated
+  DRI/RST restart-marker fixture when `cjpeg` is available, then expand to
+  4:2:2, 4:4:4, and grayscale before making it the default JPEG path.
 
 ### Risks
 

--- a/SPACE_REDUCTION.md
+++ b/SPACE_REDUCTION.md
@@ -256,7 +256,7 @@ Approximate component-cache targets from the design note:
 
 | Source | Full component planes | Approx streaming cache |
 | --- | ---: | ---: |
-| 1280x720 4:2:0 | 1,382,400 | 30,720 |
+| 1280x720 4:2:0 | 1,382,400 | 61,440 |
 | 1280x720 4:2:2 | 1,843,200 | 61,440 |
 | 1280x720 4:4:4 | 2,764,800 | 61,440 |
 | 5120x2880 4:2:0 | not yet measured | 368,640 |
@@ -273,8 +273,9 @@ encoder slice work buffer, and the H.264 output buffer.
   non-power-of-two sampling, and non-interleaved multi-scan JPEGs.
 * Preserve restart marker handling by resetting DC predictors and bitstream
   state at the same MCU intervals as the current full-plane path.
-* Validate a 1280x720 4:2:0 fixture first, then expand to 4:2:2, 4:4:4, and
-  grayscale before making it the default JPEG path.
+* Validate a 1280x720 4:2:0 fixture first with
+  `sh264e_encode_jpeg --streaming-prototype`, then expand to 4:2:2, 4:4:4,
+  and grayscale before making it the default JPEG path.
 
 ### Risks
 

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -144,6 +144,7 @@ encoder:
   and compare SHA-256 hashes for the first 1280x720 4:2:0 I420 fixture.
 * Confirm the NanoJPEG allocation peak is below the 1,382,400-byte full
   component-plane allocation for the same fixture.
-* Add fixtures with restart markers before treating restart handling as done.
+* When `cjpeg` is available, generate a 4:2:0 fixture with DRI/RST restart
+  markers and run the same streaming-vs-component decoded-frame comparison.
 * Keep the component-plane arena path as the compatibility fallback until the
   streaming path covers grayscale, 4:2:0, 4:2:2, and 4:4:4.

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -104,6 +104,27 @@ current prototype keeps it internal and exercises it through
 the prototype proves the row-cache contract across the rest of the supported
 JPEG matrix.
 
+## Promotion Decision
+
+The row-window bridge should remain a hidden prototype for issue #5 instead of
+becoming the production default in this PR. The prototype proves the MCU-row
+decode and scaler handoff for the 1280x720 color matrix, including restart
+markers, but it still has production-boundary gaps:
+
+* The only exposed entry point is the tool-local `--streaming-prototype` path.
+* The prototype output is I420-only and does not cover the public NV12 JPEG
+  output path.
+* The source-size policy is fixed at 1280x720 rather than the existing public
+  JPEG range.
+* Row-cache allocation still uses `malloc` and is not integrated with the
+  caller-provided JPEG arena sizing API.
+* Grayscale handling is intentionally left on the component-plane fallback.
+
+Promotion should happen in a follow-up after the internal row-window contract
+can compute cache size from arbitrary supported dimensions, share the
+caller-provided arena policy, and pass the full public JPEG output matrix. Until
+then, the component-plane arena path remains the production/default JPEG path.
+
 ## Memory Estimate
 
 The current component-plane path stores the whole decoded image. From the
@@ -149,6 +170,7 @@ encoder:
   full component-plane allocation for 4:2:2 and 4:4:4.
 * When `cjpeg` is available, generate a 4:2:0 fixture with DRI/RST restart
   markers and run the same streaming-vs-component decoded-frame comparison.
-* Keep the component-plane arena path as the compatibility fallback until the
-  streaming path covers grayscale and the production API/promotion boundary is
-  decided.
+* Keep the component-plane arena path as the production fallback; the issue #5
+  decision is to leave the row-window bridge hidden until a follow-up promotes
+  it with arena sizing, dynamic source dimensions, NV12 output, and grayscale
+  coverage.

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -140,10 +140,10 @@ encoder:
 * Encode through the streaming prototype to Annex B H.264.
 * Decode the H.264 with ffmpeg and verify the same stream metadata as the
   component-plane path.
+* Decode both the streaming and component-plane H.264 outputs to raw `yuv420p`
+  and compare SHA-256 hashes for the first 1280x720 4:2:0 I420 fixture.
 * Confirm the NanoJPEG allocation peak is below the 1,382,400-byte full
   component-plane allocation for the same fixture.
-* Compare representative slice checksums or pixels against the component-plane
-  scaler output to catch row-window lifetime mistakes.
 * Add fixtures with restart markers before treating restart handling as done.
 * Keep the component-plane arena path as the compatibility fallback until the
   streaming path covers grayscale, 4:2:0, 4:2:2, and 4:4:4.

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -97,9 +97,11 @@ typedef sh264e_status_t (*sh264e_jpeg_row_ready_fn)(
     void *user);
 ```
 
-The first production API does not need to expose this callback publicly. It can
-remain an internal bridge from NanoJPEG to the existing slice scaler. A public
-streaming API should wait until the prototype proves the row-cache contract.
+The first production API does not need to expose this callback publicly. The
+current prototype keeps it internal and exercises it through
+`sh264e_encode_jpeg --streaming-prototype` for a 1280x720 4:2:0 I420 output
+fixture. A public streaming API should wait until the prototype proves the
+row-cache contract across the rest of the supported JPEG matrix.
 
 ## Memory Estimate
 
@@ -118,7 +120,7 @@ height. Approximate component-cache sizes are:
 
 | Source | MCU-row bytes | Retained rows | Approx cache |
 | --- | ---: | ---: | ---: |
-| 1280x720 4:2:0 | 30,720 | 1 MCU row | 30,720 |
+| 1280x720 4:2:0 | 30,720 | 2 MCU rows | 61,440 |
 | 1280x720 4:2:2 | 30,720 | 2 MCU rows | 61,440 |
 | 1280x720 4:4:4 | 30,720 | 2 MCU rows | 61,440 |
 | 5120x2880 4:2:0 | 122,880 | 3 MCU rows | 368,640 |
@@ -131,13 +133,15 @@ output buffer, both of which are already caller-controlled.
 
 ## Validation Plan
 
-The first prototype should add a tool/test-only path before replacing the
-default JPEG encoder:
+The prototype adds a tool/test-only path before replacing the default JPEG
+encoder:
 
 * Generate a `1280x720` `yuvj420p` JPEG fixture with ffmpeg.
 * Encode through the streaming prototype to Annex B H.264.
 * Decode the H.264 with ffmpeg and verify the same stream metadata as the
   component-plane path.
+* Confirm the NanoJPEG allocation peak is below the 1,382,400-byte full
+  component-plane allocation for the same fixture.
 * Compare representative slice checksums or pixels against the component-plane
   scaler output to catch row-window lifetime mistakes.
 * Add fixtures with restart markers before treating restart handling as done.

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -1,0 +1,145 @@
+# JPEG MCU-Row Streaming Design
+
+Issue #5 tracks the v2 path for removing the full decoded JPEG component
+planes from the JPEG-to-H.264 pipeline. The current decoder is intentionally
+simple: `njDecodeScan` decodes every MCU, `njDecodeBlock` writes each 8x8 IDCT
+block into `nj.comp[i].pixels`, and the scaler later reads those full component
+planes. This document defines the first safe streaming shape before changing
+that storage model.
+
+## Current Decode Boundary
+
+The current component-plane path has these properties:
+
+* `njDecodeSOF` computes `mbsizex`, `mbsizey`, component dimensions, and full
+  component strides.
+* `njDecodeSOF` allocates `c->pixels` for every component using
+  `c->stride * nj.mbheight * c->ssy * 8`.
+* `njDecodeScan` walks MCUs in raster order and writes decoded blocks directly
+  into those full component planes.
+* `sh264e_encode_jpeg_idr` scales the decoded components one H.264 output slice
+  at a time, where one output slice is 16 luma rows and 8 chroma rows.
+
+The streaming design keeps the existing marker, Huffman, quantization, restart,
+and IDCT logic but replaces full component-plane storage with a bounded row
+ring that only keeps source rows needed by the scaler.
+
+## Row Cache Lifetime
+
+Streaming should process one JPEG MCU row at a time:
+
+```text
+parse headers
+allocate component row rings
+for each JPEG MCU row:
+    decode MCU row into component rings
+    while enough source rows exist for the next H.264 output slice:
+        scale from component rings into slice work buffer
+        encode the H.264 slice
+        release source rows no longer needed by later output slices
+flush any remaining bottom-edge slices
+```
+
+Bilinear scaling needs at most two source rows for one output row per component.
+The row ring therefore needs to retain the source rows spanning the next output
+slice plus one extra source row for interpolation. Because JPEG emits whole MCU
+rows, the retained height is rounded up to each component's MCU-row granularity.
+
+For an output luma slice of 16 rows:
+
+```text
+needed_luma_source_rows =
+    ceil(16 * source_height / 1440) + 1
+
+cached_luma_rows =
+    round_up_to_mcu_rows(needed_luma_source_rows + bottom_edge_guard)
+```
+
+Chroma uses the same rule against the destination chroma slice height of 8 rows
+and the decoded component's native height. The bottom-edge guard lets the scaler
+clamp cleanly when the final source row for an interpolation pair is outside the
+image.
+
+## First Prototype Slice
+
+The first implementation slice should be deliberately narrow:
+
+* Baseline sequential JPEG only, preserving the current NanoJPEG scope.
+* Grayscale and three-component YCbCr only.
+* Power-of-two sampling factors only, matching current NanoJPEG validation.
+* Interleaved scans only for the first prototype.
+* Source dimensions in the existing supported range:
+  `1280x720 <= source <= 5120x2880`, even width and height.
+* H.264 output remains the existing 2560x1440 progressive IDR frame.
+
+Unsupported structures should fail before partial output begins. The first
+prototype can reject progressive/lossless JPEG, arithmetic coding, CMYK/other
+color spaces, non-power-of-two sampling, and non-interleaved multi-scan JPEGs.
+Restart markers must continue to reset DC predictors and bitstream state at the
+same MCU intervals as the current full-plane decode path.
+
+## Proposed Internal Shape
+
+Add an internal decode mode that owns the JPEG bitstream state and emits decoded
+MCU-row availability to the encoder integration layer:
+
+```c
+typedef struct sh264e_jpeg_row_window_t {
+    const uint8_t *component_pixels[3];
+    ptrdiff_t component_stride[3];
+    uint32_t component_y0[3];
+    uint32_t component_rows[3];
+    int component_count;
+} sh264e_jpeg_row_window_t;
+
+typedef sh264e_status_t (*sh264e_jpeg_row_ready_fn)(
+    const sh264e_jpeg_row_window_t *window,
+    void *user);
+```
+
+The first production API does not need to expose this callback publicly. It can
+remain an internal bridge from NanoJPEG to the existing slice scaler. A public
+streaming API should wait until the prototype proves the row-cache contract.
+
+## Memory Estimate
+
+The current component-plane path stores the whole decoded image. From the
+measured allocation report:
+
+| Source | Component-plane bytes |
+| --- | ---: |
+| 1280x720 4:2:0 | 1,382,400 |
+| 1280x720 4:2:2 | 1,843,200 |
+| 1280x720 4:4:4 | 2,764,800 |
+| 2560x1440 4:2:0 | 5,529,600 |
+
+The row-streaming cache is bounded by retained MCU rows instead of full image
+height. Approximate component-cache sizes are:
+
+| Source | MCU-row bytes | Retained rows | Approx cache |
+| --- | ---: | ---: | ---: |
+| 1280x720 4:2:0 | 30,720 | 1 MCU row | 30,720 |
+| 1280x720 4:2:2 | 30,720 | 2 MCU rows | 61,440 |
+| 1280x720 4:4:4 | 30,720 | 2 MCU rows | 61,440 |
+| 5120x2880 4:2:0 | 122,880 | 3 MCU rows | 368,640 |
+| 5120x2880 4:4:4 | 122,880 | 5 MCU rows | 614,400 |
+
+The exact retained-row count should be computed from the scaler's fixed-point
+source mapping, then rounded up to the JPEG component MCU-row height. These
+figures exclude the existing 61,440-byte encoder slice work buffer and H.264
+output buffer, both of which are already caller-controlled.
+
+## Validation Plan
+
+The first prototype should add a tool/test-only path before replacing the
+default JPEG encoder:
+
+* Generate a `1280x720` `yuvj420p` JPEG fixture with ffmpeg.
+* Encode through the streaming prototype to Annex B H.264.
+* Decode the H.264 with ffmpeg and verify the same stream metadata as the
+  component-plane path.
+* Compare representative slice checksums or pixels against the component-plane
+  scaler output to catch row-window lifetime mistakes.
+* Add fixtures with restart markers before treating restart handling as done.
+* Keep the component-plane arena path as the compatibility fallback until the
+  streaming path covers grayscale, 4:2:0, 4:2:2, and 4:4:4.

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -99,9 +99,10 @@ typedef sh264e_status_t (*sh264e_jpeg_row_ready_fn)(
 
 The first production API does not need to expose this callback publicly. The
 current prototype keeps it internal and exercises it through
-`sh264e_encode_jpeg --streaming-prototype` for a 1280x720 4:2:0 I420 output
-fixture. A public streaming API should wait until the prototype proves the
-row-cache contract across the rest of the supported JPEG matrix.
+`sh264e_encode_jpeg --streaming-prototype` for 1280x720 4:2:0, 4:2:2, and
+4:4:4 YCbCr inputs to I420 output. A public streaming API should wait until
+the prototype proves the row-cache contract across the rest of the supported
+JPEG matrix.
 
 ## Memory Estimate
 
@@ -121,8 +122,8 @@ height. Approximate component-cache sizes are:
 | Source | MCU-row bytes | Retained rows | Approx cache |
 | --- | ---: | ---: | ---: |
 | 1280x720 4:2:0 | 30,720 | 2 MCU rows | 61,440 |
-| 1280x720 4:2:2 | 30,720 | 2 MCU rows | 61,440 |
-| 1280x720 4:4:4 | 30,720 | 2 MCU rows | 61,440 |
+| 1280x720 4:2:2 | 40,960 | 2 MCU rows | 81,920 |
+| 1280x720 4:4:4 | 61,440 | 2 MCU rows | 122,880 |
 | 5120x2880 4:2:0 | 122,880 | 3 MCU rows | 368,640 |
 | 5120x2880 4:4:4 | 122,880 | 5 MCU rows | 614,400 |
 
@@ -136,15 +137,18 @@ output buffer, both of which are already caller-controlled.
 The prototype adds a tool/test-only path before replacing the default JPEG
 encoder:
 
-* Generate a `1280x720` `yuvj420p` JPEG fixture with ffmpeg.
+* Generate `1280x720` `yuvj420p`, `yuvj422p`, and `yuvj444p` JPEG fixtures
+  with ffmpeg.
 * Encode through the streaming prototype to Annex B H.264.
 * Decode the H.264 with ffmpeg and verify the same stream metadata as the
   component-plane path.
 * Decode both the streaming and component-plane H.264 outputs to raw `yuv420p`
-  and compare SHA-256 hashes for the first 1280x720 4:2:0 I420 fixture.
+  and compare SHA-256 hashes for each I420 fixture.
 * Confirm the NanoJPEG allocation peak is below the 1,382,400-byte full
-  component-plane allocation for the same fixture.
+  component-plane allocation for the 4:2:0 fixture and below the corresponding
+  full component-plane allocation for 4:2:2 and 4:4:4.
 * When `cjpeg` is available, generate a 4:2:0 fixture with DRI/RST restart
   markers and run the same streaming-vs-component decoded-frame comparison.
 * Keep the component-plane arena path as the compatibility fallback until the
-  streaming path covers grayscale, 4:2:0, 4:2:2, and 4:4:4.
+  streaming path covers grayscale and the production API/promotion boundary is
+  decided.

--- a/src/nanojpeg.c
+++ b/src/nanojpeg.c
@@ -143,6 +143,9 @@ nj_result_t njDecode(const void* jpeg, const int size);
 // grayscale planes, including their native dimensions and stride.
 nj_result_t njDecodeComponents(const void* jpeg, const int size);
 
+typedef int (*nj_mcu_row_callback_t)(int mcu_y, void* user);
+nj_result_t njDecodeMcuRows(const void* jpeg, const int size, nj_mcu_row_callback_t callback, void* user);
+
 // njGetWidth: Return the width (in pixels) of the most recently decoded
 // image. If njDecode() failed, the result of njGetWidth() is undefined.
 int njGetWidth(void);
@@ -175,6 +178,9 @@ const unsigned char* njGetComponentPixels(int index);
 int njGetComponentWidth(int index);
 int njGetComponentHeight(int index);
 int njGetComponentStride(int index);
+int njGetComponentSsx(int index);
+int njGetComponentSsy(int index);
+int njGetMcuRowCount(void);
 
 // njDone: Uninitialize NanoJPEG.
 // Resets NanoJPEG's internal state and frees all memory that has been
@@ -343,6 +349,9 @@ typedef struct _nj_ctx {
     int rstinterval;
     unsigned char *rgb;
     int decode_components_only;
+    int decode_mcu_rows_only;
+    nj_mcu_row_callback_t mcu_row_callback;
+    void* mcu_row_user;
 } nj_context_t;
 
 static nj_context_t nj;
@@ -577,11 +586,12 @@ NJ_INLINE void njDecodeSOF(void) {
     nj.mbwidth = (nj.width + nj.mbsizex - 1) / nj.mbsizex;
     nj.mbheight = (nj.height + nj.mbsizey - 1) / nj.mbsizey;
     for (i = 0, c = nj.comp;  i < nj.ncomp;  ++i, ++c) {
+        const int allocated_rows = nj.decode_mcu_rows_only ? (c->ssy << 3) : (nj.mbheight * c->ssy << 3);
         c->width = (nj.width * c->ssx + ssxmax - 1) / ssxmax;
         c->height = (nj.height * c->ssy + ssymax - 1) / ssymax;
         c->stride = nj.mbwidth * c->ssx << 3;
         if (((c->width < 3) && (c->ssx != ssxmax)) || ((c->height < 3) && (c->ssy != ssymax))) njThrow(NJ_UNSUPPORTED);
-        if (!(c->pixels = (unsigned char*) njAllocMem(c->stride * nj.mbheight * c->ssy << 3))) njThrow(NJ_OUT_OF_MEM);
+        if (!(c->pixels = (unsigned char*) njAllocMem(c->stride * allocated_rows))) njThrow(NJ_OUT_OF_MEM);
     }
     if ((nj.ncomp == 3) && !nj.decode_components_only) {
         nj.rgb = (unsigned char*) njAllocMem(nj.width * nj.height * nj.ncomp);
@@ -713,11 +723,15 @@ NJ_INLINE void njDecodeScan(void) {
         for (i = 0, c = nj.comp;  i < nj.ncomp;  ++i, ++c)
             for (sby = 0;  sby < c->ssy;  ++sby)
                 for (sbx = 0;  sbx < c->ssx;  ++sbx) {
-                    njDecodeBlock(c, &c->pixels[((mby * c->ssy + sby) * c->stride + mbx * c->ssx + sbx) << 3]);
+                    const int row = nj.decode_mcu_rows_only ? sby : (mby * c->ssy + sby);
+                    njDecodeBlock(c, &c->pixels[(row * c->stride + mbx * c->ssx + sbx) << 3]);
                     njCheckError();
                 }
         if (++mbx >= nj.mbwidth) {
             mbx = 0;
+            if (nj.decode_mcu_rows_only && nj.mcu_row_callback) {
+                if (nj.mcu_row_callback(mby, nj.mcu_row_user)) njThrow(NJ_INTERNAL_ERR);
+            }
             if (++mby >= nj.mbheight) break;
         }
         if (nj.rstinterval && !(--rstcount)) {
@@ -893,9 +907,17 @@ void njDone(void) {
     njInit();
 }
 
-static nj_result_t njDecodeInternal(const void* jpeg, const int size, int components_only) {
+static nj_result_t njDecodeInternal(const void* jpeg,
+                                    const int size,
+                                    int components_only,
+                                    int mcu_rows_only,
+                                    nj_mcu_row_callback_t callback,
+                                    void* user) {
     njDone();
     nj.decode_components_only = components_only;
+    nj.decode_mcu_rows_only = mcu_rows_only;
+    nj.mcu_row_callback = callback;
+    nj.mcu_row_user = user;
     nj.pos = (const unsigned char*) jpeg;
     nj.size = size & 0x7FFFFFFF;
     if (nj.size < 2) return NJ_NO_JPEG;
@@ -925,11 +947,16 @@ static nj_result_t njDecodeInternal(const void* jpeg, const int size, int compon
 }
 
 nj_result_t njDecode(const void* jpeg, const int size) {
-    return njDecodeInternal(jpeg, size, 0);
+    return njDecodeInternal(jpeg, size, 0, 0, NULL, NULL);
 }
 
 nj_result_t njDecodeComponents(const void* jpeg, const int size) {
-    return njDecodeInternal(jpeg, size, 1);
+    return njDecodeInternal(jpeg, size, 1, 0, NULL, NULL);
+}
+
+nj_result_t njDecodeMcuRows(const void* jpeg, const int size, nj_mcu_row_callback_t callback, void* user) {
+    if (!callback) return NJ_INTERNAL_ERR;
+    return njDecodeInternal(jpeg, size, 1, 1, callback, user);
 }
 
 int njGetWidth(void)            { return nj.width; }
@@ -954,5 +981,14 @@ int njGetComponentStride(int index) {
     if ((index < 0) || (index >= nj.ncomp)) return 0;
     return nj.comp[index].stride;
 }
+int njGetComponentSsx(int index) {
+    if ((index < 0) || (index >= nj.ncomp)) return 0;
+    return nj.comp[index].ssx;
+}
+int njGetComponentSsy(int index) {
+    if ((index < 0) || (index >= nj.ncomp)) return 0;
+    return nj.comp[index].ssy;
+}
+int njGetMcuRowCount(void)     { return nj.mbheight; }
 
 #endif // _NJ_INCLUDE_HEADER_ONLY

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -882,14 +882,24 @@ static void streaming_free_cache(sh264e_jpeg_stream_context_t *ctx)
 static sh264e_status_t streaming_init_cache(sh264e_jpeg_stream_context_t *ctx)
 {
     const int component_count = njGetComponentCount();
+    const int y_width = njGetComponentWidth(0);
+    const int y_height = njGetComponentHeight(0);
+    const int cb_width = njGetComponentWidth(1);
+    const int cb_height = njGetComponentHeight(1);
+    const int cr_width = njGetComponentWidth(2);
+    const int cr_height = njGetComponentHeight(2);
     unsigned i;
 
     if (component_count != 3 || njGetWidth() != 1280 || njGetHeight() != 720) {
         return SH264E_ERR_UNSUPPORTED_CONFIG;
     }
-    if (njGetComponentSsx(0) != 2 || njGetComponentSsy(0) != 2 ||
-        njGetComponentSsx(1) != 1 || njGetComponentSsy(1) != 1 ||
-        njGetComponentSsx(2) != 1 || njGetComponentSsy(2) != 1) {
+    if (y_width != 1280 || y_height != 720 ||
+        cb_width != cr_width || cb_height != cr_height) {
+        return SH264E_ERR_UNSUPPORTED_CONFIG;
+    }
+    if (!((cb_width == 640 && cb_height == 360) ||
+          (cb_width == 640 && cb_height == 720) ||
+          (cb_width == 1280 && cb_height == 720))) {
         return SH264E_ERR_UNSUPPORTED_CONFIG;
     }
 

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -73,14 +73,41 @@ typedef enum sh264e_jpeg_alloc_mode_t {
     SH264E_JPEG_ALLOC_ARENA = 1
 } sh264e_jpeg_alloc_mode_t;
 
+typedef struct sh264e_jpeg_stream_component_t {
+    uint8_t *pixels;
+    uint32_t width;
+    uint32_t height;
+    uint32_t row0;
+    uint32_t rows;
+    uint32_t rows_per_mcu;
+    ptrdiff_t stride;
+} sh264e_jpeg_stream_component_t;
+
+typedef struct sh264e_jpeg_stream_context_t {
+    sh264e_encoder_t *encoder;
+    uint8_t *work_buffer;
+    uint8_t *out;
+    size_t out_capacity;
+    size_t offset;
+    size_t cache_bytes;
+    unsigned next_slice;
+    unsigned idr_started;
+    int initialized;
+    sh264e_status_t status;
+    sh264e_jpeg_stream_component_t components[3];
+} sh264e_jpeg_stream_context_t;
+
 typedef struct sh264e_jpeg_alloc_header_t {
     size_t size;
     size_t arena_span;
     unsigned from_arena;
 } sh264e_jpeg_alloc_header_t;
 
+typedef int (*nj_mcu_row_callback_t)(int mcu_y, void *user);
+
 void njInit(void);
 int njDecodeComponents(const void *jpeg, const int size);
+int njDecodeMcuRows(const void *jpeg, const int size, nj_mcu_row_callback_t callback, void *user);
 int njGetWidth(void);
 int njGetHeight(void);
 int njGetComponentCount(void);
@@ -88,6 +115,8 @@ const unsigned char *njGetComponentPixels(int index);
 int njGetComponentWidth(int index);
 int njGetComponentHeight(int index);
 int njGetComponentStride(int index);
+int njGetComponentSsx(int index);
+int njGetComponentSsy(int index);
 void njDone(void);
 
 static size_t sh264e_jpeg_alloc_current_bytes;
@@ -99,6 +128,7 @@ static unsigned sh264e_jpeg_alloc_arena_failed;
 static sh264e_jpeg_alloc_mode_t sh264e_jpeg_alloc_mode = SH264E_JPEG_ALLOC_HEAP;
 static uint8_t *sh264e_jpeg_alloc_arena;
 static size_t sh264e_jpeg_alloc_arena_capacity;
+static size_t sh264e_jpeg_streaming_last_cache_bytes;
 
 static void reset_progressive_state(sh264e_encoder_t *encoder);
 
@@ -686,6 +716,289 @@ static void jpeg_make_nv12_slice(const sh264e_jpeg_component_t *components,
     slice->plane[1] = dst_uv;
     slice->stride[0] = SH264E_V1_WIDTH;
     slice->stride[1] = SH264E_V1_WIDTH;
+}
+
+static uint8_t streaming_bilinear_sample_plane(const sh264e_jpeg_stream_component_t *src,
+                                               sh264e_scale_coord_t sx,
+                                               sh264e_scale_coord_t sy)
+{
+    uint32_t y0 = sy.index;
+    uint32_t y1 = y0 + 1u < src->height ? y0 + 1u : y0;
+    const uint32_t x0 = sx.index;
+    const uint32_t x1 = x0 + 1u < src->width ? x0 + 1u : x0;
+    const uint8_t *row0;
+    const uint8_t *row1;
+
+    if (y0 < src->row0) {
+        y0 = src->row0;
+    }
+    if (y1 < src->row0) {
+        y1 = src->row0;
+    }
+    y0 -= src->row0;
+    y1 -= src->row0;
+    if (y0 >= src->rows) {
+        y0 = src->rows - 1u;
+    }
+    if (y1 >= src->rows) {
+        y1 = src->rows - 1u;
+    }
+
+    row0 = src->pixels + (size_t)y0 * (size_t)src->stride;
+    row1 = src->pixels + (size_t)y1 * (size_t)src->stride;
+    return bilinear_blend_u8(row0[x0], row0[x1], row1[x0], row1[x1], sx.fraction, sy.fraction);
+}
+
+static void streaming_scale_component_slice(const sh264e_jpeg_stream_component_t *src,
+                                            uint8_t *dst,
+                                            uint32_t dst_width,
+                                            uint32_t dst_height,
+                                            uint32_t dst_y_start,
+                                            uint32_t dst_rows,
+                                            ptrdiff_t dst_stride)
+{
+    sh264e_axis_mapper_t y_mapper = scale_axis_mapper_init(src->height, dst_height, dst_y_start);
+    uint32_t y;
+
+    for (y = 0; y < dst_rows; y++) {
+        uint8_t *dst_row = dst + (size_t)y * (size_t)dst_stride;
+        const sh264e_scale_coord_t sy = scale_coord_from_raw(y_mapper.pos, src->height);
+        sh264e_axis_mapper_t x_mapper = scale_axis_mapper_init(src->width, dst_width, 0u);
+        uint32_t x;
+
+        for (x = 0; x < dst_width; x++) {
+            const sh264e_scale_coord_t sx = scale_coord_from_raw(x_mapper.pos, src->width);
+            dst_row[x] = streaming_bilinear_sample_plane(src, sx, sy);
+            scale_axis_mapper_advance(&x_mapper);
+        }
+        scale_axis_mapper_advance(&y_mapper);
+    }
+}
+
+static void streaming_source_range(uint32_t src_height,
+                                   uint32_t dst_height,
+                                   uint32_t dst_y_start,
+                                   uint32_t dst_rows,
+                                   uint32_t *out_min_y,
+                                   uint32_t *out_max_y)
+{
+    sh264e_axis_mapper_t y_mapper = scale_axis_mapper_init(src_height, dst_height, dst_y_start);
+    uint32_t min_y = UINT_MAX;
+    uint32_t max_y = 0u;
+    uint32_t y;
+
+    for (y = 0; y < dst_rows; y++) {
+        const sh264e_scale_coord_t sy = scale_coord_from_raw(y_mapper.pos, src_height);
+        const uint32_t y1 = sy.index + 1u < src_height ? sy.index + 1u : sy.index;
+        if (sy.index < min_y) {
+            min_y = sy.index;
+        }
+        if (y1 > max_y) {
+            max_y = y1;
+        }
+        scale_axis_mapper_advance(&y_mapper);
+    }
+    *out_min_y = min_y;
+    *out_max_y = max_y;
+}
+
+static int streaming_slice_available(const sh264e_jpeg_stream_context_t *ctx, unsigned slice_index)
+{
+    uint32_t min_y;
+    uint32_t max_y;
+    unsigned i;
+
+    streaming_source_range(ctx->components[0].height,
+                           SH264E_V1_HEIGHT,
+                           slice_index * SH264E_V1_SLICE_LUMA_HEIGHT,
+                           SH264E_V1_SLICE_LUMA_HEIGHT,
+                           &min_y,
+                           &max_y);
+    if (min_y < ctx->components[0].row0 ||
+        max_y >= ctx->components[0].row0 + ctx->components[0].rows) {
+        return 0;
+    }
+
+    for (i = 1u; i < 3u; i++) {
+        streaming_source_range(ctx->components[i].height,
+                               SH264E_V1_HEIGHT / 2u,
+                               slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT,
+                               SH264E_V1_SLICE_CHROMA_HEIGHT,
+                               &min_y,
+                               &max_y);
+        if (min_y < ctx->components[i].row0 ||
+            max_y >= ctx->components[i].row0 + ctx->components[i].rows) {
+            return 0;
+        }
+    }
+    return 1;
+}
+
+static void streaming_make_i420_slice(const sh264e_jpeg_stream_context_t *ctx,
+                                      unsigned slice_index,
+                                      sh264e_slice_t *slice)
+{
+    uint8_t *dst_y = ctx->work_buffer;
+    uint8_t *dst_u = dst_y + (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_LUMA_HEIGHT;
+    uint8_t *dst_v = dst_u + (size_t)SH264E_CHROMA_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT;
+
+    streaming_scale_component_slice(&ctx->components[0], dst_y,
+                                    SH264E_V1_WIDTH, SH264E_V1_HEIGHT,
+                                    slice_index * SH264E_V1_SLICE_LUMA_HEIGHT,
+                                    SH264E_V1_SLICE_LUMA_HEIGHT,
+                                    SH264E_V1_WIDTH);
+    streaming_scale_component_slice(&ctx->components[1], dst_u,
+                                    SH264E_CHROMA_WIDTH, SH264E_V1_HEIGHT / 2u,
+                                    slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                    SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                    SH264E_CHROMA_WIDTH);
+    streaming_scale_component_slice(&ctx->components[2], dst_v,
+                                    SH264E_CHROMA_WIDTH, SH264E_V1_HEIGHT / 2u,
+                                    slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                    SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                    SH264E_CHROMA_WIDTH);
+
+    memset(slice, 0, sizeof(*slice));
+    slice->pixfmt = SH264E_PIXFMT_I420;
+    slice->plane[0] = dst_y;
+    slice->plane[1] = dst_u;
+    slice->plane[2] = dst_v;
+    slice->stride[0] = SH264E_V1_WIDTH;
+    slice->stride[1] = SH264E_CHROMA_WIDTH;
+    slice->stride[2] = SH264E_CHROMA_WIDTH;
+}
+
+static void streaming_free_cache(sh264e_jpeg_stream_context_t *ctx)
+{
+    unsigned i;
+
+    for (i = 0u; i < 3u; i++) {
+        free(ctx->components[i].pixels);
+        ctx->components[i].pixels = NULL;
+    }
+    ctx->initialized = 0;
+}
+
+static sh264e_status_t streaming_init_cache(sh264e_jpeg_stream_context_t *ctx)
+{
+    const int component_count = njGetComponentCount();
+    unsigned i;
+
+    if (component_count != 3 || njGetWidth() != 1280 || njGetHeight() != 720) {
+        return SH264E_ERR_UNSUPPORTED_CONFIG;
+    }
+    if (njGetComponentSsx(0) != 2 || njGetComponentSsy(0) != 2 ||
+        njGetComponentSsx(1) != 1 || njGetComponentSsy(1) != 1 ||
+        njGetComponentSsx(2) != 1 || njGetComponentSsy(2) != 1) {
+        return SH264E_ERR_UNSUPPORTED_CONFIG;
+    }
+
+    for (i = 0u; i < 3u; i++) {
+        sh264e_jpeg_stream_component_t *component = &ctx->components[i];
+        const int width = njGetComponentWidth((int)i);
+        const int height = njGetComponentHeight((int)i);
+        const int stride = njGetComponentStride((int)i);
+        const int rows_per_mcu = njGetComponentSsy((int)i) * 8;
+        size_t bytes;
+
+        if (width <= 0 || height <= 0 || stride < width || rows_per_mcu <= 0) {
+            return SH264E_ERR_UNSUPPORTED_CONFIG;
+        }
+        component->width = (uint32_t)width;
+        component->height = (uint32_t)height;
+        component->stride = (ptrdiff_t)stride;
+        component->rows_per_mcu = (uint32_t)rows_per_mcu;
+        component->row0 = 0u;
+        component->rows = 0u;
+        bytes = (size_t)stride * (size_t)rows_per_mcu * 2u;
+        component->pixels = (uint8_t *)malloc(bytes);
+        if (component->pixels == NULL) {
+            streaming_free_cache(ctx);
+            return SH264E_ERR_ALLOCATION_FAILED;
+        }
+        ctx->cache_bytes += bytes;
+    }
+    ctx->initialized = 1;
+    return SH264E_OK;
+}
+
+static void streaming_copy_current_mcu_row(sh264e_jpeg_stream_context_t *ctx, int mcu_y)
+{
+    unsigned i;
+
+    for (i = 0u; i < 3u; i++) {
+        sh264e_jpeg_stream_component_t *component = &ctx->components[i];
+        const uint8_t *src = njGetComponentPixels((int)i);
+        const size_t row_bytes = (size_t)component->stride * component->rows_per_mcu;
+        const uint32_t new_row0 = (uint32_t)mcu_y * component->rows_per_mcu;
+
+        if (mcu_y == 0) {
+            memcpy(component->pixels, src, row_bytes);
+            component->row0 = 0u;
+            component->rows = component->rows_per_mcu;
+        } else if (mcu_y == 1) {
+            memcpy(component->pixels + row_bytes, src, row_bytes);
+            component->row0 = 0u;
+            component->rows = component->rows_per_mcu * 2u;
+            if (component->rows > component->height) {
+                component->rows = component->height;
+            }
+        } else {
+            memmove(component->pixels,
+                    component->pixels + row_bytes,
+                    row_bytes);
+            memcpy(component->pixels + row_bytes, src, row_bytes);
+            component->row0 = new_row0 - component->rows_per_mcu;
+            component->rows = component->rows_per_mcu * 2u;
+            if (component->row0 + component->rows > component->height) {
+                component->rows = component->height - component->row0;
+            }
+        }
+    }
+}
+
+static int streaming_mcu_row_ready(int mcu_y, void *user)
+{
+    sh264e_jpeg_stream_context_t *ctx = (sh264e_jpeg_stream_context_t *)user;
+
+    if (ctx == NULL || ctx->status != SH264E_OK) {
+        return 1;
+    }
+    if (!ctx->initialized) {
+        ctx->status = streaming_init_cache(ctx);
+        if (ctx->status != SH264E_OK) {
+            return 1;
+        }
+    }
+
+    streaming_copy_current_mcu_row(ctx, mcu_y);
+    if (!ctx->idr_started) {
+        size_t bytes = 0u;
+        ctx->status = sh264e_begin_idr(ctx->encoder, ctx->out, ctx->out_capacity, &bytes);
+        if (ctx->status != SH264E_OK) {
+            return 1;
+        }
+        ctx->offset += bytes;
+        ctx->idr_started = 1u;
+    }
+
+    while (ctx->next_slice < SH264E_V1_SLICE_COUNT &&
+           streaming_slice_available(ctx, ctx->next_slice)) {
+        sh264e_slice_t slice;
+        size_t bytes = 0u;
+
+        streaming_make_i420_slice(ctx, ctx->next_slice, &slice);
+        ctx->status = sh264e_encode_idr_slice(ctx->encoder, &slice,
+                                              ctx->out + ctx->offset,
+                                              ctx->out_capacity - ctx->offset,
+                                              &bytes);
+        if (ctx->status != SH264E_OK) {
+            return 1;
+        }
+        ctx->offset += bytes;
+        ctx->next_slice++;
+    }
+    return 0;
 }
 
 static void resize_scale_plane_slice(const uint8_t *src,
@@ -1764,6 +2077,80 @@ sh264e_status_t sh264e_encode_jpeg_idr_with_arena(sh264e_encoder_t *encoder,
                                        jpeg_arena, jpeg_arena_size, 1,
                                        work_buffer, work_buffer_capacity,
                                        out, out_capacity, out_size);
+}
+
+size_t sh264e_jpeg_get_last_streaming_cache_bytes(void)
+{
+    return sh264e_jpeg_streaming_last_cache_bytes;
+}
+
+sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype(sh264e_encoder_t *encoder,
+                                                           const uint8_t *jpeg_data,
+                                                           size_t jpeg_size,
+                                                           uint8_t *work_buffer,
+                                                           size_t work_buffer_capacity,
+                                                           uint8_t *out,
+                                                           size_t out_capacity,
+                                                           size_t *out_size)
+{
+    sh264e_jpeg_stream_context_t ctx;
+    sh264e_status_t status;
+    size_t required_work = 0u;
+
+    if (encoder == NULL || jpeg_data == NULL || work_buffer == NULL ||
+        out == NULL || out_size == NULL) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+    *out_size = 0u;
+    sh264e_jpeg_streaming_last_cache_bytes = 0u;
+    if (encoder->idr_active != 0u) {
+        return SH264E_ERR_BAD_STATE;
+    }
+    if (encoder->config.pixfmt != SH264E_PIXFMT_I420) {
+        return SH264E_ERR_UNSUPPORTED_CONFIG;
+    }
+    if (jpeg_size == 0u || jpeg_size > (size_t)INT_MAX) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+    status = sh264e_jpeg_get_slice_buffer_size(&required_work);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    if (work_buffer_capacity < required_work) {
+        return SH264E_ERR_BUFFER_TOO_SMALL;
+    }
+
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.encoder = encoder;
+    ctx.work_buffer = work_buffer;
+    ctx.out = out;
+    ctx.out_capacity = out_capacity;
+    ctx.status = SH264E_OK;
+
+    jpeg_allocation_stats_reset();
+    status = map_jpeg_result(njDecodeMcuRows(jpeg_data, (int)jpeg_size,
+                                             streaming_mcu_row_ready, &ctx));
+    if (ctx.status != SH264E_OK) {
+        status = ctx.status;
+    }
+    if (status == SH264E_OK && ctx.next_slice != SH264E_V1_SLICE_COUNT) {
+        status = SH264E_ERR_INTERNAL;
+    }
+    if (status == SH264E_OK) {
+        size_t bytes = 0u;
+        status = sh264e_end_idr(encoder);
+        if (status == SH264E_OK) {
+            ctx.offset += bytes;
+            *out_size = ctx.offset;
+        }
+    }
+    if (status != SH264E_OK) {
+        reset_progressive_state(encoder);
+    }
+    njDone();
+    sh264e_jpeg_streaming_last_cache_bytes = ctx.cache_bytes;
+    streaming_free_cache(&ctx);
+    return status;
 }
 
 sh264e_status_t sh264e_encoder_create(const sh264e_config_t *config,

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -174,6 +174,30 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream):
     raise RuntimeError(f"JPEG encoder did not report peak allocation bytes: {result.stdout!r}")
 
 
+def encode_jpeg_streaming_prototype(args, jpeg_input, bitstream):
+    result = run_capture([
+        args.jpeg_encoder,
+        "--streaming-prototype",
+        "--format",
+        "i420",
+        str(jpeg_input),
+        str(bitstream),
+    ])
+    if "jpeg current allocation bytes: 0" not in result.stdout:
+        raise RuntimeError(f"streaming JPEG prototype leaked tracked allocations: {result.stdout!r}")
+    peak = None
+    cache = None
+    for line in result.stdout.splitlines():
+        if line.startswith("jpeg peak allocation bytes:"):
+            peak = int(line.rsplit(" ", 1)[1])
+        if line.startswith("jpeg streaming cache bytes:"):
+            cache = int(line.rsplit(" ", 1)[1])
+    if peak is None or peak >= 1382400:
+        raise RuntimeError(f"streaming JPEG prototype did not reduce NanoJPEG allocation peak: {result.stdout!r}")
+    if cache is None or cache == 0:
+        raise RuntimeError(f"streaming JPEG prototype did not report cache bytes: {result.stdout!r}")
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--encoder", required=True)
@@ -266,6 +290,9 @@ def main():
                 str(jpeg_input),
                 str(workdir / "output_jpeg_arena_too_small.h264"),
             ], stderr_contains="buffer too small")
+            streaming_output = workdir / "output_jpeg_streaming_yuvj420p_i420.h264"
+            encode_jpeg_streaming_prototype(args, jpeg_input, streaming_output)
+            validate_bitstream(args.ffprobe, args.ffmpeg, streaming_output)
         for fmt in ("i420", "nv12"):
             jpeg_output = workdir / f"output_jpeg_{pix_fmt}_{fmt}.h264"
             encode_jpeg(args, fmt, jpeg_input, jpeg_output)

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -208,6 +208,48 @@ def make_color_jpeg(args, path, pix_fmt):
     validate_image_pix_fmt(args.ffprobe, path, pix_fmt)
 
 
+def make_restart_marker_jpeg(args, path):
+    ppm = path.with_suffix(".ppm")
+    with ppm.open("wb") as f:
+        f.write(f"P6\n{SMALL_WIDTH} {SMALL_HEIGHT}\n255\n".encode("ascii"))
+        for y in range(SMALL_HEIGHT):
+            row = bytearray()
+            for x in range(SMALL_WIDTH):
+                row.extend((
+                    (x // 5 + y // 3) & 0xFF,
+                    (64 + x // 7) & 0xFF,
+                    (192 + y // 5) & 0xFF,
+                ))
+            f.write(row)
+    run([
+        args.cjpeg,
+        "-baseline",
+        "-quality",
+        "85",
+        "-sample",
+        "2x2,1x1,1x1",
+        "-restart",
+        "1",
+        "-outfile",
+        str(path),
+        str(ppm),
+    ])
+    validate_image_pix_fmt(args.ffprobe, path, "yuvj420p")
+    validate_jpeg_restart_markers(path)
+
+
+def validate_jpeg_restart_markers(path):
+    data = path.read_bytes()
+    if b"\xff\xdd" not in data:
+        raise RuntimeError(f"{path} is missing a JPEG DRI marker")
+    restart_count = 0
+    for i in range(len(data) - 1):
+        if data[i] == 0xFF and 0xD0 <= data[i + 1] <= 0xD7:
+            restart_count += 1
+    if restart_count == 0:
+        raise RuntimeError(f"{path} is missing JPEG RST markers")
+
+
 def encode_jpeg(args, fmt, jpeg_input, bitstream):
     result = run_capture([args.jpeg_encoder, "--format", fmt, str(jpeg_input), str(bitstream)])
     if "jpeg current allocation bytes: 0" not in result.stdout:
@@ -254,6 +296,7 @@ def main():
     parser.add_argument("--jpeg-encoder", required=True)
     parser.add_argument("--ffprobe", required=True)
     parser.add_argument("--ffmpeg", required=True)
+    parser.add_argument("--cjpeg")
     parser.add_argument("--workdir", required=True)
     args = parser.parse_args()
 
@@ -349,6 +392,18 @@ def main():
             if pix_fmt == "yuvj420p" and fmt == "i420":
                 compare_decoded_i420(args, jpeg_output, streaming_output,
                                      "output_jpeg_yuvj420p_i420_streaming_compare")
+
+    if args.cjpeg:
+        restart_jpeg_input = workdir / "input_720p_yuvj420p_restart.jpg"
+        make_restart_marker_jpeg(args, restart_jpeg_input)
+        restart_streaming_output = workdir / "output_jpeg_streaming_yuvj420p_restart_i420.h264"
+        restart_jpeg_output = workdir / "output_jpeg_yuvj420p_restart_i420.h264"
+        encode_jpeg_streaming_prototype(args, restart_jpeg_input, restart_streaming_output)
+        validate_bitstream(args.ffprobe, args.ffmpeg, restart_streaming_output)
+        encode_jpeg(args, "i420", restart_jpeg_input, restart_jpeg_output)
+        validate_bitstream(args.ffprobe, args.ffmpeg, restart_jpeg_output)
+        compare_decoded_i420(args, restart_jpeg_output, restart_streaming_output,
+                             "output_jpeg_yuvj420p_restart_i420_streaming_compare")
 
     grayscale_jpeg_input = workdir / "input_gray_720p.jpg"
     run([

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import hashlib
 import subprocess
 from pathlib import Path
 
@@ -131,6 +132,53 @@ def validate_image_pix_fmt(ffprobe, image, expected_pix_fmt):
     got = probe.stdout.strip()
     if got != expected_pix_fmt:
         raise RuntimeError(f"{image} pix_fmt: got {got}, expected {expected_pix_fmt}")
+
+
+def sha256_file(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def decode_i420_frame(args, bitstream, raw_output):
+    run([
+        args.ffmpeg,
+        "-y",
+        "-v",
+        "error",
+        "-i",
+        str(bitstream),
+        "-f",
+        "rawvideo",
+        "-pix_fmt",
+        "yuv420p",
+        str(raw_output),
+    ])
+    expected_size = WIDTH * HEIGHT * 3 // 2
+    got_size = raw_output.stat().st_size
+    if got_size != expected_size:
+        raise RuntimeError(
+            f"decoded frame size mismatch for {bitstream}: got {got_size}, expected {expected_size}"
+        )
+    return sha256_file(raw_output)
+
+
+def compare_decoded_i420(args, reference_bitstream, candidate_bitstream, stem):
+    workdir = Path(args.workdir)
+    reference_raw = workdir / f"{stem}_reference.yuv"
+    candidate_raw = workdir / f"{stem}_candidate.yuv"
+    reference_hash = decode_i420_frame(args, reference_bitstream, reference_raw)
+    candidate_hash = decode_i420_frame(args, candidate_bitstream, candidate_raw)
+    if reference_hash != candidate_hash:
+        raise RuntimeError(
+            "decoded frame mismatch between component-plane and streaming JPEG paths: "
+            f"{reference_hash} != {candidate_hash}"
+        )
 
 
 def run_case(args, fmt, make_input):
@@ -279,6 +327,7 @@ def main():
 
     for pix_fmt in ("yuvj420p", "yuvj422p", "yuvj444p"):
         jpeg_input = workdir / f"input_720p_{pix_fmt}.jpg"
+        streaming_output = None
         make_color_jpeg(args, jpeg_input, pix_fmt)
         if pix_fmt == "yuvj420p":
             run_expect_fail([
@@ -297,6 +346,9 @@ def main():
             jpeg_output = workdir / f"output_jpeg_{pix_fmt}_{fmt}.h264"
             encode_jpeg(args, fmt, jpeg_input, jpeg_output)
             validate_bitstream(args.ffprobe, args.ffmpeg, jpeg_output)
+            if pix_fmt == "yuvj420p" and fmt == "i420":
+                compare_decoded_i420(args, jpeg_output, streaming_output,
+                                     "output_jpeg_yuvj420p_i420_streaming_compare")
 
     grayscale_jpeg_input = workdir / "input_gray_720p.jpg"
     run([

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -370,7 +370,6 @@ def main():
 
     for pix_fmt in ("yuvj420p", "yuvj422p", "yuvj444p"):
         jpeg_input = workdir / f"input_720p_{pix_fmt}.jpg"
-        streaming_output = None
         make_color_jpeg(args, jpeg_input, pix_fmt)
         if pix_fmt == "yuvj420p":
             run_expect_fail([
@@ -382,16 +381,16 @@ def main():
                 str(jpeg_input),
                 str(workdir / "output_jpeg_arena_too_small.h264"),
             ], stderr_contains="buffer too small")
-            streaming_output = workdir / "output_jpeg_streaming_yuvj420p_i420.h264"
-            encode_jpeg_streaming_prototype(args, jpeg_input, streaming_output)
-            validate_bitstream(args.ffprobe, args.ffmpeg, streaming_output)
+        streaming_output = workdir / f"output_jpeg_streaming_{pix_fmt}_i420.h264"
+        encode_jpeg_streaming_prototype(args, jpeg_input, streaming_output)
+        validate_bitstream(args.ffprobe, args.ffmpeg, streaming_output)
         for fmt in ("i420", "nv12"):
             jpeg_output = workdir / f"output_jpeg_{pix_fmt}_{fmt}.h264"
             encode_jpeg(args, fmt, jpeg_input, jpeg_output)
             validate_bitstream(args.ffprobe, args.ffmpeg, jpeg_output)
-            if pix_fmt == "yuvj420p" and fmt == "i420":
+            if fmt == "i420":
                 compare_decoded_i420(args, jpeg_output, streaming_output,
-                                     "output_jpeg_yuvj420p_i420_streaming_compare")
+                                     f"output_jpeg_{pix_fmt}_i420_streaming_compare")
 
     if args.cjpeg:
         restart_jpeg_input = workdir / "input_720p_yuvj420p_restart.jpg"

--- a/tools/sh264e_encode_jpeg.c
+++ b/tools/sh264e_encode_jpeg.c
@@ -5,11 +5,21 @@
 #include <string.h>
 
 void sh264e_jpeg_set_test_allocation_limit(size_t max_bytes);
+size_t sh264e_jpeg_get_last_streaming_cache_bytes(void);
+sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype(sh264e_encoder_t *encoder,
+                                                           const uint8_t *jpeg_data,
+                                                           size_t jpeg_size,
+                                                           uint8_t *work_buffer,
+                                                           size_t work_buffer_capacity,
+                                                           uint8_t *out,
+                                                           size_t out_capacity,
+                                                           size_t *out_size);
 
 static void usage(const char *argv0)
 {
     fprintf(stderr,
-            "usage: %s [--test-allocation-limit BYTES] [--test-arena-shrink BYTES] "
+            "usage: %s [--streaming-prototype] [--test-allocation-limit BYTES] "
+            "[--test-arena-shrink BYTES] "
             "--format i420|nv12 input.jpg output.h264\n",
             argv0);
 }
@@ -112,17 +122,21 @@ int main(int argc, char **argv)
     size_t output_size = 0;
     size_t allocation_limit = (size_t)-1;
     size_t arena_shrink = 0;
+    int streaming_prototype = 0;
     int argi = 1;
     int rc = 1;
 
-    while (argi + 1 < argc) {
-        if (strcmp(argv[argi], "--test-allocation-limit") == 0) {
+    while (argi < argc) {
+        if (strcmp(argv[argi], "--streaming-prototype") == 0) {
+            streaming_prototype = 1;
+            argi++;
+        } else if (argi + 1 < argc && strcmp(argv[argi], "--test-allocation-limit") == 0) {
             if (!parse_size(argv[argi + 1], &allocation_limit)) {
                 usage(argv[0]);
                 return 2;
             }
             argi += 2;
-        } else if (strcmp(argv[argi], "--test-arena-shrink") == 0) {
+        } else if (argi + 1 < argc && strcmp(argv[argi], "--test-arena-shrink") == 0) {
             if (!parse_size(argv[argi + 1], &arena_shrink)) {
                 usage(argv[0]);
                 return 2;
@@ -145,7 +159,11 @@ int main(int argc, char **argv)
         fprintf(stderr, "failed to read JPEG input: %s\n", input_path);
         goto done;
     }
-    if (allocation_limit == (size_t)-1) {
+    if (streaming_prototype && (allocation_limit != (size_t)-1 || arena_shrink != 0u)) {
+        fprintf(stderr, "--streaming-prototype cannot be combined with allocation test options\n");
+        goto done;
+    }
+    if (allocation_limit == (size_t)-1 && !streaming_prototype) {
         status = sh264e_jpeg_get_work_size(jpeg_data, jpeg_size, &jpeg_work_size);
         if (status != SH264E_OK) {
             fprintf(stderr, "sh264e_jpeg_get_work_size failed: %s\n", sh264e_status_string(status));
@@ -179,7 +197,7 @@ int main(int argc, char **argv)
         goto done;
     }
 
-    if (allocation_limit == (size_t)-1) {
+    if (allocation_limit == (size_t)-1 && !streaming_prototype) {
         jpeg_arena = (uint8_t *)malloc(jpeg_arena_size);
         if (jpeg_arena == NULL) {
             fprintf(stderr, "failed to allocate JPEG arena\n");
@@ -204,6 +222,10 @@ int main(int argc, char **argv)
         status = sh264e_encode_jpeg_idr(encoder, jpeg_data, jpeg_size,
                                         work, work_size,
                                         output_buf, output_capacity, &output_size);
+    } else if (streaming_prototype) {
+        status = sh264e_encode_jpeg_idr_streaming_prototype(encoder, jpeg_data, jpeg_size,
+                                                            work, work_size,
+                                                            output_buf, output_capacity, &output_size);
     } else {
         status = sh264e_encode_jpeg_idr_with_arena(encoder, jpeg_data, jpeg_size,
                                                    jpeg_arena, jpeg_arena_size,
@@ -236,6 +258,9 @@ int main(int argc, char **argv)
         printf("jpeg work arena bytes: %zu\n", jpeg_work_size);
         printf("jpeg current allocation bytes: %zu\n", stats.current_bytes);
         printf("jpeg peak allocation bytes: %zu\n", stats.peak_bytes);
+        if (streaming_prototype) {
+            printf("jpeg streaming cache bytes: %zu\n", sh264e_jpeg_get_last_streaming_cache_bytes());
+        }
     }
     printf("encoded JPEG input to progressive IDR frame\n");
     rc = 0;


### PR DESCRIPTION
## Summary

- add a repo-grounded MCU-row streaming design note for the JPEG v2 memory path
- add an internal NanoJPEG MCU-row callback mode that decodes one MCU row per component instead of full component planes
- add a hidden `sh264e_encode_jpeg --streaming-prototype` path for 1280x720 4:2:0, 4:2:2, and 4:4:4 JPEG inputs to I420 H.264 output
- validate the prototype in ffmpeg integration, including decoded-frame SHA-256 comparison against the component-plane JPEG path
- add `cjpeg`-generated DRI/RST restart-marker fixture coverage for the streaming prototype when `cjpeg` is available
- assert NanoJPEG peak allocation stays below the corresponding full component-plane baselines
- document the promotion decision: keep the row-window bridge hidden for #5 and defer production/default promotion until dynamic sizing, arena integration, NV12 output, and grayscale coverage are added
- update README and memory-reduction notes with the prototype boundary and measured row-cache sizes

Refs #5

## Validation

- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build -R sh264e_ffmpeg_integration --output-on-failure`
- `ctest --test-dir build --output-on-failure`
- `ctest --test-dir build -R qemu --output-on-failure`
- `build/sh264e_encode_jpeg --streaming-prototype --format i420 build/integration/input_720p_yuvj420p.jpg /tmp/streaming_yuvj420p.h264`
- `build/sh264e_encode_jpeg --streaming-prototype --format i420 build/integration/input_720p_yuvj422p.jpg /tmp/streaming_yuvj422p.h264`
- `build/sh264e_encode_jpeg --streaming-prototype --format i420 build/integration/input_720p_yuvj444p.jpg /tmp/streaming_yuvj444p.h264`

QEMU note: this environment still skips QEMU firmware tests because `arm-none-eabi-gcc` cannot compile `<stdlib.h>`, so the qemu-filtered CTest run finds no tests.

## Prototype Result

- 1280x720 4:2:0 streaming NanoJPEG allocation peak: 30,720 bytes; retained row cache: 61,440 bytes; full component-plane baseline: 1,382,400 bytes
- 1280x720 4:2:2 streaming NanoJPEG allocation peak: 40,960 bytes; retained row cache: 81,920 bytes; full component-plane baseline: 1,843,200 bytes
- 1280x720 4:4:4 streaming NanoJPEG allocation peak: 61,440 bytes; retained row cache: 122,880 bytes; full component-plane baseline: 2,764,800 bytes
- decoded streaming and component-plane I420 H.264 outputs match byte-for-byte after ffmpeg raw `yuv420p` decode for the 1280x720 yuvj420p/yuvj422p/yuvj444p fixtures
- `cjpeg -restart 1` fixture includes DRI/RST markers and passes the same streaming-vs-component decoded-frame comparison

## Promotion Boundary

The row-window bridge remains hidden prototype scope in this PR. Production/default promotion should be a follow-up that adds dynamic source-size cache sizing, caller-provided arena integration, NV12 output, and grayscale coverage.
