### PR TITLE
jpeg: lock streaming row cache bridge metrics

### DIFF
--- a/MEMORY_REDUCTION_PLAN.md
+++ b/MEMORY_REDUCTION_PLAN.md
@@ -135,6 +135,16 @@ Acceptance criteria:
 * `2560x1440` 4:2:0 uses row-cache scaling instead of full component planes.
 * The measured cache target for `2560x1440` 4:2:0 is documented.
 
+Implemented bridge contract:
+
+* The hidden streaming bridge sizes row-cache storage from decoded component
+  geometry and the scaler's per-slice source row window.
+* The integration matrix asserts exact row-cache bytes for color JPEG inputs:
+  61,440 bytes for 1280x720 4:2:0, 81,920 bytes for 1280x720 4:2:2,
+  122,880 bytes for 1280x720 4:4:4, and 184,320 bytes for 2560x1440 4:2:0.
+* The JPEG tool and integration matrix also assert the scaled output slice work
+  buffer remains 61,440 bytes.
+
 ### 3. Production API Switch
 
 Make the arena-backed JPEG encoder use the streaming path by default.

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -168,6 +168,33 @@ one MCU-row margin so slices at row-window boundaries can still sample the
 previous row. These figures exclude the existing 61,440-byte encoder slice work
 buffer and H.264 output buffer, both of which are already caller-controlled.
 
+## Rolling Row-Cache Bridge
+
+The hidden streaming bridge now derives retained row-cache size from the decoded
+component geometry and the existing fixed-point scaler's per-slice source row
+window. Each component cache is sized to the largest source row span needed by
+any 16-row luma or 8-row chroma output slice, rounded up to that component's
+JPEG MCU-row height plus one MCU-row margin. Decoded MCU rows are copied into
+the rolling component cache, and slices are encoded as soon as all source rows
+for the next output slice are available.
+
+The bridge keeps the public JPEG API unchanged and keeps the default
+arena-backed JPEG encode path on the component-plane implementation. Issue #20
+owns switching that production entry point to the streaming bridge.
+
+Measured bridge contract:
+
+| Source | Streaming row cache | Slice work buffer |
+| --- | ---: | ---: |
+| 1280x720 4:2:0 | 61,440 | 61,440 |
+| 1280x720 4:2:2 | 81,920 | 61,440 |
+| 1280x720 4:4:4 | 122,880 | 61,440 |
+| 2560x1440 4:2:0 | 184,320 | 61,440 |
+
+The integration matrix asserts these row-cache values for color JPEG inputs and
+asserts that the streaming path continues to use the same 61,440-byte scaled
+slice work buffer as the component-plane path.
+
 ## Validation Plan
 
 The prototype adds a tool/test-only path before replacing the default JPEG

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -10,6 +10,13 @@ SMALL_WIDTH = 1280
 SMALL_HEIGHT = 720
 LARGE_WIDTH = 2560
 LARGE_HEIGHT = 1440
+JPEG_SLICE_WORK_BYTES = WIDTH * 16 + (WIDTH // 2) * 8 * 2
+STREAMING_CACHE_BYTES_720P = {
+    "yuvj420p": 61_440,
+    "yuvj422p": 81_920,
+    "yuvj444p": 122_880,
+}
+STREAMING_CACHE_BYTES_1440P_420 = 184_320
 
 
 def run(cmd):
@@ -256,6 +263,13 @@ def validate_jpeg_restart_markers(path):
         raise RuntimeError(f"{path} is missing JPEG RST markers")
 
 
+def parse_jpeg_metric(stdout, prefix):
+    for line in stdout.splitlines():
+        if line.startswith(prefix):
+            return int(line.rsplit(" ", 1)[1])
+    raise RuntimeError(f"JPEG encoder did not report {prefix!r}: {stdout!r}")
+
+
 def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None):
     command = [args.jpeg_encoder]
     if extra_args:
@@ -266,15 +280,17 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None):
         raise RuntimeError(f"JPEG encoder did not release tracked allocations: {result.stdout!r}")
     if "jpeg work arena bytes:" not in result.stdout:
         raise RuntimeError(f"JPEG encoder did not report work arena size: {result.stdout!r}")
-    for line in result.stdout.splitlines():
-        if line.startswith("jpeg peak allocation bytes:"):
-            if int(line.rsplit(" ", 1)[1]) == 0:
-                raise RuntimeError(f"JPEG encoder reported zero peak allocation bytes: {result.stdout!r}")
-            return
-    raise RuntimeError(f"JPEG encoder did not report peak allocation bytes: {result.stdout!r}")
+    slice_work = parse_jpeg_metric(result.stdout, "jpeg slice work bytes:")
+    if slice_work != JPEG_SLICE_WORK_BYTES:
+        raise RuntimeError(
+            f"JPEG encoder slice work changed: got {slice_work}, expected {JPEG_SLICE_WORK_BYTES}"
+        )
+    peak = parse_jpeg_metric(result.stdout, "jpeg peak allocation bytes:")
+    if peak == 0:
+        raise RuntimeError(f"JPEG encoder reported zero peak allocation bytes: {result.stdout!r}")
 
 
-def encode_jpeg_streaming_prototype(args, fmt, jpeg_input, bitstream):
+def encode_jpeg_streaming_prototype(args, fmt, jpeg_input, bitstream, expected_cache_bytes=None):
     result = run_capture([
         args.jpeg_encoder,
         "--streaming-prototype",
@@ -285,22 +301,24 @@ def encode_jpeg_streaming_prototype(args, fmt, jpeg_input, bitstream):
     ])
     if "jpeg current allocation bytes: 0" not in result.stdout:
         raise RuntimeError(f"streaming JPEG prototype leaked tracked allocations: {result.stdout!r}")
-    peak = None
-    cache = None
-    work = None
-    for line in result.stdout.splitlines():
-        if line.startswith("jpeg work arena bytes:"):
-            work = int(line.rsplit(" ", 1)[1])
-        if line.startswith("jpeg peak allocation bytes:"):
-            peak = int(line.rsplit(" ", 1)[1])
-        if line.startswith("jpeg streaming cache bytes:"):
-            cache = int(line.rsplit(" ", 1)[1])
-    if work is None or work == 0:
+    work = parse_jpeg_metric(result.stdout, "jpeg work arena bytes:")
+    if work == 0:
         raise RuntimeError(f"streaming JPEG prototype did not report arena work size: {result.stdout!r}")
-    if peak is None or peak >= 1382400:
+    slice_work = parse_jpeg_metric(result.stdout, "jpeg slice work bytes:")
+    if slice_work != JPEG_SLICE_WORK_BYTES:
+        raise RuntimeError(
+            f"streaming JPEG prototype slice work changed: got {slice_work}, expected {JPEG_SLICE_WORK_BYTES}"
+        )
+    peak = parse_jpeg_metric(result.stdout, "jpeg peak allocation bytes:")
+    if peak >= 1382400:
         raise RuntimeError(f"streaming JPEG prototype did not reduce NanoJPEG allocation peak: {result.stdout!r}")
-    if cache is None or cache == 0:
+    cache = parse_jpeg_metric(result.stdout, "jpeg streaming cache bytes:")
+    if cache == 0:
         raise RuntimeError(f"streaming JPEG prototype did not report cache bytes: {result.stdout!r}")
+    if expected_cache_bytes is not None and cache != expected_cache_bytes:
+        raise RuntimeError(
+            f"streaming JPEG row cache changed for {jpeg_input}: got {cache}, expected {expected_cache_bytes}"
+        )
 
 
 def main():
@@ -414,7 +432,8 @@ def main():
             jpeg_output = workdir / f"output_jpeg_{pix_fmt}_{fmt}.h264"
             streaming_output = workdir / f"output_jpeg_streaming_{pix_fmt}_{fmt}.h264"
             encode_jpeg(args, fmt, jpeg_input, jpeg_output)
-            encode_jpeg_streaming_prototype(args, fmt, jpeg_input, streaming_output)
+            encode_jpeg_streaming_prototype(args, fmt, jpeg_input, streaming_output,
+                                            STREAMING_CACHE_BYTES_720P[pix_fmt])
             validate_bitstream(args.ffprobe, args.ffmpeg, jpeg_output)
             validate_bitstream(args.ffprobe, args.ffmpeg, streaming_output)
             compare_decoded_i420(args, jpeg_output, streaming_output,
@@ -425,7 +444,8 @@ def main():
     large_streaming_output = workdir / "output_jpeg_streaming_1440p_yuvj420p_i420.h264"
     make_color_jpeg_sized(args, large_jpeg_input, "yuvj420p", LARGE_WIDTH, LARGE_HEIGHT)
     encode_jpeg(args, "i420", large_jpeg_input, large_jpeg_output)
-    encode_jpeg_streaming_prototype(args, "i420", large_jpeg_input, large_streaming_output)
+    encode_jpeg_streaming_prototype(args, "i420", large_jpeg_input, large_streaming_output,
+                                    STREAMING_CACHE_BYTES_1440P_420)
     validate_bitstream(args.ffprobe, args.ffmpeg, large_streaming_output)
     compare_decoded_i420(args, large_jpeg_output, large_streaming_output,
                          "output_jpeg_1440p_yuvj420p_i420_streaming_compare")
@@ -435,7 +455,8 @@ def main():
         make_restart_marker_jpeg(args, restart_jpeg_input)
         restart_streaming_output = workdir / "output_jpeg_streaming_yuvj420p_restart_i420.h264"
         restart_jpeg_output = workdir / "output_jpeg_yuvj420p_restart_i420.h264"
-        encode_jpeg_streaming_prototype(args, "i420", restart_jpeg_input, restart_streaming_output)
+        encode_jpeg_streaming_prototype(args, "i420", restart_jpeg_input, restart_streaming_output,
+                                        STREAMING_CACHE_BYTES_720P["yuvj420p"])
         validate_bitstream(args.ffprobe, args.ffmpeg, restart_streaming_output)
         encode_jpeg(args, "i420", restart_jpeg_input, restart_jpeg_output)
         validate_bitstream(args.ffprobe, args.ffmpeg, restart_jpeg_output)

--- a/tools/sh264e_encode_jpeg.c
+++ b/tools/sh264e_encode_jpeg.c
@@ -291,6 +291,7 @@ int main(int argc, char **argv)
             goto done;
         }
         printf("jpeg work arena bytes: %zu\n", jpeg_work_size);
+        printf("jpeg slice work bytes: %zu\n", work_size);
         printf("jpeg current allocation bytes: %zu\n", stats.current_bytes);
         printf("jpeg peak allocation bytes: %zu\n", stats.peak_bytes);
         if (streaming_prototype) {


### PR DESCRIPTION
## Summary

- make the JPEG tool report the scaled slice work buffer size used by both component-plane and streaming paths
- tighten ffmpeg integration coverage to assert exact streaming row-cache bytes for the color JPEG matrix
- document the rolling row-cache bridge contract and the measured `2560x1440` 4:2:0 `184,320` byte row-cache target

Refs #19

## Validation

- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `build/sh264e_encode_jpeg --streaming-prototype --format i420 build/integration/input_1440p_yuvj420p.jpg build/issue19_streaming_1440_i420.h264`

Measured targeted run:

- `jpeg slice work bytes: 61440`
- `jpeg streaming cache bytes: 184320`

Scope note: this keeps the public JPEG API unchanged and does not switch `sh264e_encode_jpeg_idr_with_arena` to streaming by default; that remains #20.

QEMU note: CMake still skips QEMU firmware tests in this environment because `arm-none-eabi-gcc` cannot compile `<stdlib.h>`.
