### PR TITLE
jpeg: guard missing dynamic VLC tables

### DIFF
--- a/SPACE_REDUCTION.md
+++ b/SPACE_REDUCTION.md
@@ -238,14 +238,19 @@ arm-none-eabi-size -A nanojpeg.o
 
 | Build mode | `.text` | `.bss` | Notes |
 | --- | ---: | ---: | --- |
-| Static VLC tables, `NJ_DYNAMIC_VLC=0` | 5,988 | 525,032 | Original fixed SRAM model |
-| Dynamic VLC tables, default `NJ_DYNAMIC_VLC=1` | 5,796 | 748 | VLC tables move to tracked JPEG allocation |
+| Static VLC tables, `NJ_DYNAMIC_VLC=0` | 5,920 | 525,036 | Original fixed SRAM model |
+| Dynamic VLC tables, default `NJ_DYNAMIC_VLC=1` | 5,864 | 752 | VLC tables move to tracked JPEG allocation |
 
 The dynamic table block is `4 * 65,536 * sizeof(nj_vlc_code_t)`, currently
 524,288 bytes. This increases per-decode heap/arena work size by that amount,
 but removes it from fixed BSS and makes placement explicit for embedded
 integrations. Builds that prefer the original static allocation/speed tradeoff
 can compile NanoJPEG with `NJ_DYNAMIC_VLC=0`.
+
+Scan startup tracks which DHT/VLC tables were actually decoded and rejects
+abbreviated JPEG input before entropy decoding if SOS references a missing
+table. This keeps malformed missing-DHT streams on the deterministic
+`NJ_SYNTAX_ERROR` path instead of dereferencing uninitialized dynamic tables.
 
 ## Phase 5: MCU-Row Streaming Decode
 

--- a/src/nanojpeg.c
+++ b/src/nanojpeg.c
@@ -356,6 +356,7 @@ typedef struct _nj_ctx {
     int ncomp;
     nj_component_t comp[3];
     int qtused, qtavail;
+    unsigned char vlctab_avail;
     unsigned char qtab[4][64];
 #if NJ_DYNAMIC_VLC
     nj_vlc_code_t (*vlctab)[NJ_VLC_TABLE_SIZE];
@@ -642,21 +643,21 @@ NJ_INLINE void njDecodeSOF(void) {
 }
 
 NJ_INLINE void njDecodeDHT(void) {
-    int codelen, currcnt, remain, spread, i, j;
+    int codelen, currcnt, remain, spread, table, i, j;
     nj_vlc_code_t *vlc;
     static unsigned char counts[16];
     njDecodeLength();
     njCheckError();
     if (!njEnsureVlcTables()) njThrow(NJ_OUT_OF_MEM);
     while (nj.length >= 17) {
-        i = nj.pos[0];
-        if (i & 0xEC) njThrow(NJ_SYNTAX_ERROR);
-        if (i & 0x02) njThrow(NJ_UNSUPPORTED);
-        i = (i | (i >> 3)) & 3;  // combined DC/AC + tableid value
+        table = nj.pos[0];
+        if (table & 0xEC) njThrow(NJ_SYNTAX_ERROR);
+        if (table & 0x02) njThrow(NJ_UNSUPPORTED);
+        table = (table | (table >> 3)) & 3;  // combined DC/AC + tableid value
         for (codelen = 1;  codelen <= 16;  ++codelen)
             counts[codelen - 1] = nj.pos[codelen];
         njSkip(17);
-        vlc = &nj.vlctab[i][0];
+        vlc = &nj.vlctab[table][0];
         remain = spread = 65536;
         for (codelen = 1;  codelen <= 16;  ++codelen) {
             spread >>= 1;
@@ -679,6 +680,7 @@ NJ_INLINE void njDecodeDHT(void) {
             vlc->bits = 0;
             ++vlc;
         }
+        nj.vlctab_avail |= (unsigned char)(1u << table);
     }
     if (nj.length) njThrow(NJ_SYNTAX_ERROR);
 }
@@ -757,6 +759,8 @@ NJ_INLINE void njDecodeScan(void) {
         if (nj.pos[1] & 0xEE) njThrow(NJ_SYNTAX_ERROR);
         c->dctabsel = nj.pos[1] >> 4;
         c->actabsel = (nj.pos[1] & 1) | 2;
+        if (!(nj.vlctab_avail & (1u << c->dctabsel))) njThrow(NJ_SYNTAX_ERROR);
+        if (!(nj.vlctab_avail & (1u << c->actabsel))) njThrow(NJ_SYNTAX_ERROR);
         njSkip(2);
     }
     if (nj.pos[0] || (nj.pos[1] != 63) || nj.pos[2]) njThrow(NJ_UNSUPPORTED);

--- a/tests/test_jpeg_mcu_rows.c
+++ b/tests/test_jpeg_mcu_rows.c
@@ -116,6 +116,50 @@ static int collect_mcu_row(int mcu_y, void *user)
     return 0;
 }
 
+static int strip_dht_segments(uint8_t *jpeg, size_t *jpeg_size)
+{
+    size_t read_pos = 2u;
+    size_t write_pos = 2u;
+    int removed = 0;
+
+    if (jpeg == NULL || jpeg_size == NULL || *jpeg_size < 4u ||
+        jpeg[0] != 0xffu || jpeg[1] != 0xd8u) {
+        return 0;
+    }
+    while (read_pos + 1u < *jpeg_size) {
+        const uint8_t marker = jpeg[read_pos + 1u];
+        size_t segment_len;
+        size_t total_len;
+
+        if (jpeg[read_pos] != 0xffu) {
+            return 0;
+        }
+        if (marker == 0xdau) {
+            memmove(&jpeg[write_pos], &jpeg[read_pos], *jpeg_size - read_pos);
+            write_pos += *jpeg_size - read_pos;
+            *jpeg_size = write_pos;
+            return removed;
+        }
+        if (read_pos + 4u > *jpeg_size) {
+            return 0;
+        }
+        segment_len = ((size_t)jpeg[read_pos + 2u] << 8) | jpeg[read_pos + 3u];
+        total_len = segment_len + 2u;
+        if (segment_len < 2u || read_pos + total_len > *jpeg_size) {
+            return 0;
+        }
+        if (marker == 0xc4u) {
+            read_pos += total_len;
+            removed = 1;
+            continue;
+        }
+        memmove(&jpeg[write_pos], &jpeg[read_pos], total_len);
+        read_pos += total_len;
+        write_pos += total_len;
+    }
+    return 0;
+}
+
 static int expect_status(const char *name, int got, int expected)
 {
     if (got != expected) {
@@ -274,6 +318,31 @@ static int unsupported_sof_is_deterministic(void)
            expect_int("unsupported callback count", state.row_count, 0);
 }
 
+static int missing_dht_is_deterministic(void)
+{
+    uint8_t jpeg[512];
+    size_t jpeg_size = 0u;
+    row_callback_state_t state;
+    int status;
+
+    if (!hex_to_bytes(k_color_jpeg_hex, jpeg, sizeof(jpeg), &jpeg_size)) {
+        fprintf(stderr, "failed to decode missing-DHT fixture hex\n");
+        return 0;
+    }
+    if (!strip_dht_segments(jpeg, &jpeg_size)) {
+        fprintf(stderr, "failed to strip DHT marker from fixture\n");
+        return 0;
+    }
+
+    memset(&state, 0, sizeof(state));
+    state.fail_after_rows = -1;
+    njInit();
+    status = njDecodeMcuRows(jpeg, (int)jpeg_size, collect_mcu_row, &state);
+    njDone();
+    return expect_status("missing DHT", status, NJ_SYNTAX_ERROR) &&
+           expect_int("missing DHT callback count", state.row_count, 0);
+}
+
 int main(void)
 {
     int ok = 1;
@@ -282,6 +351,7 @@ int main(void)
     ok &= decode_and_check_gray();
     ok &= callback_abort_is_deterministic();
     ok &= unsupported_sof_is_deterministic();
+    ok &= missing_dht_is_deterministic();
 
     return ok ? 0 : 1;
 }


### PR DESCRIPTION
## Summary

- track which NanoJPEG DHT/VLC tables were decoded before SOS processing
- reject SOS references to missing VLC tables with `NJ_SYNTAX_ERROR` before entropy decode
- add an MCU-row regression that strips DHT from a JPEG fixture and verifies deterministic failure without callbacks
- update the NanoJPEG static-BSS object-size table after the guard field

Refs #22

## Validation

- `git diff --check`
- `cmake -S . -B build/issue22-missing-dht`
- `cmake --build build/issue22-missing-dht`
- `ctest --test-dir build/issue22-missing-dht --output-on-failure -R sh264e_jpeg_mcu_rows`
- `ctest --test-dir build/issue22-missing-dht --output-on-failure`
- `arm-none-eabi-gcc -mcpu=cortex-m4 -mthumb -O2 -ffreestanding -fno-builtin -DNJ_USE_LIBC=0 -Iinclude -c src/nanojpeg.c -o build/issue22-missing-dht-size/nanojpeg_dynamic_vlc.o`
- `arm-none-eabi-size -A build/issue22-missing-dht-size/nanojpeg_dynamic_vlc.o` -> `.bss` 752 bytes
- `arm-none-eabi-gcc -mcpu=cortex-m4 -mthumb -O2 -ffreestanding -fno-builtin -DNJ_USE_LIBC=0 -DNJ_DYNAMIC_VLC=0 -Iinclude -c src/nanojpeg.c -o build/issue22-missing-dht-size/nanojpeg_static_vlc.o`
- `arm-none-eabi-size -A build/issue22-missing-dht-size/nanojpeg_static_vlc.o` -> `.bss` 525,036 bytes

QEMU note: CMake still skips QEMU firmware tests in this environment because `arm-none-eabi-gcc` cannot compile `<stdlib.h>`.