### PR TITLE
jpeg: expand streaming prototype matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Encode a baseline JPEG memory-input path through the library wrapper:
 
 The JPEG path uses NanoJPEG inside the core library. The tool only reads the JPEG file; the library API accepts a caller-provided JPEG byte buffer and emits H.264 into a caller-provided output buffer.
 The tool sizes a caller-provided JPEG decoder arena with `sh264e_jpeg_get_work_size`, passes that arena to `sh264e_encode_jpeg_idr_with_arena`, and prints the arena requirement plus current and peak NanoJPEG allocation bytes reported by `sh264e_jpeg_get_last_allocation_stats`. The allocation stats cover decoded JPEG component planes and exclude caller-owned input, arena overhead, slice-work, and H.264 output buffers.
-The hidden `--streaming-prototype` flag exercises the experimental MCU-row streaming path for 1280x720 4:2:0, 4:2:2, and 4:4:4 JPEG inputs to I420 output without making it the default encoder path.
+The hidden `--streaming-prototype` flag exercises the experimental MCU-row streaming path across the supported JPEG source-size range for grayscale and YCbCr inputs, with I420 and NV12 output. The tool sizes and passes a caller-provided streaming arena for both NanoJPEG's one-MCU-row decode buffers and the retained row cache. This path remains opt-in; the component-plane arena path is still the production/default JPEG encoder path.
 
 For Cortex-M validation, CMake builds QEMU smoke firmware for M3/M4/M7 when the ARM bare-metal toolchain and QEMU are available. CMake first probes whether `arm-none-eabi-gcc` can compile the library's standard-header usage; if the toolchain is only partially installed, QEMU firmware tests are skipped instead of breaking the host build.
 

--- a/SPACE_REDUCTION.md
+++ b/SPACE_REDUCTION.md
@@ -235,10 +235,12 @@ JPEG bitstream
 ```
 
 This is a larger decoder refactor and should not replace the component-plane
-path until a narrow prototype is validated. The first slice should keep the
-current baseline JPEG scope, decode one MCU row at a time into component row
-rings, and feed the existing progressive H.264 slice encoder when enough source
-rows are available for the next 16-row luma output slice.
+path until the hidden prototype has passed the public JPEG matrix. The current
+prototype decodes one MCU row at a time into component row rings, feeds the
+existing progressive H.264 slice encoder when enough source rows are available
+for the next output slice, and uses the same caller-provided JPEG arena policy
+as the component-plane path for both NanoJPEG's one-MCU-row buffers and the
+retained row cache.
 
 ### Expected Benefit
 
@@ -259,27 +261,30 @@ Approximate component-cache targets from the design note:
 | 1280x720 4:2:0 | 1,382,400 | 61,440 |
 | 1280x720 4:2:2 | 1,843,200 | 81,920 |
 | 1280x720 4:4:4 | 2,764,800 | 122,880 |
-| 5120x2880 4:2:0 | not yet measured | 368,640 |
-| 5120x2880 4:4:4 | not yet measured | 614,400 |
+| 2560x1440 4:2:0 | 5,529,600 | 184,320 |
+| 5120x2880 4:2:0 | not yet measured | 491,520 |
+| 5120x2880 4:4:4 | not yet measured | 819,200 |
 
 These estimates exclude caller-owned JPEG input, the existing 61,440-byte
-encoder slice work buffer, and the H.264 output buffer.
+encoder slice work buffer, and the H.264 output buffer. The streaming cache
+adds one MCU-row margin beyond the maximum fixed-point source window so slices
+at row-window boundaries can still sample the previous row.
 
-### First Prototype Boundary
+### Current Prototype Boundary
 
 * Keep the public API unchanged until the internal row-window contract is proven.
-* Support baseline sequential grayscale or three-component YCbCr JPEGs.
+* Support baseline sequential grayscale or three-component YCbCr JPEGs within
+  the public JPEG source-size policy.
 * Reject progressive/lossless JPEG, arithmetic coding, CMYK/other color spaces,
   non-power-of-two sampling, and non-interleaved multi-scan JPEGs.
 * Preserve restart marker handling by resetting DC predictors and bitstream
   state at the same MCU intervals as the current full-plane path.
-* Validate 1280x720 4:2:0, 4:2:2, and 4:4:4 fixtures with
-  `sh264e_encode_jpeg --streaming-prototype`, including a `cjpeg`-generated
-  DRI/RST restart-marker fixture when `cjpeg` is available, then expand to
-  grayscale before making it the default JPEG path.
-* Keep the row-window bridge hidden for this prototype. Promotion to the
-  production/default JPEG path should wait for dynamic source-size cache sizing,
-  caller-provided arena integration, NV12 output, and grayscale coverage.
+* Validate 1280x720 4:2:0, 4:2:2, and 4:4:4 fixtures, 2560x1440 4:2:0,
+  grayscale, I420 and NV12 output, and a `cjpeg`-generated DRI/RST
+  restart-marker fixture when `cjpeg` is available.
+* Keep the row-window bridge hidden and opt-in for now. The production/default
+  JPEG path remains the component-plane arena path until the streaming path is
+  exposed through a public policy rather than a tool-only flag.
 
 ### Risks
 

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -99,31 +99,22 @@ typedef sh264e_status_t (*sh264e_jpeg_row_ready_fn)(
 
 The first production API does not need to expose this callback publicly. The
 current prototype keeps it internal and exercises it through
-`sh264e_encode_jpeg --streaming-prototype` for 1280x720 4:2:0, 4:2:2, and
-4:4:4 YCbCr inputs to I420 output. A public streaming API should wait until
-the prototype proves the row-cache contract across the rest of the supported
-JPEG matrix.
+`sh264e_encode_jpeg --streaming-prototype`. The prototype now covers the
+supported JPEG source-size policy for grayscale and YCbCr inputs, I420 and NV12
+output, and caller-provided arena allocation for the retained row cache.
 
 ## Promotion Decision
 
-The row-window bridge should remain a hidden prototype for issue #5 instead of
-becoming the production default in this PR. The prototype proves the MCU-row
-decode and scaler handoff for the 1280x720 color matrix, including restart
-markers, but it still has production-boundary gaps:
+The row-window bridge should remain hidden and opt-in instead of becoming the
+production default in this issue. The prototype now closes the main
+production-matrix gaps: dynamic cache sizing, caller-provided arena allocation,
+I420 and NV12 output, grayscale coverage, color subsampling coverage, and
+restart-marker coverage.
 
-* The only exposed entry point is the tool-local `--streaming-prototype` path.
-* The prototype output is I420-only and does not cover the public NV12 JPEG
-  output path.
-* The source-size policy is fixed at 1280x720 rather than the existing public
-  JPEG range.
-* Row-cache allocation still uses `malloc` and is not integrated with the
-  caller-provided JPEG arena sizing API.
-* Grayscale handling is intentionally left on the component-plane fallback.
-
-Promotion should happen in a follow-up after the internal row-window contract
-can compute cache size from arbitrary supported dimensions, share the
-caller-provided arena policy, and pass the full public JPEG output matrix. Until
-then, the component-plane arena path remains the production/default JPEG path.
+The default JPEG path still remains the component-plane arena path because it is
+the public API contract today. Streaming should become default only after the
+project decides how to expose the row-window policy outside the tool-local
+`--streaming-prototype` flag.
 
 ## Memory Estimate
 
@@ -145,32 +136,34 @@ height. Approximate component-cache sizes are:
 | 1280x720 4:2:0 | 30,720 | 2 MCU rows | 61,440 |
 | 1280x720 4:2:2 | 40,960 | 2 MCU rows | 81,920 |
 | 1280x720 4:4:4 | 61,440 | 2 MCU rows | 122,880 |
-| 5120x2880 4:2:0 | 122,880 | 3 MCU rows | 368,640 |
-| 5120x2880 4:4:4 | 122,880 | 5 MCU rows | 614,400 |
+| 2560x1440 4:2:0 | 61,440 | dynamic + margin | 184,320 |
+| 5120x2880 4:2:0 | 122,880 | dynamic + margin | 491,520 |
+| 5120x2880 4:4:4 | 122,880 | dynamic + margin | 819,200 |
 
 The exact retained-row count should be computed from the scaler's fixed-point
-source mapping, then rounded up to the JPEG component MCU-row height. These
-figures exclude the existing 61,440-byte encoder slice work buffer and H.264
-output buffer, both of which are already caller-controlled.
+source mapping, rounded up to the JPEG component MCU-row height, and extended by
+one MCU-row margin so slices at row-window boundaries can still sample the
+previous row. These figures exclude the existing 61,440-byte encoder slice work
+buffer and H.264 output buffer, both of which are already caller-controlled.
 
 ## Validation Plan
 
 The prototype adds a tool/test-only path before replacing the default JPEG
 encoder:
 
-* Generate `1280x720` `yuvj420p`, `yuvj422p`, and `yuvj444p` JPEG fixtures
-  with ffmpeg.
-* Encode through the streaming prototype to Annex B H.264.
+* Generate `1280x720` `yuvj420p`, `yuvj422p`, and `yuvj444p` JPEG fixtures,
+  a `2560x1440` `yuvj420p` JPEG fixture, and a grayscale JPEG fixture with
+  ffmpeg.
+* Encode through the streaming prototype to Annex B H.264 for I420 and NV12
+  output where applicable.
 * Decode the H.264 with ffmpeg and verify the same stream metadata as the
   component-plane path.
 * Decode both the streaming and component-plane H.264 outputs to raw `yuv420p`
-  and compare SHA-256 hashes for each I420 fixture.
+  and compare SHA-256 hashes for each covered fixture.
 * Confirm the NanoJPEG allocation peak is below the 1,382,400-byte full
   component-plane allocation for the 4:2:0 fixture and below the corresponding
   full component-plane allocation for 4:2:2 and 4:4:4.
 * When `cjpeg` is available, generate a 4:2:0 fixture with DRI/RST restart
   markers and run the same streaming-vs-component decoded-frame comparison.
-* Keep the component-plane arena path as the production fallback; the issue #5
-  decision is to leave the row-window bridge hidden until a follow-up promotes
-  it with arena sizing, dynamic source dimensions, NV12 output, and grayscale
-  coverage.
+* Keep the component-plane arena path as the production/default path while the
+  row-window bridge remains hidden behind the streaming prototype flag.

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -79,6 +79,7 @@ typedef struct sh264e_jpeg_stream_component_t {
     uint32_t height;
     uint32_t row0;
     uint32_t rows;
+    uint32_t cache_rows;
     uint32_t rows_per_mcu;
     ptrdiff_t stride;
 } sh264e_jpeg_stream_component_t;
@@ -92,6 +93,8 @@ typedef struct sh264e_jpeg_stream_context_t {
     size_t cache_bytes;
     unsigned next_slice;
     unsigned idr_started;
+    int component_count;
+    int measure_only;
     int initialized;
     sh264e_status_t status;
     sh264e_jpeg_stream_component_t components[3];
@@ -784,6 +787,32 @@ static void streaming_scale_component_slice(const sh264e_jpeg_stream_component_t
     }
 }
 
+static void streaming_scale_nv12_component_chroma_slice(const sh264e_jpeg_stream_component_t *cb,
+                                                        const sh264e_jpeg_stream_component_t *cr,
+                                                        uint8_t *dst_uv,
+                                                        uint32_t dst_y_start)
+{
+    sh264e_axis_mapper_t y_mapper = scale_axis_mapper_init(cb->height,
+                                                           SH264E_V1_HEIGHT / 2u,
+                                                           dst_y_start);
+    uint32_t y;
+
+    for (y = 0; y < SH264E_V1_SLICE_CHROMA_HEIGHT; y++) {
+        uint8_t *row = dst_uv + (size_t)y * SH264E_V1_WIDTH;
+        const sh264e_scale_coord_t sy = scale_coord_from_raw(y_mapper.pos, cb->height);
+        sh264e_axis_mapper_t x_mapper = scale_axis_mapper_init(cb->width, SH264E_CHROMA_WIDTH, 0u);
+        uint32_t x;
+
+        for (x = 0; x < SH264E_CHROMA_WIDTH; x++) {
+            const sh264e_scale_coord_t sx = scale_coord_from_raw(x_mapper.pos, cb->width);
+            row[(size_t)x * 2u] = streaming_bilinear_sample_plane(cb, sx, sy);
+            row[(size_t)x * 2u + 1u] = streaming_bilinear_sample_plane(cr, sx, sy);
+            scale_axis_mapper_advance(&x_mapper);
+        }
+        scale_axis_mapper_advance(&y_mapper);
+    }
+}
+
 static void streaming_source_range(uint32_t src_height,
                                    uint32_t dst_height,
                                    uint32_t dst_y_start,
@@ -811,6 +840,32 @@ static void streaming_source_range(uint32_t src_height,
     *out_max_y = max_y;
 }
 
+static uint32_t streaming_cache_rows_for_slice_window(uint32_t src_height,
+                                                      uint32_t dst_height,
+                                                      uint32_t dst_rows,
+                                                      uint32_t rows_per_mcu)
+{
+    uint32_t max_rows = rows_per_mcu;
+    uint32_t slice_y;
+
+    for (slice_y = 0u; slice_y < dst_height; slice_y += dst_rows) {
+        uint32_t min_y;
+        uint32_t max_y;
+        uint32_t rows;
+
+        streaming_source_range(src_height, dst_height, slice_y, dst_rows, &min_y, &max_y);
+        rows = max_y - min_y + 1u;
+        if (rows > max_rows) {
+            max_rows = rows;
+        }
+    }
+
+    if ((max_rows % rows_per_mcu) != 0u) {
+        max_rows += rows_per_mcu - (max_rows % rows_per_mcu);
+    }
+    return max_rows + rows_per_mcu;
+}
+
 static int streaming_slice_available(const sh264e_jpeg_stream_context_t *ctx, unsigned slice_index)
 {
     uint32_t min_y;
@@ -828,7 +883,7 @@ static int streaming_slice_available(const sh264e_jpeg_stream_context_t *ctx, un
         return 0;
     }
 
-    for (i = 1u; i < 3u; i++) {
+    for (i = 1u; i < (unsigned)ctx->component_count; i++) {
         streaming_source_range(ctx->components[i].height,
                                SH264E_V1_HEIGHT / 2u,
                                slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT,
@@ -856,16 +911,20 @@ static void streaming_make_i420_slice(const sh264e_jpeg_stream_context_t *ctx,
                                     slice_index * SH264E_V1_SLICE_LUMA_HEIGHT,
                                     SH264E_V1_SLICE_LUMA_HEIGHT,
                                     SH264E_V1_WIDTH);
-    streaming_scale_component_slice(&ctx->components[1], dst_u,
-                                    SH264E_CHROMA_WIDTH, SH264E_V1_HEIGHT / 2u,
-                                    slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT,
-                                    SH264E_V1_SLICE_CHROMA_HEIGHT,
-                                    SH264E_CHROMA_WIDTH);
-    streaming_scale_component_slice(&ctx->components[2], dst_v,
-                                    SH264E_CHROMA_WIDTH, SH264E_V1_HEIGHT / 2u,
-                                    slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT,
-                                    SH264E_V1_SLICE_CHROMA_HEIGHT,
-                                    SH264E_CHROMA_WIDTH);
+    if (ctx->component_count == 1) {
+        jpeg_fill_i420_neutral_chroma(dst_u, dst_v);
+    } else {
+        streaming_scale_component_slice(&ctx->components[1], dst_u,
+                                        SH264E_CHROMA_WIDTH, SH264E_V1_HEIGHT / 2u,
+                                        slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                        SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                        SH264E_CHROMA_WIDTH);
+        streaming_scale_component_slice(&ctx->components[2], dst_v,
+                                        SH264E_CHROMA_WIDTH, SH264E_V1_HEIGHT / 2u,
+                                        slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                        SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                        SH264E_CHROMA_WIDTH);
+    }
 
     memset(slice, 0, sizeof(*slice));
     slice->pixfmt = SH264E_PIXFMT_I420;
@@ -877,12 +936,40 @@ static void streaming_make_i420_slice(const sh264e_jpeg_stream_context_t *ctx,
     slice->stride[2] = SH264E_CHROMA_WIDTH;
 }
 
+static void streaming_make_nv12_slice(const sh264e_jpeg_stream_context_t *ctx,
+                                      unsigned slice_index,
+                                      sh264e_slice_t *slice)
+{
+    uint8_t *dst_y = ctx->work_buffer;
+    uint8_t *dst_uv = dst_y + (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_LUMA_HEIGHT;
+
+    streaming_scale_component_slice(&ctx->components[0], dst_y,
+                                    SH264E_V1_WIDTH, SH264E_V1_HEIGHT,
+                                    slice_index * SH264E_V1_SLICE_LUMA_HEIGHT,
+                                    SH264E_V1_SLICE_LUMA_HEIGHT,
+                                    SH264E_V1_WIDTH);
+    if (ctx->component_count == 1) {
+        jpeg_fill_nv12_neutral_chroma(dst_uv);
+    } else {
+        streaming_scale_nv12_component_chroma_slice(&ctx->components[1], &ctx->components[2],
+                                                    dst_uv,
+                                                    slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT);
+    }
+
+    memset(slice, 0, sizeof(*slice));
+    slice->pixfmt = SH264E_PIXFMT_NV12;
+    slice->plane[0] = dst_y;
+    slice->plane[1] = dst_uv;
+    slice->stride[0] = SH264E_V1_WIDTH;
+    slice->stride[1] = SH264E_V1_WIDTH;
+}
+
 static void streaming_free_cache(sh264e_jpeg_stream_context_t *ctx)
 {
     unsigned i;
 
     for (i = 0u; i < 3u; i++) {
-        free(ctx->components[i].pixels);
+        njFreeMem(ctx->components[i].pixels);
         ctx->components[i].pixels = NULL;
     }
     ctx->initialized = 0;
@@ -891,28 +978,38 @@ static void streaming_free_cache(sh264e_jpeg_stream_context_t *ctx)
 static sh264e_status_t streaming_init_cache(sh264e_jpeg_stream_context_t *ctx)
 {
     const int component_count = njGetComponentCount();
+    const int image_width = njGetWidth();
+    const int image_height = njGetHeight();
     const int y_width = njGetComponentWidth(0);
     const int y_height = njGetComponentHeight(0);
-    const int cb_width = njGetComponentWidth(1);
-    const int cb_height = njGetComponentHeight(1);
-    const int cr_width = njGetComponentWidth(2);
-    const int cr_height = njGetComponentHeight(2);
     unsigned i;
 
-    if (component_count != 3 || njGetWidth() != 1280 || njGetHeight() != 720) {
+    if (component_count != 1 && component_count != 3) {
         return SH264E_ERR_UNSUPPORTED_CONFIG;
     }
-    if (y_width != 1280 || y_height != 720 ||
-        cb_width != cr_width || cb_height != cr_height) {
+    if (image_width < (int)SH264E_RESIZE_MIN_SRC_WIDTH ||
+        image_width > (int)SH264E_RESIZE_MAX_SRC_WIDTH ||
+        image_height < (int)SH264E_RESIZE_MIN_SRC_HEIGHT ||
+        image_height > (int)SH264E_RESIZE_MAX_SRC_HEIGHT ||
+        (image_width & 1) != 0 ||
+        (image_height & 1) != 0) {
         return SH264E_ERR_UNSUPPORTED_CONFIG;
     }
-    if (!((cb_width == 640 && cb_height == 360) ||
-          (cb_width == 640 && cb_height == 720) ||
-          (cb_width == 1280 && cb_height == 720))) {
+    if (y_width != image_width || y_height != image_height) {
         return SH264E_ERR_UNSUPPORTED_CONFIG;
     }
+    if (component_count == 3) {
+        const int cb_width = njGetComponentWidth(1);
+        const int cb_height = njGetComponentHeight(1);
+        const int cr_width = njGetComponentWidth(2);
+        const int cr_height = njGetComponentHeight(2);
+        if (cb_width != cr_width || cb_height != cr_height) {
+            return SH264E_ERR_UNSUPPORTED_CONFIG;
+        }
+    }
+    ctx->component_count = component_count;
 
-    for (i = 0u; i < 3u; i++) {
+    for (i = 0u; i < (unsigned)component_count; i++) {
         sh264e_jpeg_stream_component_t *component = &ctx->components[i];
         const int width = njGetComponentWidth((int)i);
         const int height = njGetComponentHeight((int)i);
@@ -929,8 +1026,17 @@ static sh264e_status_t streaming_init_cache(sh264e_jpeg_stream_context_t *ctx)
         component->rows_per_mcu = (uint32_t)rows_per_mcu;
         component->row0 = 0u;
         component->rows = 0u;
-        bytes = (size_t)stride * (size_t)rows_per_mcu * 2u;
-        component->pixels = (uint8_t *)malloc(bytes);
+        component->cache_rows = streaming_cache_rows_for_slice_window(
+            component->height,
+            i == 0u ? SH264E_V1_HEIGHT : SH264E_V1_HEIGHT / 2u,
+            i == 0u ? SH264E_V1_SLICE_LUMA_HEIGHT : SH264E_V1_SLICE_CHROMA_HEIGHT,
+            component->rows_per_mcu);
+        bytes = (size_t)stride * (size_t)component->cache_rows;
+        if (bytes > (size_t)INT_MAX) {
+            streaming_free_cache(ctx);
+            return SH264E_ERR_UNSUPPORTED_CONFIG;
+        }
+        component->pixels = (uint8_t *)njAllocMem((int)bytes);
         if (component->pixels == NULL) {
             streaming_free_cache(ctx);
             return SH264E_ERR_ALLOCATION_FAILED;
@@ -941,39 +1047,47 @@ static sh264e_status_t streaming_init_cache(sh264e_jpeg_stream_context_t *ctx)
     return SH264E_OK;
 }
 
-static void streaming_copy_current_mcu_row(sh264e_jpeg_stream_context_t *ctx, int mcu_y)
+static sh264e_status_t streaming_copy_current_mcu_row(sh264e_jpeg_stream_context_t *ctx, int mcu_y)
 {
     unsigned i;
 
-    for (i = 0u; i < 3u; i++) {
+    for (i = 0u; i < (unsigned)ctx->component_count; i++) {
         sh264e_jpeg_stream_component_t *component = &ctx->components[i];
         const uint8_t *src = njGetComponentPixels((int)i);
-        const size_t row_bytes = (size_t)component->stride * component->rows_per_mcu;
         const uint32_t new_row0 = (uint32_t)mcu_y * component->rows_per_mcu;
+        uint32_t rows_to_copy = component->rows_per_mcu;
 
-        if (mcu_y == 0) {
-            memcpy(component->pixels, src, row_bytes);
-            component->row0 = 0u;
-            component->rows = component->rows_per_mcu;
-        } else if (mcu_y == 1) {
-            memcpy(component->pixels + row_bytes, src, row_bytes);
-            component->row0 = 0u;
-            component->rows = component->rows_per_mcu * 2u;
-            if (component->rows > component->height) {
-                component->rows = component->height;
-            }
-        } else {
-            memmove(component->pixels,
-                    component->pixels + row_bytes,
-                    row_bytes);
-            memcpy(component->pixels + row_bytes, src, row_bytes);
-            component->row0 = new_row0 - component->rows_per_mcu;
-            component->rows = component->rows_per_mcu * 2u;
-            if (component->row0 + component->rows > component->height) {
-                component->rows = component->height - component->row0;
-            }
+        if (src == NULL || component->pixels == NULL || component->cache_rows < component->rows_per_mcu) {
+            return SH264E_ERR_INTERNAL;
         }
+        if (new_row0 >= component->height) {
+            continue;
+        }
+        if (new_row0 + rows_to_copy > component->height) {
+            rows_to_copy = component->height - new_row0;
+        }
+        if (component->rows != 0u && component->row0 + component->rows != new_row0) {
+            return SH264E_ERR_INTERNAL;
+        }
+        while (component->rows + rows_to_copy > component->cache_rows) {
+            const uint32_t drop_rows = component->rows < component->rows_per_mcu
+                                           ? component->rows
+                                           : component->rows_per_mcu;
+            if (drop_rows == 0u || drop_rows > component->rows) {
+                return SH264E_ERR_INTERNAL;
+            }
+            memmove(component->pixels,
+                    component->pixels + (size_t)drop_rows * (size_t)component->stride,
+                    (size_t)(component->rows - drop_rows) * (size_t)component->stride);
+            component->row0 += drop_rows;
+            component->rows -= drop_rows;
+        }
+        memcpy(component->pixels + (size_t)component->rows * (size_t)component->stride,
+               src,
+               (size_t)rows_to_copy * (size_t)component->stride);
+        component->rows += rows_to_copy;
     }
+    return SH264E_OK;
 }
 
 static int streaming_mcu_row_ready(int mcu_y, void *user)
@@ -990,7 +1104,13 @@ static int streaming_mcu_row_ready(int mcu_y, void *user)
         }
     }
 
-    streaming_copy_current_mcu_row(ctx, mcu_y);
+    ctx->status = streaming_copy_current_mcu_row(ctx, mcu_y);
+    if (ctx->status != SH264E_OK) {
+        return 1;
+    }
+    if (ctx->measure_only) {
+        return 0;
+    }
     if (!ctx->idr_started) {
         size_t bytes = 0u;
         ctx->status = sh264e_begin_idr(ctx->encoder, ctx->out, ctx->out_capacity, &bytes);
@@ -1006,7 +1126,11 @@ static int streaming_mcu_row_ready(int mcu_y, void *user)
         sh264e_slice_t slice;
         size_t bytes = 0u;
 
-        streaming_make_i420_slice(ctx, ctx->next_slice, &slice);
+        if (ctx->encoder->config.pixfmt == SH264E_PIXFMT_I420) {
+            streaming_make_i420_slice(ctx, ctx->next_slice, &slice);
+        } else {
+            streaming_make_nv12_slice(ctx, ctx->next_slice, &slice);
+        }
         ctx->status = sh264e_encode_idr_slice(ctx->encoder, &slice,
                                               ctx->out + ctx->offset,
                                               ctx->out_capacity - ctx->offset,
@@ -2103,14 +2227,54 @@ size_t sh264e_jpeg_get_last_streaming_cache_bytes(void)
     return sh264e_jpeg_streaming_last_cache_bytes;
 }
 
-sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype(sh264e_encoder_t *encoder,
-                                                           const uint8_t *jpeg_data,
-                                                           size_t jpeg_size,
-                                                           uint8_t *work_buffer,
-                                                           size_t work_buffer_capacity,
-                                                           uint8_t *out,
-                                                           size_t out_capacity,
-                                                           size_t *out_size)
+sh264e_status_t sh264e_jpeg_get_streaming_work_size(const uint8_t *jpeg_data,
+                                                    size_t jpeg_size,
+                                                    size_t *out_size)
+{
+    sh264e_jpeg_stream_context_t ctx;
+    sh264e_status_t status;
+
+    if (jpeg_data == NULL || out_size == NULL) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+    *out_size = 0u;
+    sh264e_jpeg_streaming_last_cache_bytes = 0u;
+    if (jpeg_size == 0u || jpeg_size > (size_t)INT_MAX) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.measure_only = 1;
+    ctx.status = SH264E_OK;
+
+    jpeg_allocation_begin_heap();
+    njInit();
+    status = map_jpeg_result(njDecodeMcuRows(jpeg_data, (int)jpeg_size,
+                                             streaming_mcu_row_ready, &ctx));
+    if (ctx.status != SH264E_OK) {
+        status = ctx.status;
+    }
+    if (status == SH264E_OK) {
+        *out_size = sh264e_jpeg_alloc_peak_arena_bytes;
+    }
+    sh264e_jpeg_streaming_last_cache_bytes = ctx.cache_bytes;
+    streaming_free_cache(&ctx);
+    njDone();
+    jpeg_allocation_end();
+    return status;
+}
+
+static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *encoder,
+                                                             const uint8_t *jpeg_data,
+                                                             size_t jpeg_size,
+                                                             uint8_t *jpeg_arena,
+                                                             size_t jpeg_arena_size,
+                                                             int use_arena,
+                                                             uint8_t *work_buffer,
+                                                             size_t work_buffer_capacity,
+                                                             uint8_t *out,
+                                                             size_t out_capacity,
+                                                             size_t *out_size)
 {
     sh264e_jpeg_stream_context_t ctx;
     sh264e_status_t status;
@@ -2125,10 +2289,10 @@ sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype(sh264e_encoder_t *enc
     if (encoder->idr_active != 0u) {
         return SH264E_ERR_BAD_STATE;
     }
-    if (encoder->config.pixfmt != SH264E_PIXFMT_I420) {
-        return SH264E_ERR_UNSUPPORTED_CONFIG;
-    }
     if (jpeg_size == 0u || jpeg_size > (size_t)INT_MAX) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+    if (use_arena != 0 && (jpeg_arena == NULL || jpeg_arena_size == 0u)) {
         return SH264E_ERR_INVALID_ARGUMENT;
     }
     status = sh264e_jpeg_get_slice_buffer_size(&required_work);
@@ -2146,7 +2310,12 @@ sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype(sh264e_encoder_t *enc
     ctx.out_capacity = out_capacity;
     ctx.status = SH264E_OK;
 
-    jpeg_allocation_stats_reset();
+    if (use_arena != 0) {
+        jpeg_allocation_begin_arena(jpeg_arena, jpeg_arena_size);
+    } else {
+        jpeg_allocation_begin_heap();
+    }
+    njInit();
     status = map_jpeg_result(njDecodeMcuRows(jpeg_data, (int)jpeg_size,
                                              streaming_mcu_row_ready, &ctx));
     if (ctx.status != SH264E_OK) {
@@ -2166,10 +2335,43 @@ sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype(sh264e_encoder_t *enc
     if (status != SH264E_OK) {
         reset_progressive_state(encoder);
     }
-    njDone();
     sh264e_jpeg_streaming_last_cache_bytes = ctx.cache_bytes;
     streaming_free_cache(&ctx);
+    njDone();
+    jpeg_allocation_end();
     return status;
+}
+
+sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype(sh264e_encoder_t *encoder,
+                                                           const uint8_t *jpeg_data,
+                                                           size_t jpeg_size,
+                                                           uint8_t *work_buffer,
+                                                           size_t work_buffer_capacity,
+                                                           uint8_t *out,
+                                                           size_t out_capacity,
+                                                           size_t *out_size)
+{
+    return sh264e_encode_jpeg_idr_streaming_impl(encoder, jpeg_data, jpeg_size,
+                                                 NULL, 0u, 0,
+                                                 work_buffer, work_buffer_capacity,
+                                                 out, out_capacity, out_size);
+}
+
+sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype_with_arena(sh264e_encoder_t *encoder,
+                                                                      const uint8_t *jpeg_data,
+                                                                      size_t jpeg_size,
+                                                                      uint8_t *jpeg_arena,
+                                                                      size_t jpeg_arena_size,
+                                                                      uint8_t *work_buffer,
+                                                                      size_t work_buffer_capacity,
+                                                                      uint8_t *out,
+                                                                      size_t out_capacity,
+                                                                      size_t *out_size)
+{
+    return sh264e_encode_jpeg_idr_streaming_impl(encoder, jpeg_data, jpeg_size,
+                                                 jpeg_arena, jpeg_arena_size, 1,
+                                                 work_buffer, work_buffer_capacity,
+                                                 out, out_capacity, out_size);
 }
 
 sh264e_status_t sh264e_encoder_create(const sh264e_config_t *config,

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -8,6 +8,8 @@ WIDTH = 2560
 HEIGHT = 1440
 SMALL_WIDTH = 1280
 SMALL_HEIGHT = 720
+LARGE_WIDTH = 2560
+LARGE_HEIGHT = 1440
 
 
 def run(cmd):
@@ -189,14 +191,14 @@ def run_case(args, fmt, make_input):
     validate_bitstream(args.ffprobe, args.ffmpeg, bitstream)
 
 
-def make_color_jpeg(args, path, pix_fmt):
+def make_color_jpeg_sized(args, path, pix_fmt, width, height):
     run([
         args.ffmpeg,
         "-y",
         "-f",
         "lavfi",
         "-i",
-        f"testsrc2=size={SMALL_WIDTH}x{SMALL_HEIGHT}:rate=1",
+        f"testsrc2=size={width}x{height}:rate=1",
         "-frames:v",
         "1",
         "-pix_fmt",
@@ -206,6 +208,10 @@ def make_color_jpeg(args, path, pix_fmt):
         str(path),
     ])
     validate_image_pix_fmt(args.ffprobe, path, pix_fmt)
+
+
+def make_color_jpeg(args, path, pix_fmt):
+    make_color_jpeg_sized(args, path, pix_fmt, SMALL_WIDTH, SMALL_HEIGHT)
 
 
 def make_restart_marker_jpeg(args, path):
@@ -268,12 +274,12 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None):
     raise RuntimeError(f"JPEG encoder did not report peak allocation bytes: {result.stdout!r}")
 
 
-def encode_jpeg_streaming_prototype(args, jpeg_input, bitstream):
+def encode_jpeg_streaming_prototype(args, fmt, jpeg_input, bitstream):
     result = run_capture([
         args.jpeg_encoder,
         "--streaming-prototype",
         "--format",
-        "i420",
+        fmt,
         str(jpeg_input),
         str(bitstream),
     ])
@@ -281,11 +287,16 @@ def encode_jpeg_streaming_prototype(args, jpeg_input, bitstream):
         raise RuntimeError(f"streaming JPEG prototype leaked tracked allocations: {result.stdout!r}")
     peak = None
     cache = None
+    work = None
     for line in result.stdout.splitlines():
+        if line.startswith("jpeg work arena bytes:"):
+            work = int(line.rsplit(" ", 1)[1])
         if line.startswith("jpeg peak allocation bytes:"):
             peak = int(line.rsplit(" ", 1)[1])
         if line.startswith("jpeg streaming cache bytes:"):
             cache = int(line.rsplit(" ", 1)[1])
+    if work is None or work == 0:
+        raise RuntimeError(f"streaming JPEG prototype did not report arena work size: {result.stdout!r}")
     if peak is None or peak >= 1382400:
         raise RuntimeError(f"streaming JPEG prototype did not reduce NanoJPEG allocation peak: {result.stdout!r}")
     if cache is None or cache == 0:
@@ -389,23 +400,32 @@ def main():
             encode_jpeg(args, "i420", jpeg_input, offset_arena_output,
                         ["--test-arena-offset", "1"])
             validate_bitstream(args.ffprobe, args.ffmpeg, offset_arena_output)
-        streaming_output = workdir / f"output_jpeg_streaming_{pix_fmt}_i420.h264"
-        encode_jpeg_streaming_prototype(args, jpeg_input, streaming_output)
-        validate_bitstream(args.ffprobe, args.ffmpeg, streaming_output)
         for fmt in ("i420", "nv12"):
             jpeg_output = workdir / f"output_jpeg_{pix_fmt}_{fmt}.h264"
+            streaming_output = workdir / f"output_jpeg_streaming_{pix_fmt}_{fmt}.h264"
             encode_jpeg(args, fmt, jpeg_input, jpeg_output)
+            encode_jpeg_streaming_prototype(args, fmt, jpeg_input, streaming_output)
             validate_bitstream(args.ffprobe, args.ffmpeg, jpeg_output)
-            if fmt == "i420":
-                compare_decoded_i420(args, jpeg_output, streaming_output,
-                                     f"output_jpeg_{pix_fmt}_i420_streaming_compare")
+            validate_bitstream(args.ffprobe, args.ffmpeg, streaming_output)
+            compare_decoded_i420(args, jpeg_output, streaming_output,
+                                 f"output_jpeg_{pix_fmt}_{fmt}_streaming_compare")
+
+    large_jpeg_input = workdir / "input_1440p_yuvj420p.jpg"
+    large_jpeg_output = workdir / "output_jpeg_1440p_yuvj420p_i420.h264"
+    large_streaming_output = workdir / "output_jpeg_streaming_1440p_yuvj420p_i420.h264"
+    make_color_jpeg_sized(args, large_jpeg_input, "yuvj420p", LARGE_WIDTH, LARGE_HEIGHT)
+    encode_jpeg(args, "i420", large_jpeg_input, large_jpeg_output)
+    encode_jpeg_streaming_prototype(args, "i420", large_jpeg_input, large_streaming_output)
+    validate_bitstream(args.ffprobe, args.ffmpeg, large_streaming_output)
+    compare_decoded_i420(args, large_jpeg_output, large_streaming_output,
+                         "output_jpeg_1440p_yuvj420p_i420_streaming_compare")
 
     if args.cjpeg:
         restart_jpeg_input = workdir / "input_720p_yuvj420p_restart.jpg"
         make_restart_marker_jpeg(args, restart_jpeg_input)
         restart_streaming_output = workdir / "output_jpeg_streaming_yuvj420p_restart_i420.h264"
         restart_jpeg_output = workdir / "output_jpeg_yuvj420p_restart_i420.h264"
-        encode_jpeg_streaming_prototype(args, restart_jpeg_input, restart_streaming_output)
+        encode_jpeg_streaming_prototype(args, "i420", restart_jpeg_input, restart_streaming_output)
         validate_bitstream(args.ffprobe, args.ffmpeg, restart_streaming_output)
         encode_jpeg(args, "i420", restart_jpeg_input, restart_jpeg_output)
         validate_bitstream(args.ffprobe, args.ffmpeg, restart_jpeg_output)
@@ -434,8 +454,13 @@ def main():
     # color subsampling fixtures assert exact JPEG component layout.
     for fmt in ("i420", "nv12"):
         grayscale_jpeg_output = workdir / f"output_jpeg_gray_{fmt}.h264"
+        grayscale_streaming_output = workdir / f"output_jpeg_streaming_gray_{fmt}.h264"
         encode_jpeg(args, fmt, grayscale_jpeg_input, grayscale_jpeg_output)
+        encode_jpeg_streaming_prototype(args, fmt, grayscale_jpeg_input, grayscale_streaming_output)
         validate_bitstream(args.ffprobe, args.ffmpeg, grayscale_jpeg_output)
+        validate_bitstream(args.ffprobe, args.ffmpeg, grayscale_streaming_output)
+        compare_decoded_i420(args, grayscale_jpeg_output, grayscale_streaming_output,
+                             f"output_jpeg_gray_{fmt}_streaming_compare")
 
 
 if __name__ == "__main__":

--- a/tools/sh264e_encode_jpeg.c
+++ b/tools/sh264e_encode_jpeg.c
@@ -6,6 +6,9 @@
 
 void sh264e_jpeg_set_test_allocation_limit(size_t max_bytes);
 size_t sh264e_jpeg_get_last_streaming_cache_bytes(void);
+sh264e_status_t sh264e_jpeg_get_streaming_work_size(const uint8_t *jpeg_data,
+                                                    size_t jpeg_size,
+                                                    size_t *out_size);
 sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype(sh264e_encoder_t *encoder,
                                                            const uint8_t *jpeg_data,
                                                            size_t jpeg_size,
@@ -14,6 +17,16 @@ sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype(sh264e_encoder_t *enc
                                                            uint8_t *out,
                                                            size_t out_capacity,
                                                            size_t *out_size);
+sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype_with_arena(sh264e_encoder_t *encoder,
+                                                                      const uint8_t *jpeg_data,
+                                                                      size_t jpeg_size,
+                                                                      uint8_t *jpeg_arena,
+                                                                      size_t jpeg_arena_size,
+                                                                      uint8_t *work_buffer,
+                                                                      size_t work_buffer_capacity,
+                                                                      uint8_t *out,
+                                                                      size_t out_capacity,
+                                                                      size_t *out_size);
 
 static void usage(const char *argv0)
 {
@@ -167,15 +180,18 @@ int main(int argc, char **argv)
         fprintf(stderr, "failed to read JPEG input: %s\n", input_path);
         goto done;
     }
-    if (streaming_prototype &&
-        (allocation_limit != (size_t)-1 || arena_shrink != 0u || arena_offset != 0u)) {
-        fprintf(stderr, "--streaming-prototype cannot be combined with allocation test options\n");
+    if (streaming_prototype && allocation_limit != (size_t)-1) {
+        fprintf(stderr, "--streaming-prototype cannot be combined with --test-allocation-limit\n");
         goto done;
     }
-    if (allocation_limit == (size_t)-1 && !streaming_prototype) {
-        status = sh264e_jpeg_get_work_size(jpeg_data, jpeg_size, &jpeg_work_size);
+    if (allocation_limit == (size_t)-1) {
+        if (streaming_prototype) {
+            status = sh264e_jpeg_get_streaming_work_size(jpeg_data, jpeg_size, &jpeg_work_size);
+        } else {
+            status = sh264e_jpeg_get_work_size(jpeg_data, jpeg_size, &jpeg_work_size);
+        }
         if (status != SH264E_OK) {
-            fprintf(stderr, "sh264e_jpeg_get_work_size failed: %s\n", sh264e_status_string(status));
+            fprintf(stderr, "JPEG work-size query failed: %s\n", sh264e_status_string(status));
             goto done;
         }
         jpeg_arena_size = jpeg_work_size;
@@ -206,7 +222,7 @@ int main(int argc, char **argv)
         goto done;
     }
 
-    if (allocation_limit == (size_t)-1 && !streaming_prototype) {
+    if (allocation_limit == (size_t)-1) {
         size_t jpeg_arena_alloc_size = jpeg_arena_size;
 
         if (arena_offset > ((size_t)-1) - jpeg_arena_alloc_size) {
@@ -240,9 +256,11 @@ int main(int argc, char **argv)
                                         work, work_size,
                                         output_buf, output_capacity, &output_size);
     } else if (streaming_prototype) {
-        status = sh264e_encode_jpeg_idr_streaming_prototype(encoder, jpeg_data, jpeg_size,
-                                                            work, work_size,
-                                                            output_buf, output_capacity, &output_size);
+        status = sh264e_encode_jpeg_idr_streaming_prototype_with_arena(
+            encoder, jpeg_data, jpeg_size,
+            jpeg_arena, jpeg_arena_size,
+            work, work_size,
+            output_buf, output_capacity, &output_size);
     } else {
         status = sh264e_encode_jpeg_idr_with_arena(encoder, jpeg_data, jpeg_size,
                                                    jpeg_arena, jpeg_arena_size,


### PR DESCRIPTION
## Summary

- make the hidden MCU-row streaming JPEG path size its row cache dynamically for the public source-size policy
- allocate streaming row-cache buffers through the JPEG arena allocator instead of hidden heap allocation
- add streaming NV12 output and grayscale handling while keeping the component-plane arena path as the default production path
- expand ffmpeg integration coverage for I420/NV12 streaming, grayscale, and a 2560x1440 fixture
- update README and streaming memory notes with the opt-in promotion decision

Refs #15

## Validation

- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build -R sh264e_ffmpeg_integration --output-on-failure`
- `ctest --test-dir build --output-on-failure`

QEMU note: this environment still skips QEMU firmware tests because `arm-none-eabi-gcc` cannot compile `<stdlib.h>`, which is the expected CMake probe behavior.