### PR TITLE
test: lock JPEG streaming memory report

### DIFF
--- a/SPACE_REDUCTION.md
+++ b/SPACE_REDUCTION.md
@@ -299,6 +299,18 @@ encoder slice work buffer, and the H.264 output buffer. The streaming cache
 adds one MCU-row margin beyond the maximum fixed-point source window so slices
 at row-window boundaries can still sample the previous row.
 
+The production memory regression report is tracked in
+`docs/JPEG_STREAMING_MEMORY_REPORT.md`. The measured 4:2:0 arena-backed default
+path no longer requires the previous full decoded component planes:
+
+| Source JPEG | Previous full component planes | Production arena work | Production peak allocation | Streaming row cache |
+| --- | ---: | ---: | ---: | ---: |
+| 1280x720 4:2:0 | 1,382,400 | 616,616 | 616,448 | 61,440 |
+| 2560x1440 4:2:0 | 5,529,600 | 770,216 | 770,048 | 184,320 |
+
+The production peak includes the dynamically allocated NanoJPEG VLC table block,
+which is now caller-arena-accounted instead of fixed BSS.
+
 ### Current Production Boundary
 
 * Keep the public API unchanged; `sh264e_jpeg_get_work_size` and

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -197,6 +197,11 @@ The integration matrix asserts these row-cache values for color JPEG inputs and
 asserts that the streaming path continues to use the same 61,440-byte scaled
 slice work buffer as the component-plane path.
 
+The production memory regression report in
+`docs/JPEG_STREAMING_MEMORY_REPORT.md` records the measured default arena path:
+`1280x720` 4:2:0 uses 616,616 bytes of JPEG work arena and `2560x1440` 4:2:0
+uses 770,216 bytes, including the dynamic NanoJPEG VLC table block.
+
 ## Validation Plan
 
 The prototype adds a tool/test-only path before replacing the default JPEG

--- a/docs/JPEG_STREAMING_MEMORY_REPORT.md
+++ b/docs/JPEG_STREAMING_MEMORY_REPORT.md
@@ -1,0 +1,69 @@
+# JPEG Streaming Memory Report
+
+Issue #21 records the production memory regression target after the
+arena-backed JPEG encoder switched to the MCU-row streaming path.
+
+The baseline component-plane values are the decoded image component allocations
+from the earlier allocation report. The production measurements below are from
+`sh264e_encode_jpeg`, which calls `sh264e_jpeg_get_work_size` and
+`sh264e_encode_jpeg_idr_with_arena` on the default arena path.
+
+## Measured 4:2:0 Production Path
+
+| Source JPEG | Previous full component planes | Production arena work | Production peak allocation | Streaming row cache | Slice work buffer |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 1280x720 4:2:0 | 1,382,400 | 616,616 | 616,448 | 61,440 | 61,440 |
+| 2560x1440 4:2:0 | 5,529,600 | 770,216 | 770,048 | 184,320 | 61,440 |
+
+`Production peak allocation` includes the dynamic NanoJPEG VLC table block
+introduced by the static-BSS reduction work. That block is tracked through the
+same JPEG allocation shim as the row cache so embedded integrations can place it
+in the caller-provided arena. The streaming row cache is the decoded-image
+replacement for the previous full component planes.
+
+## Regression Coverage
+
+`tests/run_ffmpeg_integration.py` asserts the exact production arena work,
+peak-allocation, and row-cache values for the representative `1280x720` and
+`2560x1440` 4:2:0 JPEG fixtures. It also keeps broader color-subsampling
+coverage that fails if the production arena path regresses to full
+component-plane allocation.
+
+The expected validation command is:
+
+```sh
+ctest --test-dir build --output-on-failure
+```
+
+The `sh264e_ffmpeg_integration` case generates the JPEG fixtures with ffmpeg,
+encodes I420 and NV12 H.264 outputs where applicable, validates the bitstreams
+with ffprobe/ffmpeg, and compares decoded output frames against the internal
+streaming comparison path.
+
+## Manual Measurement Commands
+
+After configuring and building the repository:
+
+```sh
+build/sh264e_encode_jpeg --format i420 \
+  build/integration/input_720p_yuvj420p.jpg \
+  build/issue21_default_720_i420.h264
+
+build/sh264e_encode_jpeg --format i420 \
+  build/integration/input_1440p_yuvj420p.jpg \
+  build/issue21_default_1440_i420.h264
+```
+
+Expected metric lines:
+
+```text
+1280x720:
+jpeg work arena bytes: 616616
+jpeg peak allocation bytes: 616448
+jpeg streaming cache bytes: 61440
+
+2560x1440:
+jpeg work arena bytes: 770216
+jpeg peak allocation bytes: 770048
+jpeg streaming cache bytes: 184320
+```

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -23,6 +23,16 @@ FULL_COMPONENT_BYTES_720P = {
     "yuvj444p": 2_764_800,
 }
 FULL_COMPONENT_BYTES_1440P_420 = 5_529_600
+PRODUCTION_MEMORY_720P_420 = {
+    "work": 616_616,
+    "peak": 616_448,
+    "cache": STREAMING_CACHE_BYTES_720P["yuvj420p"],
+}
+PRODUCTION_MEMORY_1440P_420 = {
+    "work": 770_216,
+    "peak": 770_048,
+    "cache": STREAMING_CACHE_BYTES_1440P_420,
+}
 
 
 def run(cmd):
@@ -277,7 +287,8 @@ def parse_jpeg_metric(stdout, prefix):
 
 
 def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
-                expected_cache_bytes=None, max_peak_bytes=None):
+                expected_cache_bytes=None, max_peak_bytes=None,
+                expected_work_bytes=None, expected_peak_bytes=None):
     command = [args.jpeg_encoder]
     if extra_args:
         command.extend(extra_args)
@@ -287,6 +298,11 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
         raise RuntimeError(f"JPEG encoder did not release tracked allocations: {result.stdout!r}")
     if "jpeg work arena bytes:" not in result.stdout:
         raise RuntimeError(f"JPEG encoder did not report work arena size: {result.stdout!r}")
+    work = parse_jpeg_metric(result.stdout, "jpeg work arena bytes:")
+    if expected_work_bytes is not None and work != expected_work_bytes:
+        raise RuntimeError(
+            f"JPEG encoder default work arena changed for {jpeg_input}: got {work}, expected {expected_work_bytes}"
+        )
     slice_work = parse_jpeg_metric(result.stdout, "jpeg slice work bytes:")
     if slice_work != JPEG_SLICE_WORK_BYTES:
         raise RuntimeError(
@@ -295,6 +311,10 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
     peak = parse_jpeg_metric(result.stdout, "jpeg peak allocation bytes:")
     if peak == 0:
         raise RuntimeError(f"JPEG encoder reported zero peak allocation bytes: {result.stdout!r}")
+    if expected_peak_bytes is not None and peak != expected_peak_bytes:
+        raise RuntimeError(
+            f"JPEG encoder default peak changed for {jpeg_input}: got {peak}, expected {expected_peak_bytes}"
+        )
     cache = parse_jpeg_metric(result.stdout, "jpeg streaming cache bytes:")
     if cache == 0:
         raise RuntimeError(f"JPEG encoder default path did not report streaming cache bytes: {result.stdout!r}")
@@ -446,14 +466,23 @@ def main():
             encode_jpeg(args, "i420", jpeg_input, offset_arena_output,
                         ["--test-arena-offset", "1"],
                         STREAMING_CACHE_BYTES_720P[pix_fmt],
-                        FULL_COMPONENT_BYTES_720P[pix_fmt])
+                        FULL_COMPONENT_BYTES_720P[pix_fmt],
+                        PRODUCTION_MEMORY_720P_420["work"],
+                        PRODUCTION_MEMORY_720P_420["peak"])
             validate_bitstream(args.ffprobe, args.ffmpeg, offset_arena_output)
         for fmt in ("i420", "nv12"):
             jpeg_output = workdir / f"output_jpeg_{pix_fmt}_{fmt}.h264"
             streaming_output = workdir / f"output_jpeg_streaming_{pix_fmt}_{fmt}.h264"
+            expected_work = None
+            expected_peak = None
+            if pix_fmt == "yuvj420p":
+                expected_work = PRODUCTION_MEMORY_720P_420["work"]
+                expected_peak = PRODUCTION_MEMORY_720P_420["peak"]
             encode_jpeg(args, fmt, jpeg_input, jpeg_output,
                         expected_cache_bytes=STREAMING_CACHE_BYTES_720P[pix_fmt],
-                        max_peak_bytes=FULL_COMPONENT_BYTES_720P[pix_fmt])
+                        max_peak_bytes=FULL_COMPONENT_BYTES_720P[pix_fmt],
+                        expected_work_bytes=expected_work,
+                        expected_peak_bytes=expected_peak)
             encode_jpeg_streaming_prototype(args, fmt, jpeg_input, streaming_output,
                                             STREAMING_CACHE_BYTES_720P[pix_fmt])
             validate_bitstream(args.ffprobe, args.ffmpeg, jpeg_output)
@@ -467,7 +496,9 @@ def main():
     make_color_jpeg_sized(args, large_jpeg_input, "yuvj420p", LARGE_WIDTH, LARGE_HEIGHT)
     encode_jpeg(args, "i420", large_jpeg_input, large_jpeg_output,
                 expected_cache_bytes=STREAMING_CACHE_BYTES_1440P_420,
-                max_peak_bytes=FULL_COMPONENT_BYTES_1440P_420)
+                max_peak_bytes=FULL_COMPONENT_BYTES_1440P_420,
+                expected_work_bytes=PRODUCTION_MEMORY_1440P_420["work"],
+                expected_peak_bytes=PRODUCTION_MEMORY_1440P_420["peak"])
     encode_jpeg_streaming_prototype(args, "i420", large_jpeg_input, large_streaming_output,
                                     STREAMING_CACHE_BYTES_1440P_420)
     validate_bitstream(args.ffprobe, args.ffmpeg, large_streaming_output)


### PR DESCRIPTION
## Summary

- add exact production memory regression assertions for 1280x720 and 2560x1440 4:2:0 JPEG arena encodes
- document the measured before/after decoded-image memory reduction in a dedicated JPEG streaming memory report
- link the production report from the broader memory plan and MCU-row streaming design docs

Refs #21

## Validation

- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `build/sh264e_encode_jpeg --format i420 build/integration/input_720p_yuvj420p.jpg build/issue21_default_720_i420.h264`
- `build/sh264e_encode_jpeg --format i420 build/integration/input_1440p_yuvj420p.jpg build/issue21_default_1440_i420.h264`

Measured default arena path:

- 1280x720 4:2:0: work arena `616616`, peak allocation `616448`, streaming cache `61440`
- 2560x1440 4:2:0: work arena `770216`, peak allocation `770048`, streaming cache `184320`

QEMU note: CMake still skips QEMU firmware tests in this environment because `arm-none-eabi-gcc` cannot compile `<stdlib.h>`.
