### PR TITLE
jpeg: stream tool output through consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,13 +121,13 @@ Encode a baseline JPEG memory-input path through the library wrapper:
 ./build/sh264e_encode_jpeg --format nv12 input.jpg output.h264
 ```
 
-The JPEG path uses NanoJPEG inside the core library. The tool only reads the JPEG file; the library API accepts a caller-provided JPEG byte buffer and emits H.264 into a caller-provided output buffer.
-The tool sizes a caller-provided JPEG decoder arena with `sh264e_jpeg_get_work_size`, passes that arena to `sh264e_encode_jpeg_idr_with_arena`, and prints the arena requirement plus current and peak NanoJPEG allocation bytes reported by `sh264e_jpeg_get_last_allocation_stats`.
+The JPEG path uses NanoJPEG inside the core library. The tool only reads the JPEG file and writes the `.h264` output; the library API accepts a caller-provided JPEG byte buffer and emits complete Annex B chunks through caller-owned output memory.
+The tool sizes a caller-provided JPEG decoder arena with `sh264e_jpeg_get_work_size`, passes that arena to `sh264e_encode_jpeg_idr_with_arena_stream`, and prints the arena requirement plus current and peak NanoJPEG allocation bytes reported by `sh264e_jpeg_get_last_allocation_stats`.
 The arena-backed production path now uses MCU-row streaming by default. It keeps only NanoJPEG's current MCU-row buffers and the retained row cache, then feeds one scaled output slice at a time to the progressive encoder.
 The printed peak allocation includes the streaming row cache and MCU-row temp buffers; it excludes caller-owned JPEG input, arena header overhead, slice-work, H.264 output buffers, and NanoJPEG's compact in-context Huffman metadata.
 The hidden `--streaming-prototype` flag remains as a debug/comparison path for the same MCU-row streaming machinery.
 The heap-backed convenience wrapper still exists for non-deterministic host usage, but embedded integrations should prefer the arena-backed entry point.
-The current JPEG tool still uses the one-shot H.264 output API and allocates `sh264e_get_max_output_size()` bytes for the complete frame. The intended embedded follow-up is a streaming H.264 output consumer API so tools can write each SPS/PPS or slice chunk as it is produced, while embedded callers can forward chunks to flash, storage, DMA, or a ring buffer without a full-frame output buffer.
+The JPEG tool uses the streaming H.264 output consumer API for its production arena path, so it writes each SPS/PPS or slice chunk as it is produced instead of allocating `sh264e_get_max_output_size()` bytes for the complete frame. Embedded callers can use the same API to forward chunks to flash, storage, DMA, or a ring buffer without a full-frame output buffer.
 
 For Cortex-M validation, CMake builds QEMU smoke firmware for M3/M4/M7 when the ARM bare-metal toolchain and QEMU are available. CMake first probes whether `arm-none-eabi-gcc` can compile the library's standard-header usage; if the toolchain is only partially installed, QEMU firmware tests are skipped instead of breaking the host build.
 
@@ -186,7 +186,7 @@ JPEG pipeline entry points:
 * `sh264e_jpeg_get_last_allocation_stats`
 * `sh264e_encode_jpeg_idr`
 * `sh264e_encode_jpeg_idr_with_arena`
-* planned: `sh264e_encode_jpeg_idr_with_arena_stream`
+* `sh264e_encode_jpeg_idr_with_arena_stream`
 
 Frame-mode convenience entry points:
 

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -298,6 +298,7 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
         command.extend(extra_args)
     command.extend(["--format", fmt, str(jpeg_input), str(bitstream)])
     result = run_capture(command)
+    one_shot_output = extra_args is not None and "--test-one-shot-output" in extra_args
     if "jpeg current allocation bytes: 0" not in result.stdout:
         raise RuntimeError(f"JPEG encoder did not release tracked allocations: {result.stdout!r}")
     if "jpeg work arena bytes:" not in result.stdout:
@@ -330,6 +331,17 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
         raise RuntimeError(
             f"JPEG encoder default path used full component-plane memory: got peak {peak}, limit {max_peak_bytes}"
         )
+    if not one_shot_output:
+        chunks = parse_jpeg_metric(result.stdout, "jpeg output consumer chunks:")
+        if chunks != H264_OUTPUT_CONSUMER_CHUNKS:
+            raise RuntimeError(
+                f"JPEG output consumer chunk count changed: got {chunks}, expected {H264_OUTPUT_CONSUMER_CHUNKS}"
+            )
+        chunk_bytes = parse_jpeg_metric(result.stdout, "jpeg output chunk buffer bytes:")
+        if chunk_bytes != H264_OUTPUT_CHUNK_BYTES:
+            raise RuntimeError(
+                f"JPEG output consumer chunk capacity changed: got {chunk_bytes}, expected {H264_OUTPUT_CHUNK_BYTES}"
+            )
 
 
 def encode_jpeg_streaming_prototype(args, fmt, jpeg_input, bitstream, expected_cache_bytes=None):
@@ -511,11 +523,21 @@ def main():
                         expected_work_bytes=expected_work,
                         expected_peak_bytes=expected_peak)
             if pix_fmt == "yuvj420p" and fmt == "i420":
+                one_shot_output = workdir / "output_jpeg_one_shot_yuvj420p_i420.h264"
+                encode_jpeg(args, fmt, jpeg_input, one_shot_output,
+                            ["--test-one-shot-output"],
+                            STREAMING_CACHE_BYTES_720P[pix_fmt],
+                            FULL_COMPONENT_BYTES_720P[pix_fmt],
+                            PRODUCTION_MEMORY_720P_420["work"],
+                            PRODUCTION_MEMORY_720P_420["peak"])
+                validate_bitstream(args.ffprobe, args.ffmpeg, one_shot_output)
+                if jpeg_output.read_bytes() != one_shot_output.read_bytes():
+                    raise RuntimeError("JPEG default output consumer bitstream differs from one-shot output")
                 consumer_output = workdir / "output_jpeg_consumer_yuvj420p_i420.h264"
                 encode_jpeg_output_consumer(args, fmt, jpeg_input, consumer_output)
                 validate_bitstream(args.ffprobe, args.ffmpeg, consumer_output)
-                if consumer_output.read_bytes() != jpeg_output.read_bytes():
-                    raise RuntimeError("JPEG output consumer bitstream differs from one-shot output")
+                if consumer_output.read_bytes() != one_shot_output.read_bytes():
+                    raise RuntimeError("JPEG memory consumer bitstream differs from one-shot output")
                 run_expect_fail([
                     args.jpeg_encoder,
                     "--test-output-consumer-fail-after",

--- a/tools/sh264e_encode_jpeg.c
+++ b/tools/sh264e_encode_jpeg.c
@@ -34,7 +34,8 @@ static void usage(const char *argv0)
     fprintf(stderr,
             "usage: %s [--streaming-prototype] [--test-allocation-limit BYTES] "
             "[--test-arena-shrink BYTES] [--test-arena-offset BYTES] "
-            "[--test-output-consumer] [--test-output-consumer-fail-after CHUNKS] "
+            "[--test-one-shot-output] [--test-output-consumer] "
+            "[--test-output-consumer-fail-after CHUNKS] "
             "--format i420|nv12 input.jpg output.h264\n",
             argv0);
 }
@@ -117,6 +118,7 @@ static int write_exact(FILE *fp, const uint8_t *buf, size_t size)
 }
 
 typedef struct output_consumer_state_t {
+    FILE *fp;
     uint8_t *data;
     size_t capacity;
     size_t size;
@@ -135,10 +137,16 @@ static sh264e_status_t collect_output_chunk(void *user, const uint8_t *data, siz
         state->chunks >= (unsigned)state->fail_after_chunks) {
         return SH264E_ERR_INTERNAL;
     }
-    if (size > state->capacity || state->size > state->capacity - size) {
-        return SH264E_ERR_BUFFER_TOO_SMALL;
+    if (state->fp != NULL) {
+        if (!write_exact(state->fp, data, size)) {
+            return SH264E_ERR_INTERNAL;
+        }
+    } else {
+        if (size > state->capacity || state->size > state->capacity - size) {
+            return SH264E_ERR_BUFFER_TOO_SMALL;
+        }
+        memcpy(state->data + state->size, data, size);
     }
-    memcpy(state->data + state->size, data, size);
     state->size += size;
     state->chunks++;
     return SH264E_OK;
@@ -170,6 +178,7 @@ int main(int argc, char **argv)
     size_t arena_shrink = 0;
     size_t arena_offset = 0;
     int streaming_prototype = 0;
+    int one_shot_output_test = 0;
     int output_consumer_test = 0;
     int output_consumer_fail_after = -1;
     int argi = 1;
@@ -178,6 +187,9 @@ int main(int argc, char **argv)
     while (argi < argc) {
         if (strcmp(argv[argi], "--streaming-prototype") == 0) {
             streaming_prototype = 1;
+            argi++;
+        } else if (strcmp(argv[argi], "--test-one-shot-output") == 0) {
+            one_shot_output_test = 1;
             argi++;
         } else if (strcmp(argv[argi], "--test-output-consumer") == 0) {
             output_consumer_test = 1;
@@ -234,6 +246,11 @@ int main(int argc, char **argv)
         fprintf(stderr, "--test-output-consumer cannot be combined with streaming prototype or allocation-limit modes\n");
         goto done;
     }
+    if (one_shot_output_test && (streaming_prototype || output_consumer_test ||
+                                 allocation_limit != (size_t)-1)) {
+        fprintf(stderr, "--test-one-shot-output cannot be combined with other output test modes\n");
+        goto done;
+    }
     if (allocation_limit == (size_t)-1) {
         if (streaming_prototype) {
             status = sh264e_jpeg_get_streaming_work_size(jpeg_data, jpeg_size, &jpeg_work_size);
@@ -266,12 +283,15 @@ int main(int argc, char **argv)
         fprintf(stderr, "sh264e_jpeg_get_slice_buffer_size failed: %s\n", sh264e_status_string(status));
         goto done;
     }
-    status = sh264e_get_max_output_size(&config, &output_capacity);
-    if (status != SH264E_OK) {
-        fprintf(stderr, "sh264e_get_max_output_size failed: %s\n", sh264e_status_string(status));
-        goto done;
+    if (allocation_limit != (size_t)-1 || streaming_prototype ||
+        output_consumer_test || one_shot_output_test) {
+        status = sh264e_get_max_output_size(&config, &output_capacity);
+        if (status != SH264E_OK) {
+            fprintf(stderr, "sh264e_get_max_output_size failed: %s\n", sh264e_status_string(status));
+            goto done;
+        }
     }
-    if (output_consumer_test) {
+    if (allocation_limit == (size_t)-1 && !streaming_prototype && !one_shot_output_test) {
         size_t header_capacity = 0u;
         size_t slice_capacity = 0u;
 
@@ -304,12 +324,15 @@ int main(int argc, char **argv)
         jpeg_arena = jpeg_arena_alloc + arena_offset;
     }
     work = (uint8_t *)malloc(work_size);
-    output_buf = (uint8_t *)malloc(output_capacity);
-    if (output_consumer_test) {
+    if (output_capacity != 0u) {
+        output_buf = (uint8_t *)malloc(output_capacity);
+    }
+    if (output_chunk_capacity != 0u) {
         output_chunk_buf = (uint8_t *)malloc(output_chunk_capacity);
     }
-    if (work == NULL || output_buf == NULL ||
-        (output_consumer_test && output_chunk_buf == NULL)) {
+    if (work == NULL ||
+        (output_capacity != 0u && output_buf == NULL) ||
+        (output_chunk_capacity != 0u && output_chunk_buf == NULL)) {
         fprintf(stderr, "failed to allocate work/output buffers\n");
         goto done;
     }
@@ -325,6 +348,11 @@ int main(int argc, char **argv)
         status = sh264e_encode_jpeg_idr(encoder, jpeg_data, jpeg_size,
                                         work, work_size,
                                         output_buf, output_capacity, &output_size);
+    } else if (one_shot_output_test) {
+        status = sh264e_encode_jpeg_idr_with_arena(encoder, jpeg_data, jpeg_size,
+                                                   jpeg_arena, jpeg_arena_size,
+                                                   work, work_size,
+                                                   output_buf, output_capacity, &output_size);
     } else if (output_consumer_test) {
         output_consumer_state_t consumer_state;
 
@@ -365,24 +393,48 @@ int main(int argc, char **argv)
             work, work_size,
             output_buf, output_capacity, &output_size);
     } else {
-        status = sh264e_encode_jpeg_idr_with_arena(encoder, jpeg_data, jpeg_size,
-                                                   jpeg_arena, jpeg_arena_size,
-                                                   work, work_size,
-                                                   output_buf, output_capacity, &output_size);
+        output_consumer_state_t consumer_state;
+
+        output = fopen(output_path, "wb");
+        if (output == NULL) {
+            fprintf(stderr, "failed to open output: %s\n", output_path);
+            goto done;
+        }
+        memset(&consumer_state, 0, sizeof(consumer_state));
+        consumer_state.fp = output;
+        consumer_state.fail_after_chunks = output_consumer_fail_after;
+        status = sh264e_encode_jpeg_idr_with_arena_stream(
+            encoder, jpeg_data, jpeg_size,
+            jpeg_arena, jpeg_arena_size,
+            work, work_size,
+            output_chunk_buf, output_chunk_capacity,
+            collect_output_chunk, &consumer_state);
+        output_size = consumer_state.size;
+        if (status == SH264E_OK && consumer_state.chunks != 1u + SH264E_V1_SLICE_COUNT) {
+            fprintf(stderr, "output consumer saw %u chunks, expected %u\n",
+                    consumer_state.chunks, 1u + SH264E_V1_SLICE_COUNT);
+            status = SH264E_ERR_INTERNAL;
+        }
+        if (status == SH264E_OK) {
+            printf("jpeg output consumer chunks: %u\n", consumer_state.chunks);
+            printf("jpeg output chunk buffer bytes: %zu\n", output_chunk_capacity);
+        }
     }
     if (status != SH264E_OK) {
         fprintf(stderr, "JPEG encode failed: %s\n", sh264e_status_string(status));
         goto done;
     }
 
-    output = fopen(output_path, "wb");
     if (output == NULL) {
-        fprintf(stderr, "failed to open output: %s\n", output_path);
-        goto done;
-    }
-    if (!write_exact(output, output_buf, output_size)) {
-        fprintf(stderr, "failed to write output\n");
-        goto done;
+        output = fopen(output_path, "wb");
+        if (output == NULL) {
+            fprintf(stderr, "failed to open output: %s\n", output_path);
+            goto done;
+        }
+        if (!write_exact(output, output_buf, output_size)) {
+            fprintf(stderr, "failed to write output\n");
+            goto done;
+        }
     }
 
     {


### PR DESCRIPTION
## Summary

- migrate the JPEG tool production arena path to `sh264e_encode_jpeg_idr_with_arena_stream` with a file-writing consumer
- avoid allocating the full `sh264e_get_max_output_size()` output buffer on the default JPEG tool path; keep hidden one-shot and memory-consumer test modes for regression comparison
- extend ffmpeg integration to assert consumer chunk count/capacity, compare default and memory-consumer outputs byte-for-byte with the one-shot API, and keep consumer failure coverage
- update README JPEG output notes and public API list

Refs #35

## Validation

- `git diff --check`
- `cmake -S . -B build/issue35`
- `cmake --build build/issue35`
- `ctest --test-dir build/issue35 --output-on-failure -R 'sh264e_api|sh264e_no_file_io_in_library|sh264e_ffmpeg_integration'`
- `ctest --test-dir build/issue35 --output-on-failure`
- `build/issue35/sh264e_encode_jpeg --format i420 build/issue35/integration/input_1440p_yuvj420p.jpg build/issue35/consumer_output_1440_i420.h264`
- `ffmpeg -v error -xerror -i build/issue35/consumer_output_1440_i420.h264 -f null -`

Manual smoke output reported 91 consumer chunks, 126,976-byte output chunk buffer, 245,904-byte JPEG arena, 61,440-byte slice work, 245,760-byte peak allocation, and 184,320-byte streaming cache.

QEMU note: CMake skipped QEMU firmware tests because `arm-none-eabi-gcc` cannot compile `<stdlib.h>` in this environment.