### PR TITLE
jpeg: compact NanoJPEG Huffman decode

### DIFF
--- a/MEMORY_REDUCTION_PLAN.md
+++ b/MEMORY_REDUCTION_PLAN.md
@@ -182,52 +182,50 @@ directions:
 * smaller generated-on-demand decode tables
 * build-time option to trade speed for SRAM
 
-Selected implementation direction:
+Interim implementation direction:
 
-* Default to arena-backed/dynamic VLC tables with `NJ_DYNAMIC_VLC=1`.
-* Keep `NJ_DYNAMIC_VLC=0` as a build-time escape hatch for projects that prefer
+* Defaulted to arena-backed/dynamic VLC tables with `NJ_DYNAMIC_VLC=1`.
+* Kept `NJ_DYNAMIC_VLC=0` as a build-time escape hatch for projects that prefer
   the original static-table model.
-* Route the dynamic tables through the existing NanoJPEG allocation shim so
+* Routed the dynamic tables through the existing NanoJPEG allocation shim so
   heap and caller-provided arena paths both report the 524,288-byte table block
   in their work-size/peak-allocation accounting.
+
+Issue #31 supersedes this interim direction by replacing the dynamic 16-bit
+lookup block with compact canonical Huffman decode and `NJ_VLC_FAST_BITS`.
 
 Acceptance criteria:
 
 * Cortex-M object-size report shows reduced fixed SRAM usage.
 * JPEG correctness tests still pass.
 
-### 6. Compact or XIP Huffman Decode Follow-Up
+### 6. Compact Huffman Decode
 
 The static BSS reduction moved the 524,288-byte VLC table block out of fixed
-SRAM, but it still appears in decode-time arena peak allocation. For
-`2560x1440` 4:2:0, the current production peak is:
+SRAM, but it still appeared in decode-time arena peak allocation. Issue #31
+replaced the 16-bit SRAM VLC lookup block with canonical Huffman metadata plus
+a configurable small fast table. With default `NJ_VLC_FAST_BITS=8`, the
+`2560x1440` 4:2:0 production peak is now:
 
 ```text
-524,288 bytes  dynamic NanoJPEG VLC tables
 184,320 bytes  streaming retained row cache
  61,440 bytes  NanoJPEG MCU-row temp buffers
 ----------
-770,048 bytes  tracked peak allocation
+245,760 bytes  tracked peak allocation
 ```
 
-The row-cache memory target is met. The next target is to replace the 16-bit
-SRAM VLC lookup tables with a compact Huffman representation and optional
-XIP-friendly standard-Huffman fast path.
-
-Preferred direction:
+Implemented direction:
 
 * Store canonical Huffman metadata for custom DHT tables.
 * Use a small configurable fast table, for example `NJ_VLC_FAST_BITS=8` or
   `NJ_VLC_FAST_BITS=10`, with a slow fallback for longer codes.
-* Optionally add const precomputed standard-Huffman tables that can live in
-  flash/XIP for controlled JPEG sources.
-* Keep custom-DHT JPEG support unless a build option explicitly selects
-  standard-Huffman-only behavior.
+* Keep custom-DHT JPEG support instead of requiring standard-Huffman-only input.
+* Do not allocate VLC/Huffman tables through the caller arena.
 
 Acceptance criteria:
 
-* `2560x1440` 4:2:0 production peak allocation drops below 270 KiB.
-* `jpeg streaming cache bytes` remains 184,320 unless intentionally remeasured.
+* `2560x1440` 4:2:0 production peak allocation is 245,760 bytes, below 270 KiB.
+* `jpeg streaming cache bytes` remains 184,320.
 * Production encode does not regress to the old 5,529,600-byte full
   component-plane allocation.
 * Strict ffmpeg decode and full CTest remain green.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Encode a baseline JPEG memory-input path through the library wrapper:
 The JPEG path uses NanoJPEG inside the core library. The tool only reads the JPEG file; the library API accepts a caller-provided JPEG byte buffer and emits H.264 into a caller-provided output buffer.
 The tool sizes a caller-provided JPEG decoder arena with `sh264e_jpeg_get_work_size`, passes that arena to `sh264e_encode_jpeg_idr_with_arena`, and prints the arena requirement plus current and peak NanoJPEG allocation bytes reported by `sh264e_jpeg_get_last_allocation_stats`.
 The arena-backed production path now uses MCU-row streaming by default. It keeps only NanoJPEG's current MCU-row buffers and the retained row cache, then feeds one scaled output slice at a time to the progressive encoder.
-The printed peak allocation includes the dynamic NanoJPEG VLC table block, streaming row cache, and MCU-row temp buffers; it excludes caller-owned JPEG input, arena header overhead, slice-work, and H.264 output buffers.
+The printed peak allocation includes the streaming row cache and MCU-row temp buffers; it excludes caller-owned JPEG input, arena header overhead, slice-work, H.264 output buffers, and NanoJPEG's compact in-context Huffman metadata.
 The hidden `--streaming-prototype` flag remains as a debug/comparison path for the same MCU-row streaming machinery.
 The heap-backed convenience wrapper still exists for non-deterministic host usage, but embedded integrations should prefer the arena-backed entry point.
 

--- a/SPACE_REDUCTION.md
+++ b/SPACE_REDUCTION.md
@@ -222,11 +222,12 @@ NanoJPEG originally stored four fully expanded Huffman/VLC decode tables inside
 its static global context. For Cortex-M builds, that made `src/nanojpeg.c`
 reserve about 525 KiB of fixed BSS before any JPEG was decoded.
 
-The selected production-safe tradeoff is to allocate those VLC tables through
-the existing `njAllocMem` shim the first time a DHT marker is decoded. This
-keeps the public JPEG encode API unchanged and lets the heap-backed and
-caller-provided arena paths account for the table memory in the same way they
-already account for decoded component planes and row caches.
+The first production-safe tradeoff allocated those VLC tables through the
+existing `njAllocMem` shim, which removed fixed BSS but moved the same 524,288
+bytes into per-decode heap/arena peak. Issue #31 replaces that interim model
+with compact canonical Huffman metadata and a small configurable fast table
+inside the NanoJPEG context. This keeps the public JPEG encode API unchanged,
+keeps custom DHT support, and avoids the 524 KiB caller-arena allocation.
 
 Measured with:
 
@@ -238,14 +239,14 @@ arm-none-eabi-size -A nanojpeg.o
 
 | Build mode | `.text` | `.bss` | Notes |
 | --- | ---: | ---: | --- |
-| Static VLC tables, `NJ_DYNAMIC_VLC=0` | 5,920 | 525,036 | Original fixed SRAM model |
-| Dynamic VLC tables, default `NJ_DYNAMIC_VLC=1` | 5,864 | 752 | VLC tables move to tracked JPEG allocation |
+| Former static VLC tables, `NJ_DYNAMIC_VLC=0` | 5,920 | 525,036 | Original fixed SRAM model |
+| Former dynamic VLC tables, `NJ_DYNAMIC_VLC=1` | 5,864 | 752 | VLC tables moved to tracked JPEG allocation |
+| Compact Huffman, default `NJ_VLC_FAST_BITS=8` | 6,320 | 4,492 | No 524 KiB VLC arena allocation |
 
-The dynamic table block is `4 * 65,536 * sizeof(nj_vlc_code_t)`, currently
-524,288 bytes. This increases per-decode heap/arena work size by that amount,
-but removes it from fixed BSS and makes placement explicit for embedded
-integrations. Builds that prefer the original static allocation/speed tradeoff
-can compile NanoJPEG with `NJ_DYNAMIC_VLC=0`.
+The removed expanded table block was `4 * 65,536 * sizeof(nj_vlc_code_t)`, or
+524,288 bytes. The compact decoder instead stores canonical min/max ranges,
+symbol order, and an `NJ_VLC_FAST_BITS` short-code table for each JPEG Huffman
+table, with canonical fallback for longer codes.
 
 Scan startup tracks which DHT/VLC tables were actually decoded and rejects
 abbreviated JPEG input before entropy decoding if SOS references a missing
@@ -310,27 +311,25 @@ path no longer requires the previous full decoded component planes:
 
 | Source JPEG | Previous full component planes | Production arena work | Production peak allocation | Streaming row cache |
 | --- | ---: | ---: | ---: | ---: |
-| 1280x720 4:2:0 | 1,382,400 | 616,616 | 616,448 | 61,440 |
-| 2560x1440 4:2:0 | 5,529,600 | 770,216 | 770,048 | 184,320 |
+| 1280x720 4:2:0 | 1,382,400 | 92,304 | 92,160 | 61,440 |
+| 2560x1440 4:2:0 | 5,529,600 | 245,904 | 245,760 | 184,320 |
 
-The production peak includes the dynamically allocated NanoJPEG VLC table block,
-which is now caller-arena-accounted instead of fixed BSS.
+The production peak no longer includes the previous 524,288-byte NanoJPEG VLC
+lookup block. NanoJPEG stores compact canonical Huffman metadata in its decoder
+context and uses a small `NJ_VLC_FAST_BITS` fast table plus canonical fallback
+for longer codes.
 
 Current `2560x1440` 4:2:0 production peak allocation breaks down as:
 
 | Block | Bytes |
 | --- | ---: |
-| Dynamic NanoJPEG VLC tables | 524,288 |
 | Streaming retained row cache | 184,320 |
 | NanoJPEG MCU-row temp buffers | 61,440 |
-| Total tracked peak allocation | 770,048 |
+| Total tracked peak allocation | 245,760 |
 
-The row streaming work met the decoded-image cache target. The remaining arena
-peak is dominated by the 16-bit VLC lookup tables. The next memory reduction
-step is tracked by issue #31: replace those SRAM tables with compact Huffman
-decode and, optionally, an XIP-friendly standard-Huffman fast path. The target
-is to reduce `2560x1440` 4:2:0 production peak allocation below 270 KiB without
-regressing to full component-plane decode.
+Issue #31 reduced the `2560x1440` 4:2:0 production peak below the 270 KiB target
+without increasing the 184,320-byte row cache or regressing to full
+component-plane decode.
 
 ### Current Production Boundary
 

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -199,16 +199,15 @@ slice work buffer as the component-plane path.
 
 The production memory regression report in
 `docs/JPEG_STREAMING_MEMORY_REPORT.md` records the measured default arena path:
-`1280x720` 4:2:0 uses 616,616 bytes of JPEG work arena and `2560x1440` 4:2:0
-uses 770,216 bytes, including the dynamic NanoJPEG VLC table block.
+`1280x720` 4:2:0 uses 92,304 bytes of JPEG work arena and `2560x1440` 4:2:0
+uses 245,904 bytes.
 
 That arena size is no longer dominated by decoded image storage. The
-`2560x1440` 4:2:0 row cache is 184,320 bytes, while the dynamic NanoJPEG VLC
-tables account for 524,288 bytes of the 770,048-byte tracked peak allocation.
-Issue #31 tracks replacing the 16-bit SRAM VLC tables with compact Huffman
-decode and optional XIP-friendly standard-Huffman tables. The target is to bring
-the same production path below 270 KiB peak allocation while keeping the
-184,320-byte row cache stable.
+`2560x1440` 4:2:0 row cache is 184,320 bytes. Issue #31 replaced the previous
+524,288-byte 16-bit SRAM VLC table block with compact canonical Huffman metadata
+and a small configurable fast table, bringing the same production path to
+245,760 bytes of tracked peak allocation while keeping the 184,320-byte row
+cache stable.
 
 ## Validation Plan
 

--- a/docs/JPEG_STREAMING_MEMORY_REPORT.md
+++ b/docs/JPEG_STREAMING_MEMORY_REPORT.md
@@ -12,30 +12,27 @@ from the earlier allocation report. The production measurements below are from
 
 | Source JPEG | Previous full component planes | Production arena work | Production peak allocation | Streaming row cache | Slice work buffer |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| 1280x720 4:2:0 | 1,382,400 | 616,616 | 616,448 | 61,440 | 61,440 |
-| 2560x1440 4:2:0 | 5,529,600 | 770,216 | 770,048 | 184,320 | 61,440 |
+| 1280x720 4:2:0 | 1,382,400 | 92,304 | 92,160 | 61,440 | 61,440 |
+| 2560x1440 4:2:0 | 5,529,600 | 245,904 | 245,760 | 184,320 | 61,440 |
 
-`Production peak allocation` includes the dynamic NanoJPEG VLC table block
-introduced by the static-BSS reduction work. That block is tracked through the
-same JPEG allocation shim as the row cache so embedded integrations can place it
-in the caller-provided arena. The streaming row cache is the decoded-image
-replacement for the previous full component planes.
+`Production peak allocation` now excludes the previous dynamic NanoJPEG VLC
+lookup block. NanoJPEG decodes DHT tables into compact canonical Huffman
+metadata in the decoder context, uses a small `NJ_VLC_FAST_BITS` fast table for
+short codes, and falls back to canonical range lookup for longer codes. The
+streaming row cache is the decoded-image replacement for the previous full
+component planes.
 
 For the `2560x1440` 4:2:0 row, the measured peak breaks down as:
 
 | Block | Bytes |
 | --- | ---: |
-| Dynamic NanoJPEG VLC tables | 524,288 |
 | Streaming retained row cache | 184,320 |
 | NanoJPEG MCU-row temp buffers | 61,440 |
-| Total tracked peak allocation | 770,048 |
+| Total tracked peak allocation | 245,760 |
 
-The row cache target has been met. The next memory bottleneck is the dynamic
-VLC table block. Issue #31 tracks replacing the 16-bit SRAM VLC lookup tables
-with compact Huffman decode and, where appropriate, an XIP-friendly standard
-Huffman fast path. The target for `2560x1440` 4:2:0 is to reduce production peak
-allocation below 270 KiB without increasing the 184,320-byte row cache or
-regressing to full component-plane decode.
+Issue #31 reduced production peak allocation below the 270 KiB target without
+increasing the 184,320-byte row cache or regressing to full component-plane
+decode. Custom DHT baseline JPEGs remain supported.
 
 ## Regression Coverage
 

--- a/src/nanojpeg.c
+++ b/src/nanojpeg.c
@@ -84,11 +84,9 @@
 //                           (default).
 // NJ_CHROMA_FILTER=0      = Use simple pixel repetition for chroma upsampling
 //                           (bad quality, but faster and less code).
-// NJ_DYNAMIC_VLC=1        = Allocate Huffman/VLC decode tables at decode time
-//                           through njAllocMem() instead of keeping them in
-//                           NanoJPEG's static context (default).
-// NJ_DYNAMIC_VLC=0        = Keep VLC tables in static BSS for the original
-//                           NanoJPEG speed/static-allocation tradeoff.
+// NJ_VLC_FAST_BITS=8      = Use a small per-Huffman-table fast decode table
+//                           for codes up to this bit length, with canonical
+//                           Huffman fallback for longer codes (default).
 
 
 // API
@@ -218,8 +216,12 @@ void njDone(void);
     #define NJ_CHROMA_FILTER 1
 #endif
 
-#ifndef NJ_DYNAMIC_VLC
-    #define NJ_DYNAMIC_VLC 1
+#ifndef NJ_VLC_FAST_BITS
+    #define NJ_VLC_FAST_BITS 8
+#endif
+
+#if NJ_VLC_FAST_BITS > 10
+    #error "NJ_VLC_FAST_BITS is intentionally capped at 10 to avoid large SRAM tables"
 #endif
 
 
@@ -331,8 +333,15 @@ typedef struct _nj_code {
 } nj_vlc_code_t;
 
 #define NJ_VLC_TABLE_COUNT 4
-#define NJ_VLC_TABLE_SIZE 65536
-#define NJ_VLC_TABLE_BYTES (NJ_VLC_TABLE_COUNT * NJ_VLC_TABLE_SIZE * (int) sizeof(nj_vlc_code_t))
+#define NJ_VLC_FAST_SIZE (1 << NJ_VLC_FAST_BITS)
+
+typedef struct _nj_huff {
+    unsigned char symbols[256];
+    unsigned short first_symbol[17];
+    int mincode[17];
+    int maxcode[17];
+    nj_vlc_code_t fast[NJ_VLC_FAST_SIZE];
+} nj_huff_table_t;
 
 typedef struct _nj_cmp {
     int cid;
@@ -358,11 +367,7 @@ typedef struct _nj_ctx {
     int qtused, qtavail;
     unsigned char vlctab_avail;
     unsigned char qtab[4][64];
-#if NJ_DYNAMIC_VLC
-    nj_vlc_code_t (*vlctab)[NJ_VLC_TABLE_SIZE];
-#else
-    nj_vlc_code_t vlctab[NJ_VLC_TABLE_COUNT][NJ_VLC_TABLE_SIZE];
-#endif
+    nj_huff_table_t vlctab[NJ_VLC_TABLE_COUNT];
     int buf, bufbits;
     int block[64];
     int rstinterval;
@@ -488,28 +493,14 @@ NJ_INLINE void njColIDCT(const int* blk, unsigned char *out, int stride) {
 #define njThrow(e) do { nj.error = e; return; } while (0)
 #define njCheckError() do { if (nj.error) return; } while (0)
 
-#if NJ_DYNAMIC_VLC
-NJ_INLINE void njFreeVlcTables(void) {
-    if (nj.vlctab) {
-        njFreeMem((void*) nj.vlctab);
-        nj.vlctab = NULL;
-    }
-}
-
-NJ_INLINE int njEnsureVlcTables(void) {
-    if (!nj.vlctab) {
-        nj.vlctab = (nj_vlc_code_t (*)[NJ_VLC_TABLE_SIZE])
-            njAllocMem(NJ_VLC_TABLE_BYTES);
-        if (nj.vlctab) {
-            njFillMem((void*) nj.vlctab, 0, NJ_VLC_TABLE_BYTES);
-        }
-    }
-    return nj.vlctab != NULL;
-}
-#else
 NJ_INLINE void njFreeVlcTables(void) { }
-NJ_INLINE int njEnsureVlcTables(void) { return 1; }
-#endif
+
+NJ_INLINE void njResetHuffTable(nj_huff_table_t *tab) {
+    int i;
+    njFillMem(tab, 0, sizeof(*tab));
+    for (i = 0; i <= 16; ++i)
+        tab->maxcode[i] = -1;
+}
 
 static int njShowBits(int bits) {
     unsigned char newbyte;
@@ -643,12 +634,12 @@ NJ_INLINE void njDecodeSOF(void) {
 }
 
 NJ_INLINE void njDecodeDHT(void) {
-    int codelen, currcnt, remain, spread, table, i, j;
-    nj_vlc_code_t *vlc;
-    static unsigned char counts[16];
+    int codelen, currcnt, remain, table, i, j;
+    int code = 0, symbol_index = 0;
+    nj_huff_table_t *huff;
+    unsigned char counts[16];
     njDecodeLength();
     njCheckError();
-    if (!njEnsureVlcTables()) njThrow(NJ_OUT_OF_MEM);
     while (nj.length >= 17) {
         table = nj.pos[0];
         if (table & 0xEC) njThrow(NJ_SYNTAX_ERROR);
@@ -657,28 +648,40 @@ NJ_INLINE void njDecodeDHT(void) {
         for (codelen = 1;  codelen <= 16;  ++codelen)
             counts[codelen - 1] = nj.pos[codelen];
         njSkip(17);
-        vlc = &nj.vlctab[table][0];
-        remain = spread = 65536;
+        huff = &nj.vlctab[table];
+        njResetHuffTable(huff);
+        remain = 65536;
+        code = 0;
+        symbol_index = 0;
         for (codelen = 1;  codelen <= 16;  ++codelen) {
-            spread >>= 1;
             currcnt = counts[codelen - 1];
-            if (!currcnt) continue;
-            if (nj.length < currcnt) njThrow(NJ_SYNTAX_ERROR);
             remain -= currcnt << (16 - codelen);
             if (remain < 0) njThrow(NJ_SYNTAX_ERROR);
+            if (!currcnt) {
+                code <<= 1;
+                continue;
+            }
+            if (nj.length < currcnt) njThrow(NJ_SYNTAX_ERROR);
+            if (symbol_index > 256 - currcnt) njThrow(NJ_SYNTAX_ERROR);
+            huff->mincode[codelen] = code;
+            huff->maxcode[codelen] = code + currcnt - 1;
+            huff->first_symbol[codelen] = (unsigned short)symbol_index;
             for (i = 0;  i < currcnt;  ++i) {
-                register unsigned char code = nj.pos[i];
-                for (j = spread;  j;  --j) {
-                    vlc->bits = (unsigned char) codelen;
-                    vlc->code = code;
-                    ++vlc;
+                register unsigned char symbol = nj.pos[i];
+                const int huff_code = huff->mincode[codelen] + i;
+                huff->symbols[symbol_index + i] = symbol;
+                if (codelen <= NJ_VLC_FAST_BITS) {
+                    const int spread = 1 << (NJ_VLC_FAST_BITS - codelen);
+                    const int base = huff_code << (NJ_VLC_FAST_BITS - codelen);
+                    for (j = 0; j < spread; ++j) {
+                        huff->fast[base + j].bits = (unsigned char)codelen;
+                        huff->fast[base + j].code = symbol;
+                    }
                 }
             }
+            symbol_index += currcnt;
+            code = (code + currcnt) << 1;
             njSkip(currcnt);
-        }
-        while (remain--) {
-            vlc->bits = 0;
-            ++vlc;
         }
         nj.vlctab_avail |= (unsigned char)(1u << table);
     }
@@ -710,12 +713,32 @@ NJ_INLINE void njDecodeDRI(void) {
     njSkip(nj.length);
 }
 
-static int njGetVLC(nj_vlc_code_t* vlc, unsigned char* code) {
-    int value = njShowBits(16);
-    int bits = vlc[value].bits;
-    if (!bits) { nj.error = NJ_SYNTAX_ERROR; return 0; }
-    njSkipBits(bits);
-    value = vlc[value].code;
+static int njGetVLC(nj_huff_table_t* huff, unsigned char* code) {
+    int value;
+    int bits;
+    int codelen;
+
+    value = njShowBits(NJ_VLC_FAST_BITS);
+    bits = huff->fast[value].bits;
+    if (bits) {
+        njSkipBits(bits);
+        value = huff->fast[value].code;
+    } else {
+        const int raw = njShowBits(16);
+        for (codelen = NJ_VLC_FAST_BITS + 1; codelen <= 16; ++codelen) {
+            const int prefix = raw >> (16 - codelen);
+            if ((huff->maxcode[codelen] >= 0) && (prefix >= huff->mincode[codelen]) &&
+                (prefix <= huff->maxcode[codelen])) {
+                const int index = huff->first_symbol[codelen] + prefix - huff->mincode[codelen];
+                njSkipBits(codelen);
+                value = huff->symbols[index];
+                goto have_symbol;
+            }
+        }
+        nj.error = NJ_SYNTAX_ERROR;
+        return 0;
+    }
+have_symbol:
     if (code) *code = (unsigned char) value;
     bits = value & 15;
     if (!bits) return 0;
@@ -729,10 +752,10 @@ NJ_INLINE void njDecodeBlock(nj_component_t* c, unsigned char* out) {
     unsigned char code = 0;
     int value, coef = 0;
     njFillMem(nj.block, 0, sizeof(nj.block));
-    c->dcpred += njGetVLC(&nj.vlctab[c->dctabsel][0], NULL);
+    c->dcpred += njGetVLC(&nj.vlctab[c->dctabsel], NULL);
     nj.block[0] = (c->dcpred) * nj.qtab[c->qtsel][0];
     do {
-        value = njGetVLC(&nj.vlctab[c->actabsel][0], &code);
+        value = njGetVLC(&nj.vlctab[c->actabsel], &code);
         if (!code) break;  // EOB
         if (!(code & 0x0F) && (code != 0xF0)) njThrow(NJ_SYNTAX_ERROR);
         coef += (code >> 4) + 1;

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -24,13 +24,13 @@ FULL_COMPONENT_BYTES_720P = {
 }
 FULL_COMPONENT_BYTES_1440P_420 = 5_529_600
 PRODUCTION_MEMORY_720P_420 = {
-    "work": 616_616,
-    "peak": 616_448,
+    "work": 92_304,
+    "peak": 92_160,
     "cache": STREAMING_CACHE_BYTES_720P["yuvj420p"],
 }
 PRODUCTION_MEMORY_1440P_420 = {
-    "work": 770_216,
-    "peak": 770_048,
+    "work": 245_904,
+    "peak": 245_760,
     "cache": STREAMING_CACHE_BYTES_1440P_420,
 }
 


### PR DESCRIPTION
## Summary

- replace NanoJPEG's four 65,536-entry writable VLC lookup tables with compact canonical Huffman metadata and a configurable `NJ_VLC_FAST_BITS` short-code table
- keep custom DHT support and the existing missing-DHT deterministic rejection path
- update JPEG memory regression expectations and docs for the new production arena peak below 270 KiB

Refs #31

## Validation

- `git diff --check`
- `cmake -S . -B build/issue31`
- `cmake --build build/issue31`
- `ctest --test-dir build/issue31 --output-on-failure -R sh264e_ffmpeg_integration`
- `ctest --test-dir build/issue31 --output-on-failure`
- `arm-none-eabi-gcc -mcpu=cortex-m4 -mthumb -O2 -ffreestanding -fno-builtin -DNJ_USE_LIBC=0 -Iinclude -c src/nanojpeg.c -o build/issue31/nanojpeg_compact_huffman.o`
- `arm-none-eabi-size -A build/issue31/nanojpeg_compact_huffman.o` -> `.text` 6320, `.bss` 4492
- `cc -O2 -DNJ_USE_LIBC=0 -DNJ_VLC_FAST_BITS=10 -Iinclude -c src/nanojpeg.c -o build/issue31/nanojpeg_fast10_host.o`

QEMU note: CMake skipped QEMU firmware tests in this environment because `arm-none-eabi-gcc` cannot compile `<stdlib.h>`.

## Memory Results

- `1280x720` 4:2:0 production peak: `92,160` bytes; work arena: `92,304` bytes; row cache: `61,440` bytes
- `2560x1440` 4:2:0 production peak: `245,760` bytes; work arena: `245,904` bytes; row cache: `184,320` bytes
