### PR TITLE
jpeg: reduce NanoJPEG static BSS

### DIFF
--- a/MEMORY_REDUCTION_PLAN.md
+++ b/MEMORY_REDUCTION_PLAN.md
@@ -172,6 +172,15 @@ directions:
 * smaller generated-on-demand decode tables
 * build-time option to trade speed for SRAM
 
+Selected implementation direction:
+
+* Default to arena-backed/dynamic VLC tables with `NJ_DYNAMIC_VLC=1`.
+* Keep `NJ_DYNAMIC_VLC=0` as a build-time escape hatch for projects that prefer
+  the original static-table model.
+* Route the dynamic tables through the existing NanoJPEG allocation shim so
+  heap and caller-provided arena paths both report the 524,288-byte table block
+  in their work-size/peak-allocation accounting.
+
 Acceptance criteria:
 
 * Cortex-M object-size report shows reduced fixed SRAM usage.

--- a/SPACE_REDUCTION.md
+++ b/SPACE_REDUCTION.md
@@ -216,6 +216,37 @@ Implemented API:
 * Test one-byte-too-small arena fails.
 * QEMU smoke test covers arena path when the ARM/QEMU toolchain is available.
 
+## NanoJPEG Static BSS Follow-Up
+
+NanoJPEG originally stored four fully expanded Huffman/VLC decode tables inside
+its static global context. For Cortex-M builds, that made `src/nanojpeg.c`
+reserve about 525 KiB of fixed BSS before any JPEG was decoded.
+
+The selected production-safe tradeoff is to allocate those VLC tables through
+the existing `njAllocMem` shim the first time a DHT marker is decoded. This
+keeps the public JPEG encode API unchanged and lets the heap-backed and
+caller-provided arena paths account for the table memory in the same way they
+already account for decoded component planes and row caches.
+
+Measured with:
+
+```sh
+arm-none-eabi-gcc -mcpu=cortex-m4 -mthumb -O2 -ffreestanding -fno-builtin \
+  -DNJ_USE_LIBC=0 -Iinclude -c src/nanojpeg.c -o nanojpeg.o
+arm-none-eabi-size -A nanojpeg.o
+```
+
+| Build mode | `.text` | `.bss` | Notes |
+| --- | ---: | ---: | --- |
+| Static VLC tables, `NJ_DYNAMIC_VLC=0` | 5,988 | 525,032 | Original fixed SRAM model |
+| Dynamic VLC tables, default `NJ_DYNAMIC_VLC=1` | 5,796 | 748 | VLC tables move to tracked JPEG allocation |
+
+The dynamic table block is `4 * 65,536 * sizeof(nj_vlc_code_t)`, currently
+524,288 bytes. This increases per-decode heap/arena work size by that amount,
+but removes it from fixed BSS and makes placement explicit for embedded
+integrations. Builds that prefer the original static allocation/speed tradeoff
+can compile NanoJPEG with `NJ_DYNAMIC_VLC=0`.
+
 ## Phase 5: MCU-Row Streaming Decode
 
 ### Plan

--- a/src/nanojpeg.c
+++ b/src/nanojpeg.c
@@ -84,6 +84,11 @@
 //                           (default).
 // NJ_CHROMA_FILTER=0      = Use simple pixel repetition for chroma upsampling
 //                           (bad quality, but faster and less code).
+// NJ_DYNAMIC_VLC=1        = Allocate Huffman/VLC decode tables at decode time
+//                           through njAllocMem() instead of keeping them in
+//                           NanoJPEG's static context (default).
+// NJ_DYNAMIC_VLC=0        = Keep VLC tables in static BSS for the original
+//                           NanoJPEG speed/static-allocation tradeoff.
 
 
 // API
@@ -212,6 +217,10 @@ void njDone(void);
     #define NJ_CHROMA_FILTER 1
 #endif
 
+#ifndef NJ_DYNAMIC_VLC
+    #define NJ_DYNAMIC_VLC 1
+#endif
+
 
 ///////////////////////////////////////////////////////////////////////////////
 // EXAMPLE PROGRAM                                                           //
@@ -320,6 +329,10 @@ typedef struct _nj_code {
     unsigned char bits, code;
 } nj_vlc_code_t;
 
+#define NJ_VLC_TABLE_COUNT 4
+#define NJ_VLC_TABLE_SIZE 65536
+#define NJ_VLC_TABLE_BYTES (NJ_VLC_TABLE_COUNT * NJ_VLC_TABLE_SIZE * (int) sizeof(nj_vlc_code_t))
+
 typedef struct _nj_cmp {
     int cid;
     int ssx, ssy;
@@ -343,7 +356,11 @@ typedef struct _nj_ctx {
     nj_component_t comp[3];
     int qtused, qtavail;
     unsigned char qtab[4][64];
-    nj_vlc_code_t vlctab[4][65536];
+#if NJ_DYNAMIC_VLC
+    nj_vlc_code_t (*vlctab)[NJ_VLC_TABLE_SIZE];
+#else
+    nj_vlc_code_t vlctab[NJ_VLC_TABLE_COUNT][NJ_VLC_TABLE_SIZE];
+#endif
     int buf, bufbits;
     int block[64];
     int rstinterval;
@@ -468,6 +485,29 @@ NJ_INLINE void njColIDCT(const int* blk, unsigned char *out, int stride) {
 
 #define njThrow(e) do { nj.error = e; return; } while (0)
 #define njCheckError() do { if (nj.error) return; } while (0)
+
+#if NJ_DYNAMIC_VLC
+NJ_INLINE void njFreeVlcTables(void) {
+    if (nj.vlctab) {
+        njFreeMem((void*) nj.vlctab);
+        nj.vlctab = NULL;
+    }
+}
+
+NJ_INLINE int njEnsureVlcTables(void) {
+    if (!nj.vlctab) {
+        nj.vlctab = (nj_vlc_code_t (*)[NJ_VLC_TABLE_SIZE])
+            njAllocMem(NJ_VLC_TABLE_BYTES);
+        if (nj.vlctab) {
+            njFillMem((void*) nj.vlctab, 0, NJ_VLC_TABLE_BYTES);
+        }
+    }
+    return nj.vlctab != NULL;
+}
+#else
+NJ_INLINE void njFreeVlcTables(void) { }
+NJ_INLINE int njEnsureVlcTables(void) { return 1; }
+#endif
 
 static int njShowBits(int bits) {
     unsigned char newbyte;
@@ -606,6 +646,7 @@ NJ_INLINE void njDecodeDHT(void) {
     static unsigned char counts[16];
     njDecodeLength();
     njCheckError();
+    if (!njEnsureVlcTables()) njThrow(NJ_OUT_OF_MEM);
     while (nj.length >= 17) {
         i = nj.pos[0];
         if (i & 0xEC) njThrow(NJ_SYNTAX_ERROR);
@@ -904,6 +945,7 @@ void njDone(void) {
     for (i = 0;  i < 3;  ++i)
         if (nj.comp[i].pixels) njFreeMem((void*) nj.comp[i].pixels);
     if (nj.rgb) njFreeMem((void*) nj.rgb);
+    njFreeVlcTables();
     njInit();
 }
 


### PR DESCRIPTION
## Summary

- move NanoJPEG Huffman/VLC decode tables out of the fixed static context by default
- allocate and zero-fill the VLC table block through the existing `njAllocMem` shim so heap and arena paths account for it
- document the selected `NJ_DYNAMIC_VLC` tradeoff and Cortex-M object-size report

Refs #22

## Validation

- `arm-none-eabi-gcc -mcpu=cortex-m4 -mthumb -O2 -ffreestanding -fno-builtin -DNJ_USE_LIBC=0 -Iinclude -c src/nanojpeg.c -o build/issue22/nanojpeg_dynamic_vlc.o`
- `arm-none-eabi-size -A build/issue22/nanojpeg_dynamic_vlc.o` -> `.bss` 748 bytes
- `arm-none-eabi-gcc -mcpu=cortex-m4 -mthumb -O2 -ffreestanding -fno-builtin -DNJ_USE_LIBC=0 -DNJ_DYNAMIC_VLC=0 -Iinclude -c src/nanojpeg.c -o build/issue22/nanojpeg_static_vlc.o`
- `arm-none-eabi-size -A build/issue22/nanojpeg_static_vlc.o` -> `.bss` 525,032 bytes
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `build/sh264e_encode_jpeg --format i420 build/integration/input_720p_yuvj420p.jpg build/issue22/output_issue22_i420.h264`

QEMU note: CMake still skips QEMU firmware tests in this environment because `arm-none-eabi-gcc` cannot compile `<stdlib.h>`.
