### PR TITLE
jpeg: fix streaming arena shrink error

### DIFF
--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -1038,8 +1038,11 @@ static sh264e_status_t streaming_init_cache(sh264e_jpeg_stream_context_t *ctx)
         }
         component->pixels = (uint8_t *)njAllocMem((int)bytes);
         if (component->pixels == NULL) {
+            sh264e_status_t status = sh264e_jpeg_alloc_arena_failed != 0u ?
+                                     SH264E_ERR_BUFFER_TOO_SMALL :
+                                     SH264E_ERR_ALLOCATION_FAILED;
             streaming_free_cache(ctx);
-            return SH264E_ERR_ALLOCATION_FAILED;
+            return status;
         }
         ctx->cache_bytes += bytes;
     }

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -396,6 +396,16 @@ def main():
                 str(jpeg_input),
                 str(workdir / "output_jpeg_arena_too_small.h264"),
             ], stderr_contains="buffer too small")
+            run_expect_fail([
+                args.jpeg_encoder,
+                "--streaming-prototype",
+                "--test-arena-shrink",
+                "1",
+                "--format",
+                "i420",
+                str(jpeg_input),
+                str(workdir / "output_jpeg_streaming_arena_too_small.h264"),
+            ], stderr_contains="buffer too small")
             offset_arena_output = workdir / "output_jpeg_arena_offset_i420.h264"
             encode_jpeg(args, "i420", jpeg_input, offset_arena_output,
                         ["--test-arena-offset", "1"])


### PR DESCRIPTION
## Summary

- map streaming row-cache arena exhaustion to `SH264E_ERR_BUFFER_TOO_SMALL`
- keep real heap allocation failure mapped to `SH264E_ERR_ALLOCATION_FAILED`
- add ffmpeg integration coverage for `--streaming-prototype --test-arena-shrink 1`

Refs #15
Follow-up to #16.

## Validation

- `git diff --check origin/main...HEAD`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
