### PR TITLE
jpeg: quarantine legacy NanoJPEG full-image decode

### DIFF
--- a/src/nanojpeg.c
+++ b/src/nanojpeg.c
@@ -87,6 +87,12 @@
 // NJ_VLC_FAST_BITS=8      = Use a small per-Huffman-table fast decode table
 //                           for codes up to this bit length, with canonical
 //                           Huffman fallback for longer codes (default).
+// NJ_ENABLE_FULL_IMAGE_DECODE=0
+//                         = Do not expose NanoJPEG's legacy full-image RGB or
+//                           full component-plane decode entry points (default).
+// NJ_ENABLE_FULL_IMAGE_DECODE=1
+//                         = Expose the legacy full-image/component-plane decode
+//                           entry points for explicit debug/example builds only.
 
 
 // API
@@ -133,6 +139,15 @@ typedef enum _nj_result {
 // using any of the other NanoJPEG functions.
 void njInit(void);
 
+#if defined(_NJ_EXAMPLE_PROGRAM) && !defined(NJ_ENABLE_FULL_IMAGE_DECODE)
+#define NJ_ENABLE_FULL_IMAGE_DECODE 1
+#endif
+
+#ifndef NJ_ENABLE_FULL_IMAGE_DECODE
+#define NJ_ENABLE_FULL_IMAGE_DECODE 0
+#endif
+
+#if NJ_ENABLE_FULL_IMAGE_DECODE
 // njDecode: Decode a JPEG image.
 // Decodes a memory dump of a JPEG file into internal buffers.
 // Parameters:
@@ -146,6 +161,7 @@ nj_result_t njDecode(const void* jpeg, const int size);
 // JPEGs. Component plane accessors below expose the decoded Y/Cb/Cr or
 // grayscale planes, including their native dimensions and stride.
 nj_result_t njDecodeComponents(const void* jpeg, const int size);
+#endif
 
 typedef int (*nj_mcu_row_callback_t)(int mcu_y, void* user);
 nj_result_t njDecodeMcuRows(const void* jpeg, const int size, nj_mcu_row_callback_t callback, void* user);
@@ -158,6 +174,7 @@ int njGetWidth(void);
 // image. If njDecode() failed, the result of njGetHeight() is undefined.
 int njGetHeight(void);
 
+#if NJ_ENABLE_FULL_IMAGE_DECODE
 // njIsColor: Return 1 if the most recently decoded image is a color image
 // (RGB) or 0 if it is a grayscale image. If njDecode() failed, the result
 // of njGetWidth() is undefined.
@@ -176,6 +193,7 @@ unsigned char* njGetImage(void);
 // by njGetImage(). If njDecode() failed, the result of njGetImageSize() is
 // undefined.
 int njGetImageSize(void);
+#endif
 
 int njGetComponentCount(void);
 const unsigned char* njGetComponentPixels(int index);
@@ -816,6 +834,8 @@ NJ_INLINE void njDecodeScan(void) {
     nj.error = __NJ_FINISHED;
 }
 
+#if NJ_ENABLE_FULL_IMAGE_DECODE
+
 #if NJ_CHROMA_FILTER
 
 #define CF4A (-9)
@@ -964,6 +984,8 @@ NJ_INLINE void njConvert(void) {
     }
 }
 
+#endif
+
 void njInit(void) {
     njFillMem(&nj, 0, sizeof(nj_context_t));
 }
@@ -1012,9 +1034,17 @@ static nj_result_t njDecodeInternal(const void* jpeg,
     }
     if (nj.error != __NJ_FINISHED) return nj.error;
     nj.error = NJ_OK;
-    if (!nj.decode_components_only) njConvert();
+    if (!nj.decode_components_only) {
+        #if NJ_ENABLE_FULL_IMAGE_DECODE
+            njConvert();
+        #else
+            return NJ_UNSUPPORTED;
+        #endif
+    }
     return nj.error;
 }
+
+#if NJ_ENABLE_FULL_IMAGE_DECODE
 
 nj_result_t njDecode(const void* jpeg, const int size) {
     return njDecodeInternal(jpeg, size, 0, 0, NULL, NULL);
@@ -1024,6 +1054,8 @@ nj_result_t njDecodeComponents(const void* jpeg, const int size) {
     return njDecodeInternal(jpeg, size, 1, 0, NULL, NULL);
 }
 
+#endif
+
 nj_result_t njDecodeMcuRows(const void* jpeg, const int size, nj_mcu_row_callback_t callback, void* user) {
     if (!callback) return NJ_INTERNAL_ERR;
     return njDecodeInternal(jpeg, size, 1, 1, callback, user);
@@ -1031,9 +1063,11 @@ nj_result_t njDecodeMcuRows(const void* jpeg, const int size, nj_mcu_row_callbac
 
 int njGetWidth(void)            { return nj.width; }
 int njGetHeight(void)           { return nj.height; }
+#if NJ_ENABLE_FULL_IMAGE_DECODE
 int njIsColor(void)             { return (nj.ncomp != 1); }
 unsigned char* njGetImage(void) { return (nj.ncomp == 1) ? nj.comp[0].pixels : nj.rgb; }
 int njGetImageSize(void)        { return nj.width * nj.height * nj.ncomp; }
+#endif
 int njGetComponentCount(void)   { return nj.ncomp; }
 const unsigned char* njGetComponentPixels(int index) {
     if ((index < 0) || (index >= nj.ncomp)) return NULL;

--- a/tests/check_jpeg_no_rgb_path.cmake
+++ b/tests/check_jpeg_no_rgb_path.cmake
@@ -21,6 +21,22 @@ if(NOT nanojpeg_source MATCHES "decode_mcu_rows_only")
     message(FATAL_ERROR "NanoJPEG MCU-row decode guard is missing")
 endif()
 
-if(NOT nanojpeg_source MATCHES "if[ \t\r\n]*\\(!nj\\.decode_components_only\\)[ \t\r\n]*njConvert[ \t\r\n]*\\(")
-    message(FATAL_ERROR "NanoJPEG streaming/component decode must skip RGB conversion")
+if(NOT nanojpeg_source MATCHES "#define NJ_ENABLE_FULL_IMAGE_DECODE 0")
+    message(FATAL_ERROR "NanoJPEG full-image/component decode must default to disabled")
+endif()
+
+if(NOT nanojpeg_source MATCHES "#if NJ_ENABLE_FULL_IMAGE_DECODE[ \t\r\n]+nj_result_t[ \t\r\n]+njDecode[ \t\r\n]*\\(")
+    message(FATAL_ERROR "NanoJPEG full-image decode entry point must be debug-gated")
+endif()
+
+if(NOT nanojpeg_source MATCHES "#if NJ_ENABLE_FULL_IMAGE_DECODE[ \t\r\n]+int[ \t\r\n]+njIsColor[ \t\r\n]*\\(")
+    message(FATAL_ERROR "NanoJPEG RGB image accessors must be debug-gated")
+endif()
+
+if(NOT nanojpeg_source MATCHES "#if NJ_ENABLE_FULL_IMAGE_DECODE[ \t\r\n]+njConvert[ \t\r\n]*\\(")
+    message(FATAL_ERROR "NanoJPEG RGB conversion must be debug-gated")
+endif()
+
+if(NOT nanojpeg_source MATCHES "#else[ \t\r\n]+return NJ_UNSUPPORTED;[ \t\r\n]+#endif")
+    message(FATAL_ERROR "NanoJPEG normal build must reject full-image decode")
 endif()


### PR DESCRIPTION
## Summary

- gate NanoJPEG's legacy `njDecode`, `njDecodeComponents`, RGB conversion, and RGB image accessors behind `NJ_ENABLE_FULL_IMAGE_DECODE`
- keep the example program working by enabling that debug gate only for `_NJ_EXAMPLE_PROGRAM`
- tighten the JPEG source guard so normal builds require the full-image/component decode gate and reject ungated RGB conversion

Refs #42

## Validation

- `cmake -S . -B build/issue42`
- `cmake --build build/issue42`
- `ctest --test-dir build/issue42 --output-on-failure -R 'sh264e_jpeg_no_rgb_path|sh264e_jpeg_mcu_rows|sh264e_ffmpeg_integration|sh264e_api'`
- `rg -n "jpeg_decode_memory|jpeg_decode_current|jpeg_get_components|jpeg_make_i420_slice|jpeg_make_nv12_slice" src tests tools || true`
- `nm -g build/issue42/libsimple_h264_enc_i.a | rg "njDecode|njGetImage|njGetImageSize|njIsColor|njDecodeMcuRows"`
- `ctest --test-dir build/issue42 --output-on-failure`
- `git diff --check`

The normal static library now exports `njDecodeMcuRows` but not the legacy `njDecodeComponents`, `njDecode`, `njGetImage`, `njGetImageSize`, or `njIsColor` symbols.
