### PR TITLE
jpeg: formalize diagnostic test hooks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,14 @@ project(simple_h264_enc_i VERSION 0.1.0 LANGUAGES C)
 option(SH264E_BUILD_TOOLS "Build command-line tools" ON)
 option(SH264E_BUILD_TESTS "Build tests" ON)
 option(SH264E_BUILD_QEMU_TESTS "Build Cortex-M QEMU firmware tests when the toolchain is usable" ON)
+if(NOT DEFINED SH264E_ENABLE_JPEG_TEST_HOOKS)
+    set(SH264E_ENABLE_JPEG_TEST_HOOKS ${SH264E_BUILD_TESTS})
+endif()
+set(SH264E_ENABLE_JPEG_TEST_HOOKS ${SH264E_ENABLE_JPEG_TEST_HOOKS} CACHE BOOL
+    "Build private JPEG diagnostic/test hooks used by regression tools")
+if(SH264E_BUILD_TESTS AND NOT SH264E_ENABLE_JPEG_TEST_HOOKS)
+    message(FATAL_ERROR "SH264E_BUILD_TESTS requires SH264E_ENABLE_JPEG_TEST_HOOKS")
+endif()
 
 add_library(simple_h264_enc_i STATIC
     src/sh264e.c
@@ -17,6 +25,10 @@ target_include_directories(simple_h264_enc_i
 )
 
 target_compile_features(simple_h264_enc_i PUBLIC c_std_99)
+
+if(SH264E_ENABLE_JPEG_TEST_HOOKS)
+    target_compile_definitions(simple_h264_enc_i PRIVATE SH264E_ENABLE_JPEG_TEST_HOOKS=1)
+endif()
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
     target_compile_options(simple_h264_enc_i PRIVATE
@@ -61,6 +73,12 @@ if(SH264E_BUILD_TOOLS)
     )
     target_link_libraries(sh264e_encode_jpeg PRIVATE simple_h264_enc_i)
     target_compile_features(sh264e_encode_jpeg PRIVATE c_std_99)
+    if(SH264E_ENABLE_JPEG_TEST_HOOKS)
+        target_compile_definitions(sh264e_encode_jpeg PRIVATE SH264E_ENABLE_JPEG_TEST_HOOKS=1)
+        target_include_directories(sh264e_encode_jpeg PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/tests
+        )
+    endif()
 
     if(CMAKE_C_COMPILER_ID MATCHES "Clang|GNU")
         target_compile_options(sh264e_encode_file PRIVATE
@@ -146,6 +164,12 @@ if(SH264E_BUILD_TESTS)
         COMMAND ${CMAKE_COMMAND}
             -DSH264E_SRC_DIR=${CMAKE_CURRENT_SOURCE_DIR}/src
             -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/check_jpeg_no_rgb_path.cmake
+    )
+    add_test(
+        NAME sh264e_jpeg_diagnostics_boundary
+        COMMAND ${CMAKE_COMMAND}
+            -DSH264E_PROJECT_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/check_jpeg_diagnostics_boundary.cmake
     )
 
     find_package(Python3 COMPONENTS Interpreter)

--- a/README.md
+++ b/README.md
@@ -123,9 +123,10 @@ Encode a baseline JPEG memory-input path through the library wrapper:
 
 The JPEG path uses NanoJPEG inside the core library. The tool only reads the JPEG file and writes the `.h264` output; the library API accepts a caller-provided JPEG byte buffer and emits complete Annex B chunks through caller-owned output memory.
 The tool sizes a caller-provided JPEG decoder arena with `sh264e_jpeg_get_work_size`, passes that arena to `sh264e_encode_jpeg_idr_with_arena_stream`, and prints the arena requirement plus current and peak NanoJPEG allocation bytes reported by `sh264e_jpeg_get_last_allocation_stats`.
+The public diagnostic surface also exposes `sh264e_jpeg_get_last_streaming_cache_bytes` so tools and regression tests can report decoded-row cache usage without private declarations.
 The arena-backed production path now uses MCU-row streaming by default. It keeps only NanoJPEG's current MCU-row buffers and the retained row cache, then feeds one scaled output slice at a time to the progressive encoder.
 The printed peak allocation includes the streaming row cache and MCU-row temp buffers; it excludes caller-owned JPEG input, arena header overhead, slice-work, H.264 output buffers, and NanoJPEG's compact in-context Huffman metadata.
-The hidden `--streaming-prototype` flag remains as a debug/comparison path for the same MCU-row streaming machinery.
+Diagnostic-only JPEG allocation-limit and streaming-prototype hooks are gated by `SH264E_ENABLE_JPEG_TEST_HOOKS` and declared in `tests/sh264e_jpeg_test_hooks.h`; they are not normal application APIs.
 All public JPEG entry points must use the MCU-row streaming decode path. The
 heap-backed convenience wrapper may remain non-deterministic in allocation
 placement, but it must not decode the JPEG into a full RGB, grayscale, Y, Cb, or

--- a/docs/JPEG_STREAMING_MEMORY_REPORT.md
+++ b/docs/JPEG_STREAMING_MEMORY_REPORT.md
@@ -22,6 +22,12 @@ short codes, and falls back to canonical range lookup for longer codes. The
 streaming row cache is the decoded-image replacement for the previous full
 component planes.
 
+Regression tools read tracked allocation stats through
+`sh264e_jpeg_get_last_allocation_stats` and row-cache capacity through
+`sh264e_jpeg_get_last_streaming_cache_bytes`. Allocation-limit fault injection
+and streaming-prototype comparison entry points are private test hooks gated by
+`SH264E_ENABLE_JPEG_TEST_HOOKS`, not production application APIs.
+
 For the `2560x1440` 4:2:0 row, the measured peak breaks down as:
 
 | Block | Bytes |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -327,6 +327,8 @@ sh264e_jpeg_get_slice_buffer_size
 sh264e_encode_jpeg_idr
 sh264e_encode_jpeg_idr_with_arena
 sh264e_encode_jpeg_idr_with_arena_stream
+sh264e_jpeg_get_last_allocation_stats
+sh264e_jpeg_get_last_streaming_cache_bytes
 ```
 
 The JPEG APIs accept a caller-provided JPEG byte buffer. File I/O remains outside the library.
@@ -353,6 +355,14 @@ typedef sh264e_status_t (*sh264e_output_consumer_t)(
 ```
 
 The streaming-output JPEG API should use a reusable caller-provided output chunk buffer sized for `max(header, one slice)`, call the consumer once for SPS/PPS and once per IDR slice, and stop deterministically if the consumer returns an error. The library must not call file APIs; tools/tests may implement a consumer that writes to a file.
+
+`sh264e_jpeg_get_last_allocation_stats` reports the current and peak tracked
+JPEG allocations from the last JPEG work-size query or encode call.
+`sh264e_jpeg_get_last_streaming_cache_bytes` reports the decoded row-cache
+capacity retained by the last MCU-row streaming query or encode call. These are
+diagnostic/stat APIs for regression reporting; allocation-limit and
+streaming-prototype hooks remain private test hooks gated by
+`SH264E_ENABLE_JPEG_TEST_HOOKS`.
 
 NanoJPEG decodes baseline JPEG through MCU-row streaming. The library scales decoded component rows directly into one YUV420 encoder slice at a time:
 

--- a/include/sh264e.h
+++ b/include/sh264e.h
@@ -119,6 +119,8 @@ sh264e_status_t sh264e_jpeg_get_work_size(const uint8_t *jpeg_data,
 
 sh264e_status_t sh264e_jpeg_get_last_allocation_stats(sh264e_jpeg_allocation_stats_t *out_stats);
 
+size_t sh264e_jpeg_get_last_streaming_cache_bytes(void);
+
 sh264e_status_t sh264e_encode_jpeg_idr(sh264e_encoder_t *encoder,
                                        const uint8_t *jpeg_data,
                                        size_t jpeg_size,

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -4,6 +4,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef SH264E_ENABLE_JPEG_TEST_HOOKS
+#define SH264E_ENABLE_JPEG_TEST_HOOKS 0
+#endif
+
 #define NJ_OK 0
 #define NJ_NO_JPEG 1
 #define NJ_UNSUPPORTED 2
@@ -169,11 +173,6 @@ static void jpeg_allocation_stats_reset(void)
     sh264e_jpeg_alloc_arena_offset = 0u;
     sh264e_jpeg_alloc_peak_arena_bytes = 0u;
     sh264e_jpeg_alloc_arena_failed = 0u;
-}
-
-void sh264e_jpeg_set_test_allocation_limit(size_t max_bytes)
-{
-    sh264e_jpeg_alloc_limit = max_bytes;
 }
 
 static size_t jpeg_alloc_alignment(void)
@@ -2002,6 +2001,15 @@ sh264e_status_t sh264e_jpeg_get_work_size(const uint8_t *jpeg_data,
     return jpeg_get_streaming_work_size(jpeg_data, jpeg_size, out_size);
 }
 
+#if SH264E_ENABLE_JPEG_TEST_HOOKS
+
+void sh264e_jpeg_set_test_allocation_limit(size_t max_bytes)
+{
+    sh264e_jpeg_alloc_limit = max_bytes;
+}
+
+#endif
+
 sh264e_status_t sh264e_encode_jpeg_idr(sh264e_encoder_t *encoder,
                                        const uint8_t *jpeg_data,
                                        size_t jpeg_size,
@@ -2065,13 +2073,6 @@ sh264e_status_t sh264e_encode_jpeg_idr_with_arena_stream(
 size_t sh264e_jpeg_get_last_streaming_cache_bytes(void)
 {
     return sh264e_jpeg_streaming_last_cache_bytes;
-}
-
-sh264e_status_t sh264e_jpeg_get_streaming_work_size(const uint8_t *jpeg_data,
-                                                    size_t jpeg_size,
-                                                    size_t *out_size)
-{
-    return jpeg_get_streaming_work_size(jpeg_data, jpeg_size, out_size);
 }
 
 static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *encoder,
@@ -2156,6 +2157,8 @@ static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *e
     return status;
 }
 
+#if SH264E_ENABLE_JPEG_TEST_HOOKS
+
 sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype(sh264e_encoder_t *encoder,
                                                            const uint8_t *jpeg_data,
                                                            size_t jpeg_size,
@@ -2189,6 +2192,8 @@ sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype_with_arena(sh264e_enc
                                                  out, out_capacity, out_size,
                                                  NULL, NULL);
 }
+
+#endif
 
 sh264e_status_t sh264e_encoder_create(const sh264e_config_t *config,
                                       sh264e_encoder_t **out_encoder)

--- a/tests/check_jpeg_diagnostics_boundary.cmake
+++ b/tests/check_jpeg_diagnostics_boundary.cmake
@@ -1,0 +1,40 @@
+if(NOT DEFINED SH264E_PROJECT_DIR)
+    message(FATAL_ERROR "SH264E_PROJECT_DIR is required")
+endif()
+
+file(READ "${SH264E_PROJECT_DIR}/include/sh264e.h" public_header)
+file(READ "${SH264E_PROJECT_DIR}/src/sh264e.c" sh264e_source)
+file(READ "${SH264E_PROJECT_DIR}/tools/sh264e_encode_jpeg.c" jpeg_tool)
+file(READ "${SH264E_PROJECT_DIR}/tests/sh264e_jpeg_test_hooks.h" test_hooks)
+
+if(jpeg_tool MATCHES "(void|size_t|sh264e_status_t)[ \t]+sh264e_")
+    message(FATAL_ERROR "JPEG tool must not forward-declare sh264e private diagnostics")
+endif()
+
+if(NOT jpeg_tool MATCHES "#include \"sh264e_jpeg_test_hooks\\.h\"")
+    message(FATAL_ERROR "JPEG test-only hooks must be declared by the test hook header")
+endif()
+
+if(NOT jpeg_tool MATCHES "SH264E_ENABLE_JPEG_TEST_HOOKS")
+    message(FATAL_ERROR "JPEG diagnostic test flags must be build-gated")
+endif()
+
+if(NOT public_header MATCHES "sh264e_jpeg_get_last_streaming_cache_bytes[ \t\r\n]*\\(")
+    message(FATAL_ERROR "Streaming cache stats must be intentionally declared in the public API")
+endif()
+
+if(NOT test_hooks MATCHES "sh264e_jpeg_set_test_allocation_limit[ \t\r\n]*\\(")
+    message(FATAL_ERROR "Allocation-limit hook must be test-only")
+endif()
+
+if(NOT sh264e_source MATCHES "#if SH264E_ENABLE_JPEG_TEST_HOOKS[ \t\r\n]+void[ \t\r\n]+sh264e_jpeg_set_test_allocation_limit")
+    message(FATAL_ERROR "Allocation-limit implementation must be test-hook gated")
+endif()
+
+if(NOT sh264e_source MATCHES "#if SH264E_ENABLE_JPEG_TEST_HOOKS[ \t\r\n]+sh264e_status_t[ \t\r\n]+sh264e_encode_jpeg_idr_streaming_prototype")
+    message(FATAL_ERROR "Streaming prototype implementation must be test-hook gated")
+endif()
+
+if(sh264e_source MATCHES "sh264e_jpeg_get_streaming_work_size[ \t\r\n]*\\(")
+    message(FATAL_ERROR "Use public sh264e_jpeg_get_work_size instead of private streaming work-size helper")
+endif()

--- a/tests/sh264e_jpeg_test_hooks.h
+++ b/tests/sh264e_jpeg_test_hooks.h
@@ -1,0 +1,38 @@
+#ifndef SH264E_JPEG_TEST_HOOKS_H
+#define SH264E_JPEG_TEST_HOOKS_H
+
+#include "sh264e.h"
+
+#ifndef SH264E_ENABLE_JPEG_TEST_HOOKS
+#define SH264E_ENABLE_JPEG_TEST_HOOKS 0
+#endif
+
+#if !SH264E_ENABLE_JPEG_TEST_HOOKS
+#error "sh264e_jpeg_test_hooks.h requires SH264E_ENABLE_JPEG_TEST_HOOKS"
+#endif
+
+void sh264e_jpeg_set_test_allocation_limit(size_t max_bytes);
+
+sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype(
+    sh264e_encoder_t *encoder,
+    const uint8_t *jpeg_data,
+    size_t jpeg_size,
+    uint8_t *work_buffer,
+    size_t work_buffer_capacity,
+    uint8_t *out,
+    size_t out_capacity,
+    size_t *out_size);
+
+sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype_with_arena(
+    sh264e_encoder_t *encoder,
+    const uint8_t *jpeg_data,
+    size_t jpeg_size,
+    uint8_t *jpeg_arena,
+    size_t jpeg_arena_size,
+    uint8_t *work_buffer,
+    size_t work_buffer_capacity,
+    uint8_t *out,
+    size_t out_capacity,
+    size_t *out_size);
+
+#endif

--- a/tools/sh264e_encode_jpeg.c
+++ b/tools/sh264e_encode_jpeg.c
@@ -5,34 +5,21 @@
 #include <stdlib.h>
 #include <string.h>
 
-void sh264e_jpeg_set_test_allocation_limit(size_t max_bytes);
-size_t sh264e_jpeg_get_last_streaming_cache_bytes(void);
-sh264e_status_t sh264e_jpeg_get_streaming_work_size(const uint8_t *jpeg_data,
-                                                    size_t jpeg_size,
-                                                    size_t *out_size);
-sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype(sh264e_encoder_t *encoder,
-                                                           const uint8_t *jpeg_data,
-                                                           size_t jpeg_size,
-                                                           uint8_t *work_buffer,
-                                                           size_t work_buffer_capacity,
-                                                           uint8_t *out,
-                                                           size_t out_capacity,
-                                                           size_t *out_size);
-sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype_with_arena(sh264e_encoder_t *encoder,
-                                                                      const uint8_t *jpeg_data,
-                                                                      size_t jpeg_size,
-                                                                      uint8_t *jpeg_arena,
-                                                                      size_t jpeg_arena_size,
-                                                                      uint8_t *work_buffer,
-                                                                      size_t work_buffer_capacity,
-                                                                      uint8_t *out,
-                                                                      size_t out_capacity,
-                                                                      size_t *out_size);
+#ifndef SH264E_ENABLE_JPEG_TEST_HOOKS
+#define SH264E_ENABLE_JPEG_TEST_HOOKS 0
+#endif
+
+#if SH264E_ENABLE_JPEG_TEST_HOOKS
+#include "sh264e_jpeg_test_hooks.h"
+#endif
 
 static void usage(const char *argv0)
 {
     fprintf(stderr,
-            "usage: %s [--streaming-prototype] [--test-allocation-limit BYTES] "
+            "usage: %s "
+#if SH264E_ENABLE_JPEG_TEST_HOOKS
+            "[--streaming-prototype] [--test-allocation-limit BYTES] "
+#endif
             "[--test-arena-shrink BYTES] [--test-arena-offset BYTES] "
             "[--test-one-shot-output] [--test-output-consumer] "
             "[--test-output-consumer-fail-after CHUNKS] "
@@ -185,10 +172,19 @@ int main(int argc, char **argv)
     int rc = 1;
 
     while (argi < argc) {
+#if SH264E_ENABLE_JPEG_TEST_HOOKS
         if (strcmp(argv[argi], "--streaming-prototype") == 0) {
             streaming_prototype = 1;
             argi++;
-        } else if (strcmp(argv[argi], "--test-one-shot-output") == 0) {
+        } else if (argi + 1 < argc && strcmp(argv[argi], "--test-allocation-limit") == 0) {
+            if (!parse_size(argv[argi + 1], &allocation_limit)) {
+                usage(argv[0]);
+                return 2;
+            }
+            argi += 2;
+        } else
+#endif
+        if (strcmp(argv[argi], "--test-one-shot-output") == 0) {
             one_shot_output_test = 1;
             argi++;
         } else if (strcmp(argv[argi], "--test-output-consumer") == 0) {
@@ -202,12 +198,6 @@ int main(int argc, char **argv)
             }
             output_consumer_test = 1;
             output_consumer_fail_after = (int)fail_after;
-            argi += 2;
-        } else if (argi + 1 < argc && strcmp(argv[argi], "--test-allocation-limit") == 0) {
-            if (!parse_size(argv[argi + 1], &allocation_limit)) {
-                usage(argv[0]);
-                return 2;
-            }
             argi += 2;
         } else if (argi + 1 < argc && strcmp(argv[argi], "--test-arena-shrink") == 0) {
             if (!parse_size(argv[argi + 1], &arena_shrink)) {
@@ -252,11 +242,7 @@ int main(int argc, char **argv)
         goto done;
     }
     if (allocation_limit == (size_t)-1) {
-        if (streaming_prototype) {
-            status = sh264e_jpeg_get_streaming_work_size(jpeg_data, jpeg_size, &jpeg_work_size);
-        } else {
-            status = sh264e_jpeg_get_work_size(jpeg_data, jpeg_size, &jpeg_work_size);
-        }
+        status = sh264e_jpeg_get_work_size(jpeg_data, jpeg_size, &jpeg_work_size);
         if (status != SH264E_OK) {
             fprintf(stderr, "JPEG work-size query failed: %s\n", sh264e_status_string(status));
             goto done;
@@ -344,10 +330,14 @@ int main(int argc, char **argv)
     }
 
     if (allocation_limit != (size_t)-1) {
+#if SH264E_ENABLE_JPEG_TEST_HOOKS
         sh264e_jpeg_set_test_allocation_limit(allocation_limit);
         status = sh264e_encode_jpeg_idr(encoder, jpeg_data, jpeg_size,
                                         work, work_size,
                                         output_buf, output_capacity, &output_size);
+#else
+        status = SH264E_ERR_UNSUPPORTED_CONFIG;
+#endif
     } else if (one_shot_output_test) {
         status = sh264e_encode_jpeg_idr_with_arena(encoder, jpeg_data, jpeg_size,
                                                    jpeg_arena, jpeg_arena_size,
@@ -387,11 +377,15 @@ int main(int argc, char **argv)
             printf("jpeg output chunk buffer bytes: %zu\n", output_chunk_capacity);
         }
     } else if (streaming_prototype) {
+#if SH264E_ENABLE_JPEG_TEST_HOOKS
         status = sh264e_encode_jpeg_idr_streaming_prototype_with_arena(
             encoder, jpeg_data, jpeg_size,
             jpeg_arena, jpeg_arena_size,
             work, work_size,
             output_buf, output_capacity, &output_size);
+#else
+        status = SH264E_ERR_UNSUPPORTED_CONFIG;
+#endif
     } else {
         output_consumer_state_t consumer_state;
 


### PR DESCRIPTION
## Summary

- promote `sh264e_jpeg_get_last_streaming_cache_bytes` to the documented public stats surface alongside allocation stats
- replace JPEG tool ad hoc private forward declarations with `tests/sh264e_jpeg_test_hooks.h`
- gate allocation-limit and streaming-prototype internals behind `SH264E_ENABLE_JPEG_TEST_HOOKS`
- add a diagnostics-boundary regression check so the tool cannot reintroduce private forward declarations
- document which JPEG diagnostics are public stats and which hooks are test-only

Refs #44

## Validation

- `cmake -S . -B build/issue44`
- `cmake --build build/issue44`
- `ctest --test-dir build/issue44 --output-on-failure -R 'sh264e_jpeg_diagnostics_boundary|sh264e_jpeg_no_rgb_path|sh264e_ffmpeg_integration|sh264e_api'`
- `cmake -S . -B build/issue44-nohooks -DSH264E_BUILD_TESTS=OFF -DSH264E_ENABLE_JPEG_TEST_HOOKS=OFF`
- `cmake --build build/issue44-nohooks`
- `nm -g build/issue44-nohooks/libsimple_h264_enc_i.a | rg "sh264e_jpeg_set_test|streaming_prototype|sh264e_jpeg_get_streaming_work_size|sh264e_jpeg_get_last_streaming_cache_bytes"`
- `build/issue44-nohooks/sh264e_encode_jpeg --help`
- `ctest --test-dir build/issue44 --output-on-failure`
- `git diff --check`

The no-hook symbol audit shows only the public `sh264e_jpeg_get_last_streaming_cache_bytes` stat API; allocation-limit, streaming-prototype, and removed streaming work-size helper symbols are absent.
