### PR TITLE
docs: update JPEG compact Huffman metrics

### DIFF
--- a/docs/JPEG_STREAMING_MEMORY_REPORT.md
+++ b/docs/JPEG_STREAMING_MEMORY_REPORT.md
@@ -71,16 +71,12 @@ Expected metric lines:
 
 ```text
 1280x720:
-jpeg work arena bytes: 616616
-jpeg peak allocation bytes: 616448
+jpeg work arena bytes: 92304
+jpeg peak allocation bytes: 92160
 jpeg streaming cache bytes: 61440
 
 2560x1440:
-jpeg work arena bytes: 770216
-jpeg peak allocation bytes: 770048
+jpeg work arena bytes: 245904
+jpeg peak allocation bytes: 245760
 jpeg streaming cache bytes: 184320
 ```
-
-After issue #31 lands, these expected peak/work values should be updated while
-keeping the row-cache value stable unless the row-cache algorithm is
-intentionally changed and remeasured.


### PR DESCRIPTION
## Summary

- update `docs/JPEG_STREAMING_MEMORY_REPORT.md` manual expected output for the compact-Huffman metrics from PR #32
- remove the stale future-tense note about updating values after issue #31 lands

Refs #31

## Validation

- `git diff --check`
- `rg -n "616616|616448|770216|770048|After issue #31|after issue #31|issue #31 lands" docs/JPEG_STREAMING_MEMORY_REPORT.md || true`

This is a docs-only follow-up requested by PM after PR #32 merged.
