### PR TITLE
jpeg: add output consumer API

### DIFF
--- a/include/sh264e.h
+++ b/include/sh264e.h
@@ -65,6 +65,10 @@ typedef struct sh264e_jpeg_allocation_stats_t {
 
 typedef struct sh264e_encoder_t sh264e_encoder_t;
 
+typedef sh264e_status_t (*sh264e_output_consumer_t)(void *user,
+                                                    const uint8_t *data,
+                                                    size_t size);
+
 sh264e_status_t sh264e_encoder_create(const sh264e_config_t *config,
                                       sh264e_encoder_t **out_encoder);
 
@@ -134,6 +138,19 @@ sh264e_status_t sh264e_encode_jpeg_idr_with_arena(sh264e_encoder_t *encoder,
                                                   uint8_t *out,
                                                   size_t out_capacity,
                                                   size_t *out_size);
+
+sh264e_status_t sh264e_encode_jpeg_idr_with_arena_stream(
+    sh264e_encoder_t *encoder,
+    const uint8_t *jpeg_data,
+    size_t jpeg_size,
+    uint8_t *jpeg_arena,
+    size_t jpeg_arena_size,
+    uint8_t *work_buffer,
+    size_t work_buffer_capacity,
+    uint8_t *out_buffer,
+    size_t out_buffer_capacity,
+    sh264e_output_consumer_t consumer,
+    void *consumer_user);
 
 const char *sh264e_status_string(sh264e_status_t status);
 

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -91,6 +91,8 @@ typedef struct sh264e_jpeg_stream_context_t {
     uint8_t *out;
     size_t out_capacity;
     size_t offset;
+    sh264e_output_consumer_t consumer;
+    void *consumer_user;
     size_t cache_bytes;
     unsigned next_slice;
     unsigned idr_started;
@@ -145,7 +147,9 @@ static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *e
                                                              size_t work_buffer_capacity,
                                                              uint8_t *out,
                                                              size_t out_capacity,
-                                                             size_t *out_size);
+                                                             size_t *out_size,
+                                                             sh264e_output_consumer_t consumer,
+                                                             void *consumer_user);
 
 static const uint8_t k_luma4x4_x[16] = {
     0, 4, 0, 4, 8, 12, 8, 12, 0, 4, 0, 4, 8, 12, 8, 12
@@ -1105,6 +1109,39 @@ static sh264e_status_t streaming_copy_current_mcu_row(sh264e_jpeg_stream_context
     return SH264E_OK;
 }
 
+static uint8_t *streaming_output_ptr(sh264e_jpeg_stream_context_t *ctx)
+{
+    if (ctx->consumer != NULL) {
+        return ctx->out;
+    }
+    return ctx->out + ctx->offset;
+}
+
+static size_t streaming_output_capacity(const sh264e_jpeg_stream_context_t *ctx)
+{
+    if (ctx->consumer != NULL) {
+        return ctx->out_capacity;
+    }
+    if (ctx->offset > ctx->out_capacity) {
+        return 0u;
+    }
+    return ctx->out_capacity - ctx->offset;
+}
+
+static sh264e_status_t streaming_emit_output(sh264e_jpeg_stream_context_t *ctx, size_t bytes)
+{
+    sh264e_status_t status;
+
+    if (ctx->consumer != NULL) {
+        status = ctx->consumer(ctx->consumer_user, ctx->out, bytes);
+        if (status != SH264E_OK) {
+            return status;
+        }
+    }
+    ctx->offset += bytes;
+    return SH264E_OK;
+}
+
 static int streaming_mcu_row_ready(int mcu_y, void *user)
 {
     sh264e_jpeg_stream_context_t *ctx = (sh264e_jpeg_stream_context_t *)user;
@@ -1128,11 +1165,16 @@ static int streaming_mcu_row_ready(int mcu_y, void *user)
     }
     if (!ctx->idr_started) {
         size_t bytes = 0u;
-        ctx->status = sh264e_begin_idr(ctx->encoder, ctx->out, ctx->out_capacity, &bytes);
+        ctx->status = sh264e_begin_idr(ctx->encoder,
+                                       streaming_output_ptr(ctx),
+                                       streaming_output_capacity(ctx),
+                                       &bytes);
+        if (ctx->status == SH264E_OK) {
+            ctx->status = streaming_emit_output(ctx, bytes);
+        }
         if (ctx->status != SH264E_OK) {
             return 1;
         }
-        ctx->offset += bytes;
         ctx->idr_started = 1u;
     }
 
@@ -1147,13 +1189,15 @@ static int streaming_mcu_row_ready(int mcu_y, void *user)
             streaming_make_nv12_slice(ctx, ctx->next_slice, &slice);
         }
         ctx->status = sh264e_encode_idr_slice(ctx->encoder, &slice,
-                                              ctx->out + ctx->offset,
-                                              ctx->out_capacity - ctx->offset,
+                                              streaming_output_ptr(ctx),
+                                              streaming_output_capacity(ctx),
                                               &bytes);
+        if (ctx->status == SH264E_OK) {
+            ctx->status = streaming_emit_output(ctx, bytes);
+        }
         if (ctx->status != SH264E_OK) {
             return 1;
         }
-        ctx->offset += bytes;
         ctx->next_slice++;
     }
     return 0;
@@ -2301,7 +2345,34 @@ sh264e_status_t sh264e_encode_jpeg_idr_with_arena(sh264e_encoder_t *encoder,
     return sh264e_encode_jpeg_idr_streaming_impl(encoder, jpeg_data, jpeg_size,
                                                  jpeg_arena, jpeg_arena_size, 1,
                                                  work_buffer, work_buffer_capacity,
-                                                 out, out_capacity, out_size);
+                                                 out, out_capacity, out_size,
+                                                 NULL, NULL);
+}
+
+sh264e_status_t sh264e_encode_jpeg_idr_with_arena_stream(
+    sh264e_encoder_t *encoder,
+    const uint8_t *jpeg_data,
+    size_t jpeg_size,
+    uint8_t *jpeg_arena,
+    size_t jpeg_arena_size,
+    uint8_t *work_buffer,
+    size_t work_buffer_capacity,
+    uint8_t *out_buffer,
+    size_t out_buffer_capacity,
+    sh264e_output_consumer_t consumer,
+    void *consumer_user)
+{
+    size_t ignored_size = 0u;
+
+    if (consumer == NULL) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+    return sh264e_encode_jpeg_idr_streaming_impl(encoder, jpeg_data, jpeg_size,
+                                                 jpeg_arena, jpeg_arena_size, 1,
+                                                 work_buffer, work_buffer_capacity,
+                                                 out_buffer, out_buffer_capacity,
+                                                 &ignored_size,
+                                                 consumer, consumer_user);
 }
 
 size_t sh264e_jpeg_get_last_streaming_cache_bytes(void)
@@ -2326,7 +2397,9 @@ static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *e
                                                              size_t work_buffer_capacity,
                                                              uint8_t *out,
                                                              size_t out_capacity,
-                                                             size_t *out_size)
+                                                             size_t *out_size,
+                                                             sh264e_output_consumer_t consumer,
+                                                             void *consumer_user)
 {
     sh264e_jpeg_stream_context_t ctx;
     sh264e_status_t status;
@@ -2360,6 +2433,8 @@ static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *e
     ctx.work_buffer = work_buffer;
     ctx.out = out;
     ctx.out_capacity = out_capacity;
+    ctx.consumer = consumer;
+    ctx.consumer_user = consumer_user;
     ctx.status = SH264E_OK;
 
     if (use_arena != 0) {
@@ -2406,7 +2481,8 @@ sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype(sh264e_encoder_t *enc
     return sh264e_encode_jpeg_idr_streaming_impl(encoder, jpeg_data, jpeg_size,
                                                  NULL, 0u, 0,
                                                  work_buffer, work_buffer_capacity,
-                                                 out, out_capacity, out_size);
+                                                 out, out_capacity, out_size,
+                                                 NULL, NULL);
 }
 
 sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype_with_arena(sh264e_encoder_t *encoder,
@@ -2423,7 +2499,8 @@ sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype_with_arena(sh264e_enc
     return sh264e_encode_jpeg_idr_streaming_impl(encoder, jpeg_data, jpeg_size,
                                                  jpeg_arena, jpeg_arena_size, 1,
                                                  work_buffer, work_buffer_capacity,
-                                                 out, out_capacity, out_size);
+                                                 out, out_capacity, out_size,
+                                                 NULL, NULL);
 }
 
 sh264e_status_t sh264e_encoder_create(const sh264e_config_t *config,

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -33,6 +33,8 @@ PRODUCTION_MEMORY_1440P_420 = {
     "peak": 245_760,
     "cache": STREAMING_CACHE_BYTES_1440P_420,
 }
+H264_OUTPUT_CONSUMER_CHUNKS = 1 + 90
+H264_OUTPUT_CHUNK_BYTES = 126_976
 
 
 def run(cmd):
@@ -361,6 +363,29 @@ def encode_jpeg_streaming_prototype(args, fmt, jpeg_input, bitstream, expected_c
         )
 
 
+def encode_jpeg_output_consumer(args, fmt, jpeg_input, bitstream):
+    result = run_capture([
+        args.jpeg_encoder,
+        "--test-output-consumer",
+        "--format",
+        fmt,
+        str(jpeg_input),
+        str(bitstream),
+    ])
+    chunks = parse_jpeg_metric(result.stdout, "jpeg output consumer chunks:")
+    if chunks != H264_OUTPUT_CONSUMER_CHUNKS:
+        raise RuntimeError(
+            f"JPEG output consumer chunk count changed: got {chunks}, expected {H264_OUTPUT_CONSUMER_CHUNKS}"
+        )
+    chunk_bytes = parse_jpeg_metric(result.stdout, "jpeg output chunk buffer bytes:")
+    if chunk_bytes != H264_OUTPUT_CHUNK_BYTES:
+        raise RuntimeError(
+            f"JPEG output consumer chunk capacity changed: got {chunk_bytes}, expected {H264_OUTPUT_CHUNK_BYTES}"
+        )
+    if "jpeg current allocation bytes: 0" not in result.stdout:
+        raise RuntimeError(f"JPEG output consumer leaked tracked allocations: {result.stdout!r}")
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--encoder", required=True)
@@ -485,6 +510,21 @@ def main():
                         max_peak_bytes=FULL_COMPONENT_BYTES_720P[pix_fmt],
                         expected_work_bytes=expected_work,
                         expected_peak_bytes=expected_peak)
+            if pix_fmt == "yuvj420p" and fmt == "i420":
+                consumer_output = workdir / "output_jpeg_consumer_yuvj420p_i420.h264"
+                encode_jpeg_output_consumer(args, fmt, jpeg_input, consumer_output)
+                validate_bitstream(args.ffprobe, args.ffmpeg, consumer_output)
+                if consumer_output.read_bytes() != jpeg_output.read_bytes():
+                    raise RuntimeError("JPEG output consumer bitstream differs from one-shot output")
+                run_expect_fail([
+                    args.jpeg_encoder,
+                    "--test-output-consumer-fail-after",
+                    "1",
+                    "--format",
+                    fmt,
+                    str(jpeg_input),
+                    str(workdir / "output_jpeg_consumer_fail.h264"),
+                ], stderr_contains="internal error")
             encode_jpeg_streaming_prototype(args, fmt, jpeg_input, streaming_output,
                                             STREAMING_CACHE_BYTES_720P[pix_fmt])
             validate_bitstream(args.ffprobe, args.ffmpeg, jpeg_output)

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -213,6 +213,10 @@ int main(void)
                         sh264e_encode_jpeg_idr_with_arena(NULL, NULL, 0u, NULL, 0u,
                                                           NULL, 0u, NULL, 0u, NULL),
                         SH264E_ERR_INVALID_ARGUMENT);
+    ok &= expect_status("null JPEG stream consumer",
+                        sh264e_encode_jpeg_idr_with_arena_stream(NULL, NULL, 0u, NULL, 0u,
+                                                                 NULL, 0u, NULL, 0u, NULL, NULL),
+                        SH264E_ERR_INVALID_ARGUMENT);
     jpeg_alloc_stats.current_bytes = 123u;
     jpeg_alloc_stats.peak_bytes = 456u;
     ok &= expect_status("initial JPEG allocation stats",

--- a/tools/sh264e_encode_jpeg.c
+++ b/tools/sh264e_encode_jpeg.c
@@ -1,5 +1,6 @@
 #include "sh264e.h"
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -33,6 +34,7 @@ static void usage(const char *argv0)
     fprintf(stderr,
             "usage: %s [--streaming-prototype] [--test-allocation-limit BYTES] "
             "[--test-arena-shrink BYTES] [--test-arena-offset BYTES] "
+            "[--test-output-consumer] [--test-output-consumer-fail-after CHUNKS] "
             "--format i420|nv12 input.jpg output.h264\n",
             argv0);
 }
@@ -114,6 +116,34 @@ static int write_exact(FILE *fp, const uint8_t *buf, size_t size)
     return fwrite(buf, 1u, size, fp) == size;
 }
 
+typedef struct output_consumer_state_t {
+    uint8_t *data;
+    size_t capacity;
+    size_t size;
+    unsigned chunks;
+    int fail_after_chunks;
+} output_consumer_state_t;
+
+static sh264e_status_t collect_output_chunk(void *user, const uint8_t *data, size_t size)
+{
+    output_consumer_state_t *state = (output_consumer_state_t *)user;
+
+    if (state == NULL || data == NULL || size == 0u) {
+        return SH264E_ERR_INTERNAL;
+    }
+    if (state->fail_after_chunks >= 0 &&
+        state->chunks >= (unsigned)state->fail_after_chunks) {
+        return SH264E_ERR_INTERNAL;
+    }
+    if (size > state->capacity || state->size > state->capacity - size) {
+        return SH264E_ERR_BUFFER_TOO_SMALL;
+    }
+    memcpy(state->data + state->size, data, size);
+    state->size += size;
+    state->chunks++;
+    return SH264E_OK;
+}
+
 int main(int argc, char **argv)
 {
     const char *input_path;
@@ -127,17 +157,21 @@ int main(int argc, char **argv)
     uint8_t *jpeg_arena = NULL;
     uint8_t *work = NULL;
     uint8_t *output_buf = NULL;
+    uint8_t *output_chunk_buf = NULL;
     FILE *output = NULL;
     size_t jpeg_size = 0;
     size_t jpeg_work_size = 0;
     size_t jpeg_arena_size = 0;
     size_t work_size = 0;
     size_t output_capacity = 0;
+    size_t output_chunk_capacity = 0;
     size_t output_size = 0;
     size_t allocation_limit = (size_t)-1;
     size_t arena_shrink = 0;
     size_t arena_offset = 0;
     int streaming_prototype = 0;
+    int output_consumer_test = 0;
+    int output_consumer_fail_after = -1;
     int argi = 1;
     int rc = 1;
 
@@ -145,6 +179,18 @@ int main(int argc, char **argv)
         if (strcmp(argv[argi], "--streaming-prototype") == 0) {
             streaming_prototype = 1;
             argi++;
+        } else if (strcmp(argv[argi], "--test-output-consumer") == 0) {
+            output_consumer_test = 1;
+            argi++;
+        } else if (argi + 1 < argc && strcmp(argv[argi], "--test-output-consumer-fail-after") == 0) {
+            size_t fail_after = 0u;
+            if (!parse_size(argv[argi + 1], &fail_after) || fail_after > (size_t)INT_MAX) {
+                usage(argv[0]);
+                return 2;
+            }
+            output_consumer_test = 1;
+            output_consumer_fail_after = (int)fail_after;
+            argi += 2;
         } else if (argi + 1 < argc && strcmp(argv[argi], "--test-allocation-limit") == 0) {
             if (!parse_size(argv[argi + 1], &allocation_limit)) {
                 usage(argv[0]);
@@ -184,6 +230,10 @@ int main(int argc, char **argv)
         fprintf(stderr, "--streaming-prototype cannot be combined with --test-allocation-limit\n");
         goto done;
     }
+    if (output_consumer_test && (streaming_prototype || allocation_limit != (size_t)-1)) {
+        fprintf(stderr, "--test-output-consumer cannot be combined with streaming prototype or allocation-limit modes\n");
+        goto done;
+    }
     if (allocation_limit == (size_t)-1) {
         if (streaming_prototype) {
             status = sh264e_jpeg_get_streaming_work_size(jpeg_data, jpeg_size, &jpeg_work_size);
@@ -221,6 +271,22 @@ int main(int argc, char **argv)
         fprintf(stderr, "sh264e_get_max_output_size failed: %s\n", sh264e_status_string(status));
         goto done;
     }
+    if (output_consumer_test) {
+        size_t header_capacity = 0u;
+        size_t slice_capacity = 0u;
+
+        status = sh264e_get_max_header_output_size(&config, &header_capacity);
+        if (status != SH264E_OK) {
+            fprintf(stderr, "sh264e_get_max_header_output_size failed: %s\n", sh264e_status_string(status));
+            goto done;
+        }
+        status = sh264e_get_max_slice_output_size(&config, &slice_capacity);
+        if (status != SH264E_OK) {
+            fprintf(stderr, "sh264e_get_max_slice_output_size failed: %s\n", sh264e_status_string(status));
+            goto done;
+        }
+        output_chunk_capacity = header_capacity > slice_capacity ? header_capacity : slice_capacity;
+    }
 
     if (allocation_limit == (size_t)-1) {
         size_t jpeg_arena_alloc_size = jpeg_arena_size;
@@ -239,7 +305,11 @@ int main(int argc, char **argv)
     }
     work = (uint8_t *)malloc(work_size);
     output_buf = (uint8_t *)malloc(output_capacity);
-    if (work == NULL || output_buf == NULL) {
+    if (output_consumer_test) {
+        output_chunk_buf = (uint8_t *)malloc(output_chunk_capacity);
+    }
+    if (work == NULL || output_buf == NULL ||
+        (output_consumer_test && output_chunk_buf == NULL)) {
         fprintf(stderr, "failed to allocate work/output buffers\n");
         goto done;
     }
@@ -255,6 +325,39 @@ int main(int argc, char **argv)
         status = sh264e_encode_jpeg_idr(encoder, jpeg_data, jpeg_size,
                                         work, work_size,
                                         output_buf, output_capacity, &output_size);
+    } else if (output_consumer_test) {
+        output_consumer_state_t consumer_state;
+
+        memset(&consumer_state, 0, sizeof(consumer_state));
+        consumer_state.data = output_buf;
+        consumer_state.capacity = output_capacity;
+        consumer_state.fail_after_chunks = output_consumer_fail_after;
+        status = sh264e_encode_jpeg_idr_with_arena_stream(
+            encoder, jpeg_data, jpeg_size,
+            jpeg_arena, jpeg_arena_size,
+            work, work_size,
+            output_chunk_buf, output_chunk_capacity,
+            collect_output_chunk, &consumer_state);
+        output_size = consumer_state.size;
+        if (status != SH264E_OK && output_consumer_fail_after >= 0) {
+            size_t probe_size = 0u;
+            sh264e_status_t probe_status =
+                sh264e_begin_idr(encoder, output_chunk_buf, output_chunk_capacity, &probe_size);
+            if (probe_status != SH264E_OK) {
+                fprintf(stderr, "encoder did not reset after consumer failure: %s\n",
+                        sh264e_status_string(probe_status));
+                status = probe_status;
+            }
+        }
+        if (status == SH264E_OK && consumer_state.chunks != 1u + SH264E_V1_SLICE_COUNT) {
+            fprintf(stderr, "output consumer saw %u chunks, expected %u\n",
+                    consumer_state.chunks, 1u + SH264E_V1_SLICE_COUNT);
+            status = SH264E_ERR_INTERNAL;
+        }
+        if (status == SH264E_OK) {
+            printf("jpeg output consumer chunks: %u\n", consumer_state.chunks);
+            printf("jpeg output chunk buffer bytes: %zu\n", output_chunk_capacity);
+        }
     } else if (streaming_prototype) {
         status = sh264e_encode_jpeg_idr_streaming_prototype_with_arena(
             encoder, jpeg_data, jpeg_size,
@@ -306,6 +409,7 @@ done:
         fclose(output);
     }
     sh264e_encoder_destroy(encoder);
+    free(output_chunk_buf);
     free(output_buf);
     free(work);
     free(jpeg_arena_alloc);


### PR DESCRIPTION
## Summary

- add public `sh264e_output_consumer_t` and `sh264e_encode_jpeg_idr_with_arena_stream` for arena-backed JPEG output streaming
- emit SPS/PPS and each IDR slice through a reusable output chunk buffer while preserving the one-shot JPEG API
- add hidden integration coverage for exact chunk count, 126,976-byte chunk capacity, byte-identical output, consumer failure, and encoder reset after failure

Refs #34

## Validation

- `git diff --check`
- `cmake -S . -B build/issue34`
- `cmake --build build/issue34`
- `ctest --test-dir build/issue34 --output-on-failure -R 'sh264e_api|sh264e_no_file_io_in_library|sh264e_ffmpeg_integration'`
- `ctest --test-dir build/issue34 --output-on-failure`

QEMU note: CMake skipped QEMU firmware tests because `arm-none-eabi-gcc` cannot compile `<stdlib.h>` in this environment.