### PR TITLE
jpeg: stream H.264 output chunks

### DIFF
--- a/MEMORY_OPTIMIZATION_PLAN.md
+++ b/MEMORY_OPTIMIZATION_PLAN.md
@@ -19,10 +19,10 @@ Current `2560x1440` 4:2:0 embedded budget, excluding compressed JPEG input and
 | --- | ---: | --- |
 | JPEG work arena | 245,904 | Includes streaming row cache and NanoJPEG MCU-row temp buffers |
 | JPEG/scaler slice work | 61,440 | One encoder-sized YUV420 slice |
-| Reusable H.264 output chunk buffer | 126,976 | `max(header, one slice)` complete-chunk model |
+| Reusable H.264 output chunk buffer | 4,096 | Byte-stream flush buffer |
 | Encoder heap | about 191,024 | Needs detailed breakdown |
 | Static mutable RAM | about 4,529 | Excludes `.rodata` |
-| Total | about 630 KiB class | Excludes compressed JPEG input |
+| Total | about 510 KiB class | Excludes compressed JPEG input |
 
 The old full decoded JPEG component-frame allocation was 5,529,600 bytes for
 `2560x1440` 4:2:0 and is no longer allowed for public JPEG APIs.
@@ -52,22 +52,21 @@ The old full decoded JPEG component-frame allocation was 5,529,600 bytes for
 
 Target the reusable H.264 output buffer:
 
-| Current | Target |
+| Previous | Implemented target |
 | ---: | ---: |
-| 126,976 bytes | preferably <= 4 KiB, unless implementation data justifies another bound |
+| 126,976 bytes | 4,096 bytes |
 
-The current JPEG streaming-output API emits one complete SPS/PPS chunk and one
-complete IDR slice chunk per callback. That keeps file I/O outside the library
-but still requires a buffer sized for the largest slice. The next step is a
-streaming bit writer / Annex B writer that can flush smaller byte chunks while
-preserving RBSP trailing bits and emulation-prevention behavior.
+The JPEG streaming-output API now flushes Annex B byte chunks through the
+caller-provided consumer instead of waiting for one complete SPS/PPS or IDR
+slice NALU. The implementation keeps file I/O outside the library and preserves
+RBSP trailing bits and emulation-prevention behavior across flush boundaries.
 
 Acceptance focus:
 
 * No complete-slice output buffer required for the embedded streaming path.
 * Consumer failure remains deterministic.
-* Bitstreams remain byte-for-byte identical where practical, or intentionally
-  different but strict-ffmpeg-decodable and documented.
+* Bitstreams remain byte-for-byte identical to the one-shot path for covered
+  fixtures, including tiny chunk-boundary regression coverage.
 
 ### #49 JPEG 1:1 2560x1440 4:2:0 Direct MCU-Row Fast Path
 

--- a/MEMORY_REDUCTION_PLAN.md
+++ b/MEMORY_REDUCTION_PLAN.md
@@ -254,10 +254,11 @@ still need the worst-case capacity when using the one-shot API.
 Implemented streaming behavior:
 
 * The public `sh264e_output_consumer_t` callback lets callers consume complete
-  Annex B chunks outside the library.
-* The arena-backed JPEG streaming-output API reuses one output chunk buffer for
-  SPS/PPS and each IDR slice.
-* Call the consumer once per complete Annex B chunk.
+  or partial Annex B byte-stream chunks outside the library.
+* The arena-backed JPEG streaming-output API reuses one small output chunk
+  buffer while preserving NAL-unit order and emulation-prevention behavior
+  across flush boundaries.
+* The production tool default flush buffer is 4,096 bytes.
 * Keep file I/O outside the library; tools/tests may implement file consumers.
 * Preserve the one-shot API as a convenience wrapper, potentially implemented
   through a memory consumer.
@@ -268,15 +269,16 @@ Memory target for `2560x1440` JPEG 4:2:0 embedded path:
 | --- | ---: |
 | JPEG work arena | 245,904 |
 | JPEG/scaler slice work | 61,440 |
-| Reusable H.264 output chunk buffer | 126,976 |
+| Reusable H.264 output chunk buffer | 4,096 |
 | Encoder heap | about 191,024 |
 | Static mutable RAM | about 4,529 |
-| Total, excluding compressed JPEG input and `.rodata` | about 630 KiB budget class |
+| Total, excluding compressed JPEG input and `.rodata` | about 510 KiB budget class |
 
 Acceptance criteria:
 
 * Embedded JPEG encode path using the streaming-output API no longer requires
-  the 11,428,864-byte max complete-frame output buffer.
+  the 11,428,864-byte max complete-frame output buffer or a one-slice output
+  chunk buffer.
 * Consumer callback errors stop encode deterministically.
 * Tool/test file output uses a consumer implemented outside the library.
 * One-shot API output and streaming-consumer output are byte-for-byte identical

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Encode a baseline JPEG memory-input path through the library wrapper:
 ./build/sh264e_encode_jpeg --format nv12 input.jpg output.h264
 ```
 
-The JPEG path uses NanoJPEG inside the core library. The tool only reads the JPEG file and writes the `.h264` output; the library API accepts a caller-provided JPEG byte buffer and emits complete Annex B chunks through caller-owned output memory.
+The JPEG path uses NanoJPEG inside the core library. The tool only reads the JPEG file and writes the `.h264` output; the library API accepts a caller-provided JPEG byte buffer and emits Annex B byte-stream chunks through caller-owned output memory.
 The tool sizes a caller-provided JPEG decoder arena with `sh264e_jpeg_get_work_size`, passes that arena to `sh264e_encode_jpeg_idr_with_arena_stream`, and prints the arena requirement plus current and peak NanoJPEG allocation bytes reported by `sh264e_jpeg_get_last_allocation_stats`.
 The public diagnostic surface also exposes `sh264e_jpeg_get_last_streaming_cache_bytes` so tools and regression tests can report decoded-row cache usage without private declarations.
 The arena-backed production path now uses MCU-row streaming by default. It keeps only NanoJPEG's current MCU-row buffers and the retained row cache, then feeds one scaled output slice at a time to the progressive encoder.
@@ -133,7 +133,7 @@ placement, but it must not decode the JPEG into a full RGB, grayscale, Y, Cb, or
 Cr component frame. One-shot JPEG APIs may still require a caller-provided
 complete H.264 output buffer; that output model is separate from JPEG decoded
 image memory.
-The JPEG tool uses the streaming H.264 output consumer API for its production arena path, so it writes each SPS/PPS or slice chunk as it is produced instead of allocating `sh264e_get_max_output_size()` bytes for the complete frame. For the current 2560x1440 encoder geometry this replaces the 11,428,864-byte one-shot output capacity with a reusable 126,976-byte output chunk buffer. Embedded callers can use the same API to forward chunks to flash, storage, DMA, or a ring buffer without a full-frame output buffer.
+The JPEG tool uses the streaming H.264 output consumer API for its production arena path, so it flushes the Annex B byte stream as it is produced instead of allocating `sh264e_get_max_output_size()` bytes for the complete frame. For the current 2560x1440 encoder geometry this replaces the 11,428,864-byte one-shot output capacity with a reusable 4,096-byte output chunk buffer. Embedded callers can use the same API to forward chunks to flash, storage, DMA, or a ring buffer without a full-frame or full-slice output buffer.
 
 For Cortex-M validation, CMake builds QEMU smoke firmware for M3/M4/M7 when the ARM bare-metal toolchain and QEMU are available. CMake first probes whether `arm-none-eabi-gcc` can compile the library's standard-header usage; if the toolchain is only partially installed, QEMU firmware tests are skipped instead of breaking the host build.
 

--- a/SPACE_REDUCTION.md
+++ b/SPACE_REDUCTION.md
@@ -342,10 +342,11 @@ maximum complete-frame output capacity is:
 This output buffer is caller-owned and excluded from the JPEG arena metrics, but
 it dominates an embedded memory budget if the one-shot JPEG API is used. The
 production tool path now uses the streaming H.264 output consumer API: the
-library emits SPS/PPS and each IDR slice into a reusable chunk buffer and calls
-a caller-provided consumer. Tools/tests implement file or memory consumers
+library flushes Annex B bytes into a reusable chunk buffer and calls a
+caller-provided consumer. Tools/tests implement file or memory consumers
 outside the library; embedded callers can forward chunks to storage, flash, DMA,
-or a ring buffer. The reusable output chunk buffer is currently 126,976 bytes.
+or a ring buffer. The production reusable output chunk buffer is currently
+4,096 bytes.
 
 ### Current Production Boundary
 

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -116,13 +116,13 @@ image height:
 | 2560x1440 4:2:0 | 184,320 | 61,440 |
 
 For the `2560x1440` 4:2:0 embedded path, excluding compressed JPEG input and
-`.rodata`, the current planning budget is about 630 KiB:
+`.rodata`, the current planning budget is about 510 KiB:
 
 | Block | Bytes |
 | --- | ---: |
 | JPEG work arena | 245,904 |
 | JPEG/scaler slice work | 61,440 |
-| Reusable H.264 output chunk buffer | 126,976 |
+| Reusable H.264 output chunk buffer | 4,096 |
 | Encoder heap | about 191,024 |
 | Static mutable RAM | about 4,529 |
 

--- a/docs/JPEG_STREAMING_MEMORY_REPORT.md
+++ b/docs/JPEG_STREAMING_MEMORY_REPORT.md
@@ -59,10 +59,11 @@ larger than typical encoded output; the measured `2560x1440` JPEG 4:2:0 fixture
 currently emits about 123 KiB of H.264 data.
 
 The production JPEG tool path now uses the streaming H.264 output consumer API
-and reuses one caller-owned output chunk buffer sized for `max(header, one
-slice)`, currently 126,976 bytes, instead of the 11,428,864-byte one-shot
-maximum output buffer. The tool writes each complete Annex B SPS/PPS or IDR
-slice chunk through a file consumer outside the library.
+and reuses one caller-owned byte-stream flush buffer, currently 4,096 bytes,
+instead of the 11,428,864-byte one-shot maximum output buffer or the old
+126,976-byte one-slice output chunk. The tool writes Annex B chunks through a
+file consumer outside the library; tests also cover tiny chunk boundaries to
+lock emulation-prevention behavior across flushes.
 
 For the `2560x1440` 4:2:0 embedded path, excluding compressed JPEG input and
 `.rodata`, the current budget is:
@@ -71,14 +72,14 @@ For the `2560x1440` 4:2:0 embedded path, excluding compressed JPEG input and
 | --- | ---: |
 | JPEG work arena | 245,904 |
 | JPEG/scaler slice work | 61,440 |
-| Reusable H.264 output chunk buffer | 126,976 |
+| Reusable H.264 output chunk buffer | 4,096 |
 | Encoder heap | about 191,024 |
 | Static mutable RAM | about 4,529 |
-| Rounded planning budget | about 630 KiB |
+| Rounded planning budget | about 510 KiB |
 
-The arithmetic subtotal of the rows above is about 629,873 bytes, or about
-615 KiB in binary units. The rounded planning budget remains the existing
-about-630 KiB target for this embedded path.
+The arithmetic subtotal of the rows above is about 506,993 bytes, or about
+495 KiB in binary units. The rounded planning budget is now about 510 KiB for
+this embedded path.
 
 ## Regression Coverage
 
@@ -124,22 +125,22 @@ Expected metric lines:
 
 ```text
 1280x720:
-jpeg output consumer chunks: 91
-jpeg output chunk buffer bytes: 126976
+jpeg output consumer chunks: 92
+jpeg output chunk buffer bytes: 4096
 jpeg work arena bytes: 92304
 jpeg slice work bytes: 61440
 jpeg peak allocation bytes: 92160
 jpeg streaming cache bytes: 61440
-jpeg output buffer bytes: 126976
+jpeg output buffer bytes: 4096
 
 2560x1440:
-jpeg output consumer chunks: 91
-jpeg output chunk buffer bytes: 126976
+jpeg output consumer chunks: 92
+jpeg output chunk buffer bytes: 4096
 jpeg work arena bytes: 245904
 jpeg slice work bytes: 61440
 jpeg peak allocation bytes: 245760
 jpeg streaming cache bytes: 184320
-jpeg output buffer bytes: 126976
+jpeg output buffer bytes: 4096
 ```
 
 The hidden one-shot comparison path remains available for regression tests and

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -103,7 +103,7 @@ Required public API concepts:
 * `sh264e_slice_t` — caller-provided progressive slice buffers
 * `sh264e_frame_t` — caller-provided input frame buffers
 * `sh264e_encoder_t` — opaque encoder handle
-* `sh264e_output_consumer_t` — callback that consumes complete Annex B output chunks
+* `sh264e_output_consumer_t` — callback that consumes Annex B output byte chunks
 
 The output bitstream buffer is provided by the caller. The library reports bytes written or returns a buffer-too-small error.
 
@@ -354,7 +354,13 @@ typedef sh264e_status_t (*sh264e_output_consumer_t)(
     size_t size);
 ```
 
-The streaming-output JPEG API should use a reusable caller-provided output chunk buffer sized for `max(header, one slice)`, call the consumer once for SPS/PPS and once per IDR slice, and stop deterministically if the consumer returns an error. The library must not call file APIs; tools/tests may implement a consumer that writes to a file.
+The streaming-output JPEG API uses the caller-provided output buffer as a
+reusable byte-stream flush buffer. It may split SPS/PPS or IDR slice NAL units
+across multiple consumer calls while preserving Annex B ordering, RBSP trailing
+bits, and emulation-prevention bytes across flush boundaries. The production
+tool uses a 4 KiB buffer by default, and smaller buffers are valid for tests or
+tighter embedded integrations. The library must not call file APIs; tools/tests
+may implement a consumer that writes to a file.
 
 `sh264e_jpeg_get_last_allocation_stats` reports the current and peak tracked
 JPEG allocations from the last JPEG work-size query or encode call.

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -41,6 +41,15 @@ typedef struct sh264e_bit_writer_t {
     int error;
 } sh264e_bit_writer_t;
 
+typedef struct sh264e_chunk_writer_t {
+    uint8_t *buffer;
+    size_t capacity;
+    size_t size;
+    size_t total;
+    sh264e_output_consumer_t consumer;
+    void *user;
+} sh264e_chunk_writer_t;
+
 struct sh264e_encoder_t {
     sh264e_config_t config;
     uint8_t *rbsp;
@@ -133,6 +142,19 @@ static size_t sh264e_jpeg_alloc_arena_capacity;
 static size_t sh264e_jpeg_streaming_last_cache_bytes;
 
 static void reset_progressive_state(sh264e_encoder_t *encoder);
+static sh264e_status_t sh264e_begin_idr_to_consumer(sh264e_encoder_t *encoder,
+                                                    uint8_t *chunk_buffer,
+                                                    size_t chunk_capacity,
+                                                    size_t *out_size,
+                                                    sh264e_output_consumer_t consumer,
+                                                    void *consumer_user);
+static sh264e_status_t sh264e_encode_idr_slice_to_consumer(sh264e_encoder_t *encoder,
+                                                           const sh264e_slice_t *slice,
+                                                           uint8_t *chunk_buffer,
+                                                           size_t chunk_capacity,
+                                                           size_t *out_size,
+                                                           sh264e_output_consumer_t consumer,
+                                                           void *consumer_user);
 static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *encoder,
                                                              const uint8_t *jpeg_data,
                                                              size_t jpeg_size,
@@ -1017,6 +1039,41 @@ static sh264e_status_t streaming_emit_output(sh264e_jpeg_stream_context_t *ctx, 
     return SH264E_OK;
 }
 
+static sh264e_status_t streaming_begin_idr(sh264e_jpeg_stream_context_t *ctx, size_t *bytes)
+{
+    if (ctx->consumer != NULL) {
+        return sh264e_begin_idr_to_consumer(ctx->encoder,
+                                            ctx->out,
+                                            ctx->out_capacity,
+                                            bytes,
+                                            ctx->consumer,
+                                            ctx->consumer_user);
+    }
+    return sh264e_begin_idr(ctx->encoder,
+                            streaming_output_ptr(ctx),
+                            streaming_output_capacity(ctx),
+                            bytes);
+}
+
+static sh264e_status_t streaming_encode_idr_slice(sh264e_jpeg_stream_context_t *ctx,
+                                                  const sh264e_slice_t *slice,
+                                                  size_t *bytes)
+{
+    if (ctx->consumer != NULL) {
+        return sh264e_encode_idr_slice_to_consumer(ctx->encoder,
+                                                   slice,
+                                                   ctx->out,
+                                                   ctx->out_capacity,
+                                                   bytes,
+                                                   ctx->consumer,
+                                                   ctx->consumer_user);
+    }
+    return sh264e_encode_idr_slice(ctx->encoder, slice,
+                                   streaming_output_ptr(ctx),
+                                   streaming_output_capacity(ctx),
+                                   bytes);
+}
+
 static int streaming_mcu_row_ready(int mcu_y, void *user)
 {
     sh264e_jpeg_stream_context_t *ctx = (sh264e_jpeg_stream_context_t *)user;
@@ -1040,12 +1097,11 @@ static int streaming_mcu_row_ready(int mcu_y, void *user)
     }
     if (!ctx->idr_started) {
         size_t bytes = 0u;
-        ctx->status = sh264e_begin_idr(ctx->encoder,
-                                       streaming_output_ptr(ctx),
-                                       streaming_output_capacity(ctx),
-                                       &bytes);
-        if (ctx->status == SH264E_OK) {
+        ctx->status = streaming_begin_idr(ctx, &bytes);
+        if (ctx->status == SH264E_OK && ctx->consumer == NULL) {
             ctx->status = streaming_emit_output(ctx, bytes);
+        } else if (ctx->status == SH264E_OK) {
+            ctx->offset += bytes;
         }
         if (ctx->status != SH264E_OK) {
             return 1;
@@ -1063,12 +1119,11 @@ static int streaming_mcu_row_ready(int mcu_y, void *user)
         } else {
             streaming_make_nv12_slice(ctx, ctx->next_slice, &slice);
         }
-        ctx->status = sh264e_encode_idr_slice(ctx->encoder, &slice,
-                                              streaming_output_ptr(ctx),
-                                              streaming_output_capacity(ctx),
-                                              &bytes);
-        if (ctx->status == SH264E_OK) {
+        ctx->status = streaming_encode_idr_slice(ctx, &slice, &bytes);
+        if (ctx->status == SH264E_OK && ctx->consumer == NULL) {
             ctx->status = streaming_emit_output(ctx, bytes);
+        } else if (ctx->status == SH264E_OK) {
+            ctx->offset += bytes;
         }
         if (ctx->status != SH264E_OK) {
             return 1;
@@ -1322,6 +1377,98 @@ static int append_byte(uint8_t *out, size_t capacity, size_t *offset, uint8_t va
     return 1;
 }
 
+static sh264e_status_t chunk_writer_flush(sh264e_chunk_writer_t *writer)
+{
+    sh264e_status_t status;
+
+    if (writer->size == 0u) {
+        return SH264E_OK;
+    }
+    status = writer->consumer(writer->user, writer->buffer, writer->size);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    writer->total += writer->size;
+    writer->size = 0u;
+    return SH264E_OK;
+}
+
+static sh264e_status_t chunk_writer_put_byte(sh264e_chunk_writer_t *writer, uint8_t value)
+{
+    sh264e_status_t status;
+
+    if (writer->size == writer->capacity) {
+        status = chunk_writer_flush(writer);
+        if (status != SH264E_OK) {
+            return status;
+        }
+    }
+    writer->buffer[writer->size++] = value;
+    return SH264E_OK;
+}
+
+static sh264e_status_t stream_annexb_nalu(uint8_t *chunk_buffer,
+                                          size_t chunk_capacity,
+                                          size_t *out_size,
+                                          sh264e_output_consumer_t consumer,
+                                          void *consumer_user,
+                                          uint8_t nal_header,
+                                          const uint8_t *rbsp,
+                                          size_t rbsp_size)
+{
+    sh264e_chunk_writer_t writer;
+    size_t i;
+    unsigned zero_count = 0;
+    sh264e_status_t status;
+
+    if (chunk_buffer == NULL || out_size == NULL || consumer == NULL ||
+        rbsp == NULL || chunk_capacity == 0u) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+
+    memset(&writer, 0, sizeof(writer));
+    writer.buffer = chunk_buffer;
+    writer.capacity = chunk_capacity;
+    writer.consumer = consumer;
+    writer.user = consumer_user;
+
+#define SH264E_TRY_PUT_BYTE(v)            \
+    do {                                  \
+        status = chunk_writer_put_byte(&writer, (uint8_t)(v)); \
+        if (status != SH264E_OK) {        \
+            return status;                \
+        }                                 \
+    } while (0)
+
+    SH264E_TRY_PUT_BYTE(0x00u);
+    SH264E_TRY_PUT_BYTE(0x00u);
+    SH264E_TRY_PUT_BYTE(0x01u);
+    SH264E_TRY_PUT_BYTE(nal_header);
+
+    for (i = 0; i < rbsp_size; i++) {
+        const uint8_t b = rbsp[i];
+        if (zero_count >= 2u && b <= 0x03u) {
+            SH264E_TRY_PUT_BYTE(0x03u);
+            zero_count = 0;
+        }
+        SH264E_TRY_PUT_BYTE(b);
+        if (b == 0x00u) {
+            zero_count++;
+        } else {
+            zero_count = 0;
+        }
+    }
+
+#undef SH264E_TRY_PUT_BYTE
+
+    status = chunk_writer_flush(&writer);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    *out_size = writer.total;
+    return SH264E_OK;
+}
+
 static sh264e_status_t append_annexb_nalu(uint8_t *out,
                                           size_t capacity,
                                           size_t *offset,
@@ -1360,10 +1507,7 @@ static sh264e_status_t append_annexb_nalu(uint8_t *out,
     return SH264E_OK;
 }
 
-static sh264e_status_t make_sps(sh264e_encoder_t *encoder,
-                                uint8_t *out,
-                                size_t capacity,
-                                size_t *offset)
+static sh264e_status_t write_sps_rbsp(sh264e_encoder_t *encoder, size_t *out_rbsp_size)
 {
     sh264e_bit_writer_t bw;
     bw_init(&bw, encoder->rbsp, encoder->rbsp_capacity);
@@ -1388,13 +1532,26 @@ static sh264e_status_t make_sps(sh264e_encoder_t *encoder,
     if (bw.error != 0) {
         return SH264E_ERR_INTERNAL;
     }
-    return append_annexb_nalu(out, capacity, offset, 0x67u, encoder->rbsp, bw_size(&bw));
+    *out_rbsp_size = bw_size(&bw);
+    return SH264E_OK;
 }
 
-static sh264e_status_t make_pps(sh264e_encoder_t *encoder,
+static sh264e_status_t make_sps(sh264e_encoder_t *encoder,
                                 uint8_t *out,
                                 size_t capacity,
                                 size_t *offset)
+{
+    sh264e_status_t status;
+    size_t rbsp_size = 0u;
+
+    status = write_sps_rbsp(encoder, &rbsp_size);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    return append_annexb_nalu(out, capacity, offset, 0x67u, encoder->rbsp, rbsp_size);
+}
+
+static sh264e_status_t write_pps_rbsp(sh264e_encoder_t *encoder, size_t *out_rbsp_size)
 {
     sh264e_bit_writer_t bw;
     bw_init(&bw, encoder->rbsp, encoder->rbsp_capacity);
@@ -1419,7 +1576,23 @@ static sh264e_status_t make_pps(sh264e_encoder_t *encoder,
     if (bw.error != 0) {
         return SH264E_ERR_INTERNAL;
     }
-    return append_annexb_nalu(out, capacity, offset, 0x68u, encoder->rbsp, bw_size(&bw));
+    *out_rbsp_size = bw_size(&bw);
+    return SH264E_OK;
+}
+
+static sh264e_status_t make_pps(sh264e_encoder_t *encoder,
+                                uint8_t *out,
+                                size_t capacity,
+                                size_t *offset)
+{
+    sh264e_status_t status;
+    size_t rbsp_size = 0u;
+
+    status = write_pps_rbsp(encoder, &rbsp_size);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    return append_annexb_nalu(out, capacity, offset, 0x68u, encoder->rbsp, rbsp_size);
 }
 
 static int clip_u8(int value)
@@ -1769,12 +1942,10 @@ static void set_luma_nz(sh264e_encoder_t *encoder, unsigned block_x, unsigned bl
     encoder->nz_luma[(size_t)block_y * SH264E_LUMA4_X + block_x] = nz;
 }
 
-static sh264e_status_t make_idr_slice(sh264e_encoder_t *encoder,
-                                      const sh264e_slice_t *slice,
-                                      unsigned slice_index,
-                                      uint8_t *out,
-                                      size_t capacity,
-                                      size_t *offset)
+static sh264e_status_t write_idr_slice_rbsp(sh264e_encoder_t *encoder,
+                                            const sh264e_slice_t *slice,
+                                            unsigned slice_index,
+                                            size_t *out_rbsp_size)
 {
     sh264e_bit_writer_t bw;
     unsigned mb_x;
@@ -1855,7 +2026,25 @@ static sh264e_status_t make_idr_slice(sh264e_encoder_t *encoder,
     if (bw.error != 0) {
         return SH264E_ERR_INTERNAL;
     }
-    return append_annexb_nalu(out, capacity, offset, 0x65u, encoder->rbsp, bw_size(&bw));
+    *out_rbsp_size = bw_size(&bw);
+    return SH264E_OK;
+}
+
+static sh264e_status_t make_idr_slice(sh264e_encoder_t *encoder,
+                                      const sh264e_slice_t *slice,
+                                      unsigned slice_index,
+                                      uint8_t *out,
+                                      size_t capacity,
+                                      size_t *offset)
+{
+    sh264e_status_t status;
+    size_t rbsp_size = 0u;
+
+    status = write_idr_slice_rbsp(encoder, slice, slice_index, &rbsp_size);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    return append_annexb_nalu(out, capacity, offset, 0x65u, encoder->rbsp, rbsp_size);
 }
 
 static sh264e_status_t map_jpeg_result(int result)
@@ -2392,6 +2581,103 @@ sh264e_status_t sh264e_encode_idr_slice(sh264e_encoder_t *encoder,
 
     encoder->slices_encoded++;
     *out_size = offset;
+    return SH264E_OK;
+}
+
+static sh264e_status_t sh264e_begin_idr_to_consumer(sh264e_encoder_t *encoder,
+                                                    uint8_t *chunk_buffer,
+                                                    size_t chunk_capacity,
+                                                    size_t *out_size,
+                                                    sh264e_output_consumer_t consumer,
+                                                    void *consumer_user)
+{
+    sh264e_status_t status;
+    size_t bytes = 0u;
+    size_t total = 0u;
+
+    if (encoder == NULL || chunk_buffer == NULL || out_size == NULL || consumer == NULL) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+    *out_size = 0u;
+    if (encoder->idr_active != 0u) {
+        return SH264E_ERR_BAD_STATE;
+    }
+    if (chunk_capacity == 0u) {
+        return SH264E_ERR_BUFFER_TOO_SMALL;
+    }
+
+    status = write_sps_rbsp(encoder, &bytes);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    status = stream_annexb_nalu(chunk_buffer, chunk_capacity, &bytes,
+                                consumer, consumer_user, 0x67u,
+                                encoder->rbsp, bytes);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    total += bytes;
+
+    status = write_pps_rbsp(encoder, &bytes);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    status = stream_annexb_nalu(chunk_buffer, chunk_capacity, &bytes,
+                                consumer, consumer_user, 0x68u,
+                                encoder->rbsp, bytes);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    total += bytes;
+
+    encoder->idr_active = 1u;
+    encoder->slices_encoded = 0u;
+    *out_size = total;
+    return SH264E_OK;
+}
+
+static sh264e_status_t sh264e_encode_idr_slice_to_consumer(sh264e_encoder_t *encoder,
+                                                           const sh264e_slice_t *slice,
+                                                           uint8_t *chunk_buffer,
+                                                           size_t chunk_capacity,
+                                                           size_t *out_size,
+                                                           sh264e_output_consumer_t consumer,
+                                                           void *consumer_user)
+{
+    sh264e_status_t status;
+    size_t bytes = 0u;
+
+    if (encoder == NULL || slice == NULL || chunk_buffer == NULL ||
+        out_size == NULL || consumer == NULL) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+    *out_size = 0u;
+    if (encoder->idr_active == 0u) {
+        return SH264E_ERR_BAD_STATE;
+    }
+    if (encoder->slices_encoded >= SH264E_MBS_Y) {
+        return SH264E_ERR_FRAME_COMPLETE;
+    }
+    status = validate_slice(&encoder->config, slice);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    if (chunk_capacity == 0u) {
+        return SH264E_ERR_BUFFER_TOO_SMALL;
+    }
+
+    status = write_idr_slice_rbsp(encoder, slice, encoder->slices_encoded, &bytes);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    status = stream_annexb_nalu(chunk_buffer, chunk_capacity, out_size,
+                                consumer, consumer_user, 0x65u,
+                                encoder->rbsp, bytes);
+    if (status != SH264E_OK) {
+        return status;
+    }
+
+    encoder->slices_encoded++;
     return SH264E_OK;
 }
 

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -33,8 +33,9 @@ PRODUCTION_MEMORY_1440P_420 = {
     "peak": 245_760,
     "cache": STREAMING_CACHE_BYTES_1440P_420,
 }
-H264_OUTPUT_CONSUMER_CHUNKS = 1 + 90
-H264_OUTPUT_CHUNK_BYTES = 126_976
+H264_OUTPUT_CONSUMER_CHUNKS_MIN = 1 + 90
+H264_OUTPUT_CHUNK_BYTES = 4_096
+H264_TINY_OUTPUT_CHUNK_BYTES = 7
 H264_ONE_SHOT_OUTPUT_BYTES = 11_428_864
 EMBEDDED_OUTPUT_BUFFER_TOTAL_1440P_420 = (
     PRODUCTION_MEMORY_1440P_420["work"]
@@ -350,9 +351,9 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
                 f"JPEG default path regressed to one-shot output buffering: got {output_buffer}"
             )
         chunks = parse_jpeg_metric(result.stdout, "jpeg output consumer chunks:")
-        if chunks != H264_OUTPUT_CONSUMER_CHUNKS:
+        if chunks < H264_OUTPUT_CONSUMER_CHUNKS_MIN:
             raise RuntimeError(
-                f"JPEG output consumer chunk count changed: got {chunks}, expected {H264_OUTPUT_CONSUMER_CHUNKS}"
+                f"JPEG output consumer chunk count changed: got {chunks}, expected at least {H264_OUTPUT_CONSUMER_CHUNKS_MIN}"
             )
         chunk_bytes = parse_jpeg_metric(result.stdout, "jpeg output chunk buffer bytes:")
         if chunk_bytes != H264_OUTPUT_CHUNK_BYTES:
@@ -398,24 +399,30 @@ def encode_jpeg_streaming_prototype(args, fmt, jpeg_input, bitstream, expected_c
         )
 
 
-def encode_jpeg_output_consumer(args, fmt, jpeg_input, bitstream):
-    result = run_capture([
+def encode_jpeg_output_consumer(args, fmt, jpeg_input, bitstream, extra_args=None,
+                                expected_chunk_bytes=H264_OUTPUT_CHUNK_BYTES):
+    command = [
         args.jpeg_encoder,
         "--test-output-consumer",
+    ]
+    if extra_args:
+        command.extend(extra_args)
+    command.extend([
         "--format",
         fmt,
         str(jpeg_input),
         str(bitstream),
     ])
+    result = run_capture(command)
     chunks = parse_jpeg_metric(result.stdout, "jpeg output consumer chunks:")
-    if chunks != H264_OUTPUT_CONSUMER_CHUNKS:
+    if chunks < H264_OUTPUT_CONSUMER_CHUNKS_MIN:
         raise RuntimeError(
-            f"JPEG output consumer chunk count changed: got {chunks}, expected {H264_OUTPUT_CONSUMER_CHUNKS}"
+            f"JPEG output consumer chunk count changed: got {chunks}, expected at least {H264_OUTPUT_CONSUMER_CHUNKS_MIN}"
         )
     chunk_bytes = parse_jpeg_metric(result.stdout, "jpeg output chunk buffer bytes:")
-    if chunk_bytes != H264_OUTPUT_CHUNK_BYTES:
+    if chunk_bytes != expected_chunk_bytes:
         raise RuntimeError(
-            f"JPEG output consumer chunk capacity changed: got {chunk_bytes}, expected {H264_OUTPUT_CHUNK_BYTES}"
+            f"JPEG output consumer chunk capacity changed: got {chunk_bytes}, expected {expected_chunk_bytes}"
         )
     if chunk_bytes >= H264_ONE_SHOT_OUTPUT_BYTES:
         raise RuntimeError(
@@ -565,6 +572,18 @@ def main():
                 validate_bitstream(args.ffprobe, args.ffmpeg, consumer_output)
                 if consumer_output.read_bytes() != one_shot_output.read_bytes():
                     raise RuntimeError("JPEG memory consumer bitstream differs from one-shot output")
+                tiny_consumer_output = workdir / "output_jpeg_consumer_tiny_yuvj420p_i420.h264"
+                encode_jpeg_output_consumer(
+                    args,
+                    fmt,
+                    jpeg_input,
+                    tiny_consumer_output,
+                    ["--test-output-chunk-size", str(H264_TINY_OUTPUT_CHUNK_BYTES)],
+                    H264_TINY_OUTPUT_CHUNK_BYTES,
+                )
+                validate_bitstream(args.ffprobe, args.ffmpeg, tiny_consumer_output)
+                if tiny_consumer_output.read_bytes() != one_shot_output.read_bytes():
+                    raise RuntimeError("JPEG tiny-chunk consumer bitstream differs from one-shot output")
                 run_expect_fail([
                     args.jpeg_encoder,
                     "--test-output-consumer-fail-after",
@@ -599,10 +618,10 @@ def main():
     validate_bitstream(args.ffprobe, args.ffmpeg, large_heap_wrapper_output)
     if large_heap_wrapper_output.read_bytes() != large_jpeg_output.read_bytes():
         raise RuntimeError("JPEG heap wrapper bitstream differs from arena streaming output")
-    if EMBEDDED_OUTPUT_BUFFER_TOTAL_1440P_420 != 434_320:
+    if EMBEDDED_OUTPUT_BUFFER_TOTAL_1440P_420 != 311_440:
         raise RuntimeError(
             "2560x1440 JPEG streaming memory subtotal changed: "
-            f"got {EMBEDDED_OUTPUT_BUFFER_TOTAL_1440P_420}, expected 434320"
+            f"got {EMBEDDED_OUTPUT_BUFFER_TOTAL_1440P_420}, expected 311440"
         )
     encode_jpeg_streaming_prototype(args, "i420", large_jpeg_input, large_streaming_output,
                                     STREAMING_CACHE_BYTES_1440P_420)

--- a/tools/sh264e_encode_jpeg.c
+++ b/tools/sh264e_encode_jpeg.c
@@ -13,6 +13,8 @@
 #include "sh264e_jpeg_test_hooks.h"
 #endif
 
+#define DEFAULT_OUTPUT_CHUNK_CAPACITY 4096u
+
 static void usage(const char *argv0)
 {
     fprintf(stderr,
@@ -22,7 +24,7 @@ static void usage(const char *argv0)
 #endif
             "[--test-arena-shrink BYTES] [--test-arena-offset BYTES] "
             "[--test-one-shot-output] [--test-output-consumer] "
-            "[--test-output-consumer-fail-after CHUNKS] "
+            "[--test-output-consumer-fail-after CHUNKS] [--test-output-chunk-size BYTES] "
             "--format i420|nv12 input.jpg output.h264\n",
             argv0);
 }
@@ -160,6 +162,7 @@ int main(int argc, char **argv)
     size_t work_size = 0;
     size_t output_capacity = 0;
     size_t output_chunk_capacity = 0;
+    size_t output_chunk_override = 0;
     size_t output_size = 0;
     size_t allocation_limit = (size_t)-1;
     size_t arena_shrink = 0;
@@ -198,6 +201,13 @@ int main(int argc, char **argv)
             }
             output_consumer_test = 1;
             output_consumer_fail_after = (int)fail_after;
+            argi += 2;
+        } else if (argi + 1 < argc && strcmp(argv[argi], "--test-output-chunk-size") == 0) {
+            if (!parse_size(argv[argi + 1], &output_chunk_override) ||
+                output_chunk_override == 0u) {
+                usage(argv[0]);
+                return 2;
+            }
             argi += 2;
         } else if (argi + 1 < argc && strcmp(argv[argi], "--test-arena-shrink") == 0) {
             if (!parse_size(argv[argi + 1], &arena_shrink)) {
@@ -241,6 +251,11 @@ int main(int argc, char **argv)
         fprintf(stderr, "--test-one-shot-output cannot be combined with other output test modes\n");
         goto done;
     }
+    if (output_chunk_override != 0u &&
+        (streaming_prototype || one_shot_output_test || allocation_limit != (size_t)-1)) {
+        fprintf(stderr, "--test-output-chunk-size requires streaming output mode\n");
+        goto done;
+    }
     if (allocation_limit == (size_t)-1) {
         status = sh264e_jpeg_get_work_size(jpeg_data, jpeg_size, &jpeg_work_size);
         if (status != SH264E_OK) {
@@ -278,20 +293,9 @@ int main(int argc, char **argv)
         }
     }
     if (allocation_limit == (size_t)-1 && !streaming_prototype && !one_shot_output_test) {
-        size_t header_capacity = 0u;
-        size_t slice_capacity = 0u;
-
-        status = sh264e_get_max_header_output_size(&config, &header_capacity);
-        if (status != SH264E_OK) {
-            fprintf(stderr, "sh264e_get_max_header_output_size failed: %s\n", sh264e_status_string(status));
-            goto done;
-        }
-        status = sh264e_get_max_slice_output_size(&config, &slice_capacity);
-        if (status != SH264E_OK) {
-            fprintf(stderr, "sh264e_get_max_slice_output_size failed: %s\n", sh264e_status_string(status));
-            goto done;
-        }
-        output_chunk_capacity = header_capacity > slice_capacity ? header_capacity : slice_capacity;
+        output_chunk_capacity = output_chunk_override != 0u
+                                    ? output_chunk_override
+                                    : DEFAULT_OUTPUT_CHUNK_CAPACITY;
     }
 
     if (allocation_limit == (size_t)-1) {
@@ -367,8 +371,8 @@ int main(int argc, char **argv)
                 status = probe_status;
             }
         }
-        if (status == SH264E_OK && consumer_state.chunks != 1u + SH264E_V1_SLICE_COUNT) {
-            fprintf(stderr, "output consumer saw %u chunks, expected %u\n",
+        if (status == SH264E_OK && consumer_state.chunks < 1u + SH264E_V1_SLICE_COUNT) {
+            fprintf(stderr, "output consumer saw %u chunks, expected at least %u\n",
                     consumer_state.chunks, 1u + SH264E_V1_SLICE_COUNT);
             status = SH264E_ERR_INTERNAL;
         }
@@ -404,8 +408,8 @@ int main(int argc, char **argv)
             output_chunk_buf, output_chunk_capacity,
             collect_output_chunk, &consumer_state);
         output_size = consumer_state.size;
-        if (status == SH264E_OK && consumer_state.chunks != 1u + SH264E_V1_SLICE_COUNT) {
-            fprintf(stderr, "output consumer saw %u chunks, expected %u\n",
+        if (status == SH264E_OK && consumer_state.chunks < 1u + SH264E_V1_SLICE_COUNT) {
+            fprintf(stderr, "output consumer saw %u chunks, expected at least %u\n",
                     consumer_state.chunks, 1u + SH264E_V1_SLICE_COUNT);
             status = SH264E_ERR_INTERNAL;
         }


### PR DESCRIPTION
## Summary

- route the JPEG streaming-output API through a byte-stream Annex B writer that flushes through the caller consumer with a small reusable buffer
- keep existing one-shot/progressive APIs source-compatible while preserving RBSP trailing bits and emulation-prevention across flush boundaries
- switch the JPEG tool default output chunk buffer from 126,976 bytes to 4,096 bytes and add a tiny-chunk regression path
- update memory docs, reports, and `MEMORY_OPTIMIZATION_PLAN.md` for the new output-buffer budget

Refs #48

## Validation

- `git fetch origin --prune`
- read `MEMORY_OPTIMIZATION_PLAN.md` from `origin/main` commit `2c7c3c7`
- `cmake -S . -B build/issue48`
- `cmake --build build/issue48`
- `python3 -m py_compile tests/run_ffmpeg_integration.py`
- `ctest --test-dir build/issue48 --output-on-failure -R 'sh264e_api|sh264e_ffmpeg_integration'`
- `ctest --test-dir build/issue48 --output-on-failure`
- `build/issue48/sh264e_encode_jpeg --format i420 build/issue48/integration/input_1440p_yuvj420p.jpg build/issue48/issue48_default_1440_i420.h264`
- `ffmpeg -v error -xerror -i build/issue48/issue48_default_1440_i420.h264 -f null -`
- `build/issue48/sh264e_encode_jpeg --format i420 build/issue48/integration/input_720p_yuvj420p.jpg build/issue48/issue48_default_720_i420.h264`
- `git diff --check`

Manual metric smoke reported `jpeg output chunk buffer bytes: 4096` for both 1280x720 and 2560x1440 JPEG paths. The 2560x1440 strict ffmpeg decode passed.

QEMU note: CMake skipped QEMU firmware tests because `arm-none-eabi-gcc` cannot compile `<stdlib.h>` in this environment.
