### PR TITLE
jpeg: switch arena encode to streaming

### DIFF
--- a/SPACE_REDUCTION.md
+++ b/SPACE_REDUCTION.md
@@ -265,13 +265,11 @@ JPEG bitstream
 -> H.264 slice encode
 ```
 
-This is a larger decoder refactor and should not replace the component-plane
-path until the hidden prototype has passed the public JPEG matrix. The current
-prototype decodes one MCU row at a time into component row rings, feeds the
-existing progressive H.264 slice encoder when enough source rows are available
-for the next output slice, and uses the same caller-provided JPEG arena policy
-as the component-plane path for both NanoJPEG's one-MCU-row buffers and the
-retained row cache.
+The row-cache bridge decodes one MCU row at a time into component row rings,
+feeds the existing progressive H.264 slice encoder when enough source rows are
+available for the next output slice, and uses the same caller-provided JPEG
+arena policy as the component-plane path for both NanoJPEG's one-MCU-row
+buffers and the retained row cache.
 
 ### Expected Benefit
 
@@ -301,9 +299,11 @@ encoder slice work buffer, and the H.264 output buffer. The streaming cache
 adds one MCU-row margin beyond the maximum fixed-point source window so slices
 at row-window boundaries can still sample the previous row.
 
-### Current Prototype Boundary
+### Current Production Boundary
 
-* Keep the public API unchanged until the internal row-window contract is proven.
+* Keep the public API unchanged; `sh264e_jpeg_get_work_size` and
+  `sh264e_encode_jpeg_idr_with_arena` now use the streaming row-cache path for
+  deterministic arena-backed JPEG encode.
 * Support baseline sequential grayscale or three-component YCbCr JPEGs within
   the public JPEG source-size policy.
 * Reject progressive/lossless JPEG, arithmetic coding, CMYK/other color spaces,
@@ -313,9 +313,10 @@ at row-window boundaries can still sample the previous row.
 * Validate 1280x720 4:2:0, 4:2:2, and 4:4:4 fixtures, 2560x1440 4:2:0,
   grayscale, I420 and NV12 output, and a `cjpeg`-generated DRI/RST
   restart-marker fixture when `cjpeg` is available.
-* Keep the row-window bridge hidden and opt-in for now. The production/default
-  JPEG path remains the component-plane arena path until the streaming path is
-  exposed through a public policy rather than a tool-only flag.
+* Keep the heap-backed convenience wrapper compatible for callers that do not
+  need deterministic JPEG arena placement.
+* Keep the tool-local `--streaming-prototype` path as an internal comparison
+  mode while the default arena path exercises the same row-cache bridge.
 
 ### Risks
 

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -125,18 +125,20 @@ current prototype keeps it internal and exercises it through
 supported JPEG source-size policy for grayscale and YCbCr inputs, I420 and NV12
 output, and caller-provided arena allocation for the retained row cache.
 
-## Promotion Decision
+## Production Arena Default
 
-The row-window bridge should remain hidden and opt-in instead of becoming the
-production default in this issue. The prototype now closes the main
-production-matrix gaps: dynamic cache sizing, caller-provided arena allocation,
-I420 and NV12 output, grayscale coverage, color subsampling coverage, and
-restart-marker coverage.
+The row-window bridge is now the production implementation for the public
+caller-provided arena entry point, `sh264e_encode_jpeg_idr_with_arena`, and for
+the corresponding `sh264e_jpeg_get_work_size` arena sizing query. The public
+function signatures and caller-owned buffer model remain unchanged: callers
+still provide the compressed JPEG input, a JPEG work arena, one 61,440-byte
+slice work buffer, and the H.264 output buffer.
 
-The default JPEG path still remains the component-plane arena path because it is
-the public API contract today. Streaming should become default only after the
-project decides how to expose the row-window policy outside the tool-local
-`--streaming-prototype` flag.
+The heap-backed convenience wrapper, `sh264e_encode_jpeg_idr`, remains
+compatible for callers that do not need deterministic arena placement. The
+tool-local `--streaming-prototype` flag remains available as an internal
+comparison path while the default arena path exercises the same streaming row
+cache.
 
 ## Memory Estimate
 
@@ -178,9 +180,9 @@ JPEG MCU-row height plus one MCU-row margin. Decoded MCU rows are copied into
 the rolling component cache, and slices are encoded as soon as all source rows
 for the next output slice are available.
 
-The bridge keeps the public JPEG API unchanged and keeps the default
-arena-backed JPEG encode path on the component-plane implementation. Issue #20
-owns switching that production entry point to the streaming bridge.
+The bridge keeps the public JPEG API unchanged. The arena-backed JPEG encode
+path uses this bridge by default, so production arena sizing is based on the
+rolling row cache instead of full decoded component planes.
 
 Measured bridge contract:
 
@@ -214,5 +216,6 @@ encoder:
   full component-plane allocation for 4:2:2 and 4:4:4.
 * When `cjpeg` is available, generate a 4:2:0 fixture with DRI/RST restart
   markers and run the same streaming-vs-component decoded-frame comparison.
-* Keep the component-plane arena path as the production/default path while the
-  row-window bridge remains hidden behind the streaming prototype flag.
+* Confirm the default arena-backed JPEG path reports nonzero streaming
+  row-cache bytes and stays below the full component-plane allocation for the
+  covered color fixtures.

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -135,6 +135,17 @@ static size_t sh264e_jpeg_alloc_arena_capacity;
 static size_t sh264e_jpeg_streaming_last_cache_bytes;
 
 static void reset_progressive_state(sh264e_encoder_t *encoder);
+static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *encoder,
+                                                             const uint8_t *jpeg_data,
+                                                             size_t jpeg_size,
+                                                             uint8_t *jpeg_arena,
+                                                             size_t jpeg_arena_size,
+                                                             int use_arena,
+                                                             uint8_t *work_buffer,
+                                                             size_t work_buffer_capacity,
+                                                             uint8_t *out,
+                                                             size_t out_capacity,
+                                                             size_t *out_size);
 
 static const uint8_t k_luma4x4_x[16] = {
     0, 4, 0, 4, 8, 12, 8, 12, 0, 4, 0, 4, 8, 12, 8, 12
@@ -2072,31 +2083,48 @@ sh264e_status_t sh264e_jpeg_get_last_allocation_stats(sh264e_jpeg_allocation_sta
     return SH264E_OK;
 }
 
-sh264e_status_t sh264e_jpeg_get_work_size(const uint8_t *jpeg_data,
-                                          size_t jpeg_size,
-                                          size_t *out_size)
+static sh264e_status_t jpeg_get_streaming_work_size(const uint8_t *jpeg_data,
+                                                    size_t jpeg_size,
+                                                    size_t *out_size)
 {
+    sh264e_jpeg_stream_context_t ctx;
     sh264e_status_t status;
-    int component_count = 0;
-    sh264e_jpeg_component_t components[3];
 
     if (jpeg_data == NULL || out_size == NULL) {
         return SH264E_ERR_INVALID_ARGUMENT;
     }
     *out_size = 0u;
+    sh264e_jpeg_streaming_last_cache_bytes = 0u;
     if (jpeg_size == 0u || jpeg_size > (size_t)INT_MAX) {
         return SH264E_ERR_INVALID_ARGUMENT;
     }
 
+    memset(&ctx, 0, sizeof(ctx));
+    ctx.measure_only = 1;
+    ctx.status = SH264E_OK;
+
     jpeg_allocation_begin_heap();
     njInit();
-    status = jpeg_decode_memory(jpeg_data, jpeg_size, components, &component_count);
-    njDone();
+    status = map_jpeg_result(njDecodeMcuRows(jpeg_data, (int)jpeg_size,
+                                             streaming_mcu_row_ready, &ctx));
+    if (ctx.status != SH264E_OK) {
+        status = ctx.status;
+    }
     if (status == SH264E_OK) {
         *out_size = sh264e_jpeg_alloc_peak_arena_bytes;
     }
+    sh264e_jpeg_streaming_last_cache_bytes = ctx.cache_bytes;
+    streaming_free_cache(&ctx);
+    njDone();
     jpeg_allocation_end();
     return status;
+}
+
+sh264e_status_t sh264e_jpeg_get_work_size(const uint8_t *jpeg_data,
+                                          size_t jpeg_size,
+                                          size_t *out_size)
+{
+    return jpeg_get_streaming_work_size(jpeg_data, jpeg_size, out_size);
 }
 
 static sh264e_status_t sh264e_encode_jpeg_idr_impl(sh264e_encoder_t *encoder,
@@ -2221,10 +2249,10 @@ sh264e_status_t sh264e_encode_jpeg_idr_with_arena(sh264e_encoder_t *encoder,
                                                   size_t out_capacity,
                                                   size_t *out_size)
 {
-    return sh264e_encode_jpeg_idr_impl(encoder, jpeg_data, jpeg_size,
-                                       jpeg_arena, jpeg_arena_size, 1,
-                                       work_buffer, work_buffer_capacity,
-                                       out, out_capacity, out_size);
+    return sh264e_encode_jpeg_idr_streaming_impl(encoder, jpeg_data, jpeg_size,
+                                                 jpeg_arena, jpeg_arena_size, 1,
+                                                 work_buffer, work_buffer_capacity,
+                                                 out, out_capacity, out_size);
 }
 
 size_t sh264e_jpeg_get_last_streaming_cache_bytes(void)
@@ -2236,37 +2264,7 @@ sh264e_status_t sh264e_jpeg_get_streaming_work_size(const uint8_t *jpeg_data,
                                                     size_t jpeg_size,
                                                     size_t *out_size)
 {
-    sh264e_jpeg_stream_context_t ctx;
-    sh264e_status_t status;
-
-    if (jpeg_data == NULL || out_size == NULL) {
-        return SH264E_ERR_INVALID_ARGUMENT;
-    }
-    *out_size = 0u;
-    sh264e_jpeg_streaming_last_cache_bytes = 0u;
-    if (jpeg_size == 0u || jpeg_size > (size_t)INT_MAX) {
-        return SH264E_ERR_INVALID_ARGUMENT;
-    }
-
-    memset(&ctx, 0, sizeof(ctx));
-    ctx.measure_only = 1;
-    ctx.status = SH264E_OK;
-
-    jpeg_allocation_begin_heap();
-    njInit();
-    status = map_jpeg_result(njDecodeMcuRows(jpeg_data, (int)jpeg_size,
-                                             streaming_mcu_row_ready, &ctx));
-    if (ctx.status != SH264E_OK) {
-        status = ctx.status;
-    }
-    if (status == SH264E_OK) {
-        *out_size = sh264e_jpeg_alloc_peak_arena_bytes;
-    }
-    sh264e_jpeg_streaming_last_cache_bytes = ctx.cache_bytes;
-    streaming_free_cache(&ctx);
-    njDone();
-    jpeg_allocation_end();
-    return status;
+    return jpeg_get_streaming_work_size(jpeg_data, jpeg_size, out_size);
 }
 
 static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *encoder,

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -17,6 +17,12 @@ STREAMING_CACHE_BYTES_720P = {
     "yuvj444p": 122_880,
 }
 STREAMING_CACHE_BYTES_1440P_420 = 184_320
+FULL_COMPONENT_BYTES_720P = {
+    "yuvj420p": 1_382_400,
+    "yuvj422p": 1_843_200,
+    "yuvj444p": 2_764_800,
+}
+FULL_COMPONENT_BYTES_1440P_420 = 5_529_600
 
 
 def run(cmd):
@@ -270,7 +276,8 @@ def parse_jpeg_metric(stdout, prefix):
     raise RuntimeError(f"JPEG encoder did not report {prefix!r}: {stdout!r}")
 
 
-def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None):
+def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
+                expected_cache_bytes=None, max_peak_bytes=None):
     command = [args.jpeg_encoder]
     if extra_args:
         command.extend(extra_args)
@@ -288,6 +295,17 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None):
     peak = parse_jpeg_metric(result.stdout, "jpeg peak allocation bytes:")
     if peak == 0:
         raise RuntimeError(f"JPEG encoder reported zero peak allocation bytes: {result.stdout!r}")
+    cache = parse_jpeg_metric(result.stdout, "jpeg streaming cache bytes:")
+    if cache == 0:
+        raise RuntimeError(f"JPEG encoder default path did not report streaming cache bytes: {result.stdout!r}")
+    if expected_cache_bytes is not None and cache != expected_cache_bytes:
+        raise RuntimeError(
+            f"JPEG encoder default row cache changed for {jpeg_input}: got {cache}, expected {expected_cache_bytes}"
+        )
+    if max_peak_bytes is not None and peak >= max_peak_bytes:
+        raise RuntimeError(
+            f"JPEG encoder default path used full component-plane memory: got peak {peak}, limit {max_peak_bytes}"
+        )
 
 
 def encode_jpeg_streaming_prototype(args, fmt, jpeg_input, bitstream, expected_cache_bytes=None):
@@ -426,12 +444,16 @@ def main():
             ], stderr_contains="buffer too small")
             offset_arena_output = workdir / "output_jpeg_arena_offset_i420.h264"
             encode_jpeg(args, "i420", jpeg_input, offset_arena_output,
-                        ["--test-arena-offset", "1"])
+                        ["--test-arena-offset", "1"],
+                        STREAMING_CACHE_BYTES_720P[pix_fmt],
+                        FULL_COMPONENT_BYTES_720P[pix_fmt])
             validate_bitstream(args.ffprobe, args.ffmpeg, offset_arena_output)
         for fmt in ("i420", "nv12"):
             jpeg_output = workdir / f"output_jpeg_{pix_fmt}_{fmt}.h264"
             streaming_output = workdir / f"output_jpeg_streaming_{pix_fmt}_{fmt}.h264"
-            encode_jpeg(args, fmt, jpeg_input, jpeg_output)
+            encode_jpeg(args, fmt, jpeg_input, jpeg_output,
+                        expected_cache_bytes=STREAMING_CACHE_BYTES_720P[pix_fmt],
+                        max_peak_bytes=FULL_COMPONENT_BYTES_720P[pix_fmt])
             encode_jpeg_streaming_prototype(args, fmt, jpeg_input, streaming_output,
                                             STREAMING_CACHE_BYTES_720P[pix_fmt])
             validate_bitstream(args.ffprobe, args.ffmpeg, jpeg_output)
@@ -443,7 +465,9 @@ def main():
     large_jpeg_output = workdir / "output_jpeg_1440p_yuvj420p_i420.h264"
     large_streaming_output = workdir / "output_jpeg_streaming_1440p_yuvj420p_i420.h264"
     make_color_jpeg_sized(args, large_jpeg_input, "yuvj420p", LARGE_WIDTH, LARGE_HEIGHT)
-    encode_jpeg(args, "i420", large_jpeg_input, large_jpeg_output)
+    encode_jpeg(args, "i420", large_jpeg_input, large_jpeg_output,
+                expected_cache_bytes=STREAMING_CACHE_BYTES_1440P_420,
+                max_peak_bytes=FULL_COMPONENT_BYTES_1440P_420)
     encode_jpeg_streaming_prototype(args, "i420", large_jpeg_input, large_streaming_output,
                                     STREAMING_CACHE_BYTES_1440P_420)
     validate_bitstream(args.ffprobe, args.ffmpeg, large_streaming_output)
@@ -458,7 +482,9 @@ def main():
         encode_jpeg_streaming_prototype(args, "i420", restart_jpeg_input, restart_streaming_output,
                                         STREAMING_CACHE_BYTES_720P["yuvj420p"])
         validate_bitstream(args.ffprobe, args.ffmpeg, restart_streaming_output)
-        encode_jpeg(args, "i420", restart_jpeg_input, restart_jpeg_output)
+        encode_jpeg(args, "i420", restart_jpeg_input, restart_jpeg_output,
+                    expected_cache_bytes=STREAMING_CACHE_BYTES_720P["yuvj420p"],
+                    max_peak_bytes=FULL_COMPONENT_BYTES_720P["yuvj420p"])
         validate_bitstream(args.ffprobe, args.ffmpeg, restart_jpeg_output)
         compare_decoded_i420(args, restart_jpeg_output, restart_streaming_output,
                              "output_jpeg_yuvj420p_restart_i420_streaming_compare")

--- a/tools/sh264e_encode_jpeg.c
+++ b/tools/sh264e_encode_jpeg.c
@@ -294,7 +294,7 @@ int main(int argc, char **argv)
         printf("jpeg slice work bytes: %zu\n", work_size);
         printf("jpeg current allocation bytes: %zu\n", stats.current_bytes);
         printf("jpeg peak allocation bytes: %zu\n", stats.peak_bytes);
-        if (streaming_prototype) {
+        if (streaming_prototype || sh264e_jpeg_get_last_streaming_cache_bytes() != 0u) {
             printf("jpeg streaming cache bytes: %zu\n", sh264e_jpeg_get_last_streaming_cache_bytes());
         }
     }


### PR DESCRIPTION
## Summary

- make `sh264e_jpeg_get_work_size` size the streaming row-cache arena
- make `sh264e_encode_jpeg_idr_with_arena` use the MCU-row streaming bridge by default while preserving its public signature
- tighten ffmpeg integration coverage so the default arena path reports exact row-cache bytes and stays below full component-plane memory
- update JPEG memory docs to describe the production arena default

Refs #20

## Validation

- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `build/sh264e_encode_jpeg --format i420 build/integration/input_1440p_yuvj420p.jpg build/issue20_default_1440_i420.h264`

Targeted default arena run:

- `jpeg work arena bytes: 770216`
- `jpeg slice work bytes: 61440`
- `jpeg peak allocation bytes: 770048`
- `jpeg streaming cache bytes: 184320`

QEMU note: CMake still skips QEMU firmware tests in this environment because `arm-none-eabi-gcc` cannot compile `<stdlib.h>`.
