### PR TITLE
jpeg: make arena metadata alignment-safe

### DIFF
--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -238,7 +238,8 @@ void *njAllocMem(int size)
     size_t span = 0u;
     size_t aligned_offset = 0u;
     size_t end_offset = 0u;
-    sh264e_jpeg_alloc_header_t *header;
+    sh264e_jpeg_alloc_header_t header;
+    uint8_t *header_bytes;
     void *raw;
 
     if (!jpeg_allocation_span(requested, &span)) {
@@ -253,8 +254,11 @@ void *njAllocMem(int size)
             return NULL;
         }
     }
-    if (!jpeg_align_up(sh264e_jpeg_alloc_arena_offset, &aligned_offset) ||
-        aligned_offset > ((size_t)-1) - span) {
+    if (!jpeg_align_up(sh264e_jpeg_alloc_arena_offset, &aligned_offset)) {
+        sh264e_jpeg_alloc_arena_failed = 1u;
+        return NULL;
+    }
+    if (aligned_offset > ((size_t)-1) - span) {
         sh264e_jpeg_alloc_arena_failed = 1u;
         return NULL;
     }
@@ -266,10 +270,12 @@ void *njAllocMem(int size)
             return NULL;
         }
 
-        header = (sh264e_jpeg_alloc_header_t *)(void *)(sh264e_jpeg_alloc_arena + aligned_offset);
-        header->size = requested;
-        header->arena_span = span;
-        header->from_arena = 1u;
+        header.size = requested;
+        header.arena_span = span;
+        header.from_arena = 1u;
+        header_bytes = sh264e_jpeg_alloc_arena + aligned_offset;
+        /* Caller arenas are byte buffers; do not require the arena base itself to be aligned. */
+        memcpy(header_bytes, &header, sizeof(header));
         raw = sh264e_jpeg_alloc_arena + aligned_offset + header_size;
         sh264e_jpeg_alloc_arena_offset = end_offset;
     } else {
@@ -278,10 +284,11 @@ void *njAllocMem(int size)
             return NULL;
         }
 
-        header = (sh264e_jpeg_alloc_header_t *)raw;
-        header->size = requested;
-        header->arena_span = span;
-        header->from_arena = 0u;
+        header.size = requested;
+        header.arena_span = span;
+        header.from_arena = 0u;
+        header_bytes = (uint8_t *)raw;
+        memcpy(header_bytes, &header, sizeof(header));
         raw = (uint8_t *)raw + header_size;
         sh264e_jpeg_alloc_arena_offset = end_offset;
     }
@@ -299,20 +306,22 @@ void *njAllocMem(int size)
 
 void njFreeMem(void *block)
 {
-    sh264e_jpeg_alloc_header_t *header;
+    uint8_t *header_bytes;
+    sh264e_jpeg_alloc_header_t header;
 
     if (block == NULL) {
         return;
     }
 
-    header = (sh264e_jpeg_alloc_header_t *)(void *)((uint8_t *)block - jpeg_alloc_header_size());
-    if (sh264e_jpeg_alloc_current_bytes >= header->size) {
-        sh264e_jpeg_alloc_current_bytes -= header->size;
+    header_bytes = (uint8_t *)block - jpeg_alloc_header_size();
+    memcpy(&header, header_bytes, sizeof(header));
+    if (sh264e_jpeg_alloc_current_bytes >= header.size) {
+        sh264e_jpeg_alloc_current_bytes -= header.size;
     } else {
         sh264e_jpeg_alloc_current_bytes = 0u;
     }
-    if (header->from_arena == 0u) {
-        free(header);
+    if (header.from_arena == 0u) {
+        free(header_bytes);
     }
 }
 

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -250,8 +250,12 @@ def validate_jpeg_restart_markers(path):
         raise RuntimeError(f"{path} is missing JPEG RST markers")
 
 
-def encode_jpeg(args, fmt, jpeg_input, bitstream):
-    result = run_capture([args.jpeg_encoder, "--format", fmt, str(jpeg_input), str(bitstream)])
+def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None):
+    command = [args.jpeg_encoder]
+    if extra_args:
+        command.extend(extra_args)
+    command.extend(["--format", fmt, str(jpeg_input), str(bitstream)])
+    result = run_capture(command)
     if "jpeg current allocation bytes: 0" not in result.stdout:
         raise RuntimeError(f"JPEG encoder did not release tracked allocations: {result.stdout!r}")
     if "jpeg work arena bytes:" not in result.stdout:
@@ -381,6 +385,10 @@ def main():
                 str(jpeg_input),
                 str(workdir / "output_jpeg_arena_too_small.h264"),
             ], stderr_contains="buffer too small")
+            offset_arena_output = workdir / "output_jpeg_arena_offset_i420.h264"
+            encode_jpeg(args, "i420", jpeg_input, offset_arena_output,
+                        ["--test-arena-offset", "1"])
+            validate_bitstream(args.ffprobe, args.ffmpeg, offset_arena_output)
         streaming_output = workdir / f"output_jpeg_streaming_{pix_fmt}_i420.h264"
         encode_jpeg_streaming_prototype(args, jpeg_input, streaming_output)
         validate_bitstream(args.ffprobe, args.ffmpeg, streaming_output)

--- a/tools/sh264e_encode_jpeg.c
+++ b/tools/sh264e_encode_jpeg.c
@@ -19,7 +19,7 @@ static void usage(const char *argv0)
 {
     fprintf(stderr,
             "usage: %s [--streaming-prototype] [--test-allocation-limit BYTES] "
-            "[--test-arena-shrink BYTES] "
+            "[--test-arena-shrink BYTES] [--test-arena-offset BYTES] "
             "--format i420|nv12 input.jpg output.h264\n",
             argv0);
 }
@@ -110,6 +110,7 @@ int main(int argc, char **argv)
     sh264e_encoder_t *encoder = NULL;
     sh264e_status_t status;
     uint8_t *jpeg_data = NULL;
+    uint8_t *jpeg_arena_alloc = NULL;
     uint8_t *jpeg_arena = NULL;
     uint8_t *work = NULL;
     uint8_t *output_buf = NULL;
@@ -122,6 +123,7 @@ int main(int argc, char **argv)
     size_t output_size = 0;
     size_t allocation_limit = (size_t)-1;
     size_t arena_shrink = 0;
+    size_t arena_offset = 0;
     int streaming_prototype = 0;
     int argi = 1;
     int rc = 1;
@@ -138,6 +140,12 @@ int main(int argc, char **argv)
             argi += 2;
         } else if (argi + 1 < argc && strcmp(argv[argi], "--test-arena-shrink") == 0) {
             if (!parse_size(argv[argi + 1], &arena_shrink)) {
+                usage(argv[0]);
+                return 2;
+            }
+            argi += 2;
+        } else if (argi + 1 < argc && strcmp(argv[argi], "--test-arena-offset") == 0) {
+            if (!parse_size(argv[argi + 1], &arena_offset)) {
                 usage(argv[0]);
                 return 2;
             }
@@ -159,7 +167,8 @@ int main(int argc, char **argv)
         fprintf(stderr, "failed to read JPEG input: %s\n", input_path);
         goto done;
     }
-    if (streaming_prototype && (allocation_limit != (size_t)-1 || arena_shrink != 0u)) {
+    if (streaming_prototype &&
+        (allocation_limit != (size_t)-1 || arena_shrink != 0u || arena_offset != 0u)) {
         fprintf(stderr, "--streaming-prototype cannot be combined with allocation test options\n");
         goto done;
     }
@@ -175,8 +184,8 @@ int main(int argc, char **argv)
         } else {
             jpeg_arena_size -= arena_shrink;
         }
-    } else if (arena_shrink != 0u) {
-        fprintf(stderr, "--test-arena-shrink cannot be combined with --test-allocation-limit\n");
+    } else if (arena_shrink != 0u || arena_offset != 0u) {
+        fprintf(stderr, "arena test options cannot be combined with --test-allocation-limit\n");
         goto done;
     }
 
@@ -198,11 +207,19 @@ int main(int argc, char **argv)
     }
 
     if (allocation_limit == (size_t)-1 && !streaming_prototype) {
-        jpeg_arena = (uint8_t *)malloc(jpeg_arena_size);
-        if (jpeg_arena == NULL) {
+        size_t jpeg_arena_alloc_size = jpeg_arena_size;
+
+        if (arena_offset > ((size_t)-1) - jpeg_arena_alloc_size) {
+            fprintf(stderr, "JPEG arena allocation size overflow\n");
+            goto done;
+        }
+        jpeg_arena_alloc_size += arena_offset;
+        jpeg_arena_alloc = (uint8_t *)malloc(jpeg_arena_alloc_size);
+        if (jpeg_arena_alloc == NULL) {
             fprintf(stderr, "failed to allocate JPEG arena\n");
             goto done;
         }
+        jpeg_arena = jpeg_arena_alloc + arena_offset;
     }
     work = (uint8_t *)malloc(work_size);
     output_buf = (uint8_t *)malloc(output_capacity);
@@ -272,7 +289,7 @@ done:
     sh264e_encoder_destroy(encoder);
     free(output_buf);
     free(work);
-    free(jpeg_arena);
+    free(jpeg_arena_alloc);
     free(jpeg_data);
     return rc;
 }


### PR DESCRIPTION
## Summary

- store JPEG arena allocation metadata with byte-wise copies instead of typed unaligned header stores
- keep `sh264e_jpeg_get_work_size` as the exact-size arena contract used by existing callers
- add a hidden JPEG tool test hook that offsets the caller arena pointer by one byte
- extend ffmpeg integration coverage to encode through that misaligned-arena path

Refs #4

## Validation

- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build -R sh264e_ffmpeg_integration --output-on-failure`
- `ctest --test-dir build --output-on-failure`
- `cmake -S . -B build-alignsan -DCMAKE_C_FLAGS='-fsanitize=alignment -fno-sanitize-recover=alignment'`
- `cmake --build build-alignsan`
- `build-alignsan/sh264e_encode_jpeg --test-arena-offset 1 --format i420 build/integration/input_720p_yuvj420p.jpg /tmp/arena-offset-alignsan.h264`

QEMU note: this environment still skips QEMU firmware tests because `arm-none-eabi-gcc` cannot compile `<stdlib.h>`, which is the expected CMake probe behavior.
