### PR TITLE
memory: report encoder heap breakdown

### DIFF
--- a/MEMORY_OPTIMIZATION_PLAN.md
+++ b/MEMORY_OPTIMIZATION_PLAN.md
@@ -20,7 +20,7 @@ Current `2560x1440` 4:2:0 embedded budget, excluding compressed JPEG input and
 | JPEG work arena | 245,904 | Includes streaming row cache and NanoJPEG MCU-row temp buffers |
 | JPEG/scaler slice work | 61,440 | One encoder-sized YUV420 slice |
 | Reusable H.264 output chunk buffer | 4,096 | Byte-stream flush buffer |
-| Encoder heap | about 191,024 | Needs detailed breakdown |
+| Encoder heap | 191,048 | See `docs/ENCODER_MEMORY_REPORT.md` |
 | Static mutable RAM | about 4,529 | Excludes `.rodata` |
 | Total | about 510 KiB class | Excludes compressed JPEG input |
 
@@ -94,11 +94,22 @@ Target the opaque encoder heap line item:
 
 | Current | Target |
 | ---: | --- |
-| about 191,024 bytes | measured sub-block report |
+| about 191,024 bytes | measured 191,048-byte sub-block report |
 
 This is a measurement issue before optimization. The report should identify the
 major encoder state contributors such as reconstructed storage, neighbor/nonzero
 state, bitstream scratch, and context/config overhead.
+
+Measured fixed-v1 composition:
+
+| Block | Bytes |
+| --- | ---: |
+| Encoder context/config | 72 |
+| Bitstream scratch | 126,976 |
+| Reconstructed luma slice | 40,960 |
+| Reconstructed chroma slices | 20,480 |
+| Neighbor/nonzero state | 2,560 |
+| Total encoder memory | 191,048 |
 
 Acceptance focus:
 

--- a/MEMORY_REDUCTION_PLAN.md
+++ b/MEMORY_REDUCTION_PLAN.md
@@ -41,7 +41,7 @@ the compressed JPEG input buffer:
 | --- | ---: | --- |
 | JPEG decoded component arena | 5,529,600 | Main target for this plan |
 | NanoJPEG static context BSS | about 525,032 | Mainly VLC tables |
-| Encoder internal heap | about 191,024 | One encoder instance |
+| Encoder internal heap | 191,048 | One encoder instance; see `docs/ENCODER_MEMORY_REPORT.md` |
 | H.264 header + reusable slice output buffers | 128,000 | Caller-owned |
 | JPEG/scaler output slice work buffer | 61,440 | Caller-owned |
 | Total | about 6.14 MiB | Excludes compressed JPEG input |
@@ -270,7 +270,7 @@ Memory target for `2560x1440` JPEG 4:2:0 embedded path:
 | JPEG work arena | 245,904 |
 | JPEG/scaler slice work | 61,440 |
 | Reusable H.264 output chunk buffer | 4,096 |
-| Encoder heap | about 191,024 |
+| Encoder heap | 191,048 |
 | Static mutable RAM | about 4,529 |
 | Total, excluding compressed JPEG input and `.rodata` | about 510 KiB budget class |
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ Encode a baseline JPEG memory-input path through the library wrapper:
 The JPEG path uses NanoJPEG inside the core library. The tool only reads the JPEG file and writes the `.h264` output; the library API accepts a caller-provided JPEG byte buffer and emits Annex B byte-stream chunks through caller-owned output memory.
 The tool sizes a caller-provided JPEG decoder arena with `sh264e_jpeg_get_work_size`, passes that arena to `sh264e_encode_jpeg_idr_with_arena_stream`, and prints the arena requirement plus current and peak NanoJPEG allocation bytes reported by `sh264e_jpeg_get_last_allocation_stats`.
 The public diagnostic surface also exposes `sh264e_jpeg_get_last_streaming_cache_bytes` so tools and regression tests can report decoded-row cache usage without private declarations.
+`sh264e_encoder_get_memory_report` reports the fixed-v1 encoder heap breakdown
+without creating an encoder; `docs/ENCODER_MEMORY_REPORT.md` records the current
+191,048-byte total and sub-block composition.
 The arena-backed production path now uses MCU-row streaming by default. It keeps only NanoJPEG's current MCU-row buffers and the retained row cache, then feeds one scaled output slice at a time to the progressive encoder.
 The printed peak allocation includes the streaming row cache and MCU-row temp buffers; it excludes caller-owned JPEG input, arena header overhead, slice-work, H.264 output buffers, and NanoJPEG's compact in-context Huffman metadata.
 Diagnostic-only JPEG allocation-limit and streaming-prototype hooks are gated by `SH264E_ENABLE_JPEG_TEST_HOOKS` and declared in `tests/sh264e_jpeg_test_hooks.h`; they are not normal application APIs.

--- a/docs/ENCODER_MEMORY_REPORT.md
+++ b/docs/ENCODER_MEMORY_REPORT.md
@@ -1,0 +1,51 @@
+# Encoder Memory Report
+
+Issue #50 records the fixed-v1 encoder heap breakdown used by the memory
+optimization roadmap.
+
+## Fixed V1 Breakdown
+
+For the supported `2560x1440` progressive IDR configuration, one encoder
+instance reports:
+
+| Block | Bytes | Notes |
+| --- | ---: | --- |
+| Encoder context/config | 72 | `sh264e_encoder_t` host-side control structure |
+| Bitstream scratch | 126,976 | Internal RBSP workspace sized by `sh264e_get_max_slice_output_size` |
+| Reconstructed luma slice | 40,960 | `2560 * 16` slice-local reconstructed luma |
+| Reconstructed chroma slices | 20,480 | U and V, each `1280 * 8` |
+| Neighbor/nonzero state | 2,560 | 4x4 luma nonzero state for one slice |
+| Total encoder memory | 191,048 | Sum of the rows above |
+
+The previously documented `about 191,024` byte budget was an estimate. The
+measured current 64-bit host total is `191,048` bytes.
+
+## Scope
+
+This report is only encoder-owned memory. It excludes:
+
+* caller-owned compressed JPEG input
+* JPEG decoder arena and NanoJPEG row-cache allocations
+* JPEG/scaler slice work buffer
+* H.264 output buffers or streaming output chunk buffers
+* `.rodata` and NanoJPEG compact Huffman metadata
+
+## Diagnostics
+
+`sh264e_encoder_get_memory_report` is a documented diagnostic/stat API. It
+validates the supplied encoder config and returns the sub-block sizes above
+without creating an encoder.
+
+The JPEG tool prints the same report:
+
+```text
+encoder memory total bytes: 191048
+encoder context bytes: 72
+encoder bitstream scratch bytes: 126976
+encoder recon luma bytes: 40960
+encoder recon chroma bytes: 20480
+encoder neighbor state bytes: 2560
+```
+
+`tests/test_api.c` and `tests/run_ffmpeg_integration.py` assert these values so
+accidental growth in the major encoder heap blocks is visible in CTest.

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -123,8 +123,11 @@ For the `2560x1440` 4:2:0 embedded path, excluding compressed JPEG input and
 | JPEG work arena | 245,904 |
 | JPEG/scaler slice work | 61,440 |
 | Reusable H.264 output chunk buffer | 4,096 |
-| Encoder heap | about 191,024 |
+| Encoder heap | 191,048 |
 | Static mutable RAM | about 4,529 |
+
+`docs/ENCODER_MEMORY_REPORT.md` breaks the encoder heap row into context,
+bitstream scratch, reconstructed-slice storage, and neighbor/nonzero state.
 
 The hidden one-shot comparison path still reports the complete H.264 output
 capacity, `11,428,864` bytes, when testing one-shot APIs. That is caller-owned
@@ -136,6 +139,7 @@ The normal public diagnostic surface includes:
 
 * `sh264e_jpeg_get_last_allocation_stats`
 * `sh264e_jpeg_get_last_streaming_cache_bytes`
+* `sh264e_encoder_get_memory_report`
 
 Private regression hooks such as allocation-limit fault injection and the
 streaming prototype entry points are declared in

--- a/docs/JPEG_STREAMING_MEMORY_REPORT.md
+++ b/docs/JPEG_STREAMING_MEMORY_REPORT.md
@@ -73,19 +73,23 @@ For the `2560x1440` 4:2:0 embedded path, excluding compressed JPEG input and
 | JPEG work arena | 245,904 |
 | JPEG/scaler slice work | 61,440 |
 | Reusable H.264 output chunk buffer | 4,096 |
-| Encoder heap | about 191,024 |
+| Encoder heap | 191,048 |
 | Static mutable RAM | about 4,529 |
 | Rounded planning budget | about 510 KiB |
 
-The arithmetic subtotal of the rows above is about 506,993 bytes, or about
+The arithmetic subtotal of the rows above is about 507,017 bytes, or about
 495 KiB in binary units. The rounded planning budget is now about 510 KiB for
 this embedded path.
+
+The encoder heap row is measured by `sh264e_encoder_get_memory_report`; see
+`docs/ENCODER_MEMORY_REPORT.md` for the context, bitstream scratch,
+reconstructed-slice, and neighbor-state breakdown.
 
 ## Regression Coverage
 
 `tests/run_ffmpeg_integration.py` asserts the exact production arena work,
-peak-allocation, row-cache, reusable output chunk, and one-shot output capacity
-values for representative JPEG fixtures. It also keeps broader
+peak-allocation, row-cache, reusable output chunk, encoder memory report, and
+one-shot output capacity values for representative JPEG fixtures. It also keeps broader
 color-subsampling coverage that fails if the production arena path regresses to
 full component-plane allocation or if the default JPEG tool path regresses to
 allocating `sh264e_get_max_output_size()` for H.264 output.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -329,6 +329,7 @@ sh264e_encode_jpeg_idr_with_arena
 sh264e_encode_jpeg_idr_with_arena_stream
 sh264e_jpeg_get_last_allocation_stats
 sh264e_jpeg_get_last_streaming_cache_bytes
+sh264e_encoder_get_memory_report
 ```
 
 The JPEG APIs accept a caller-provided JPEG byte buffer. File I/O remains outside the library.
@@ -369,6 +370,11 @@ capacity retained by the last MCU-row streaming query or encode call. These are
 diagnostic/stat APIs for regression reporting; allocation-limit and
 streaming-prototype hooks remain private test hooks gated by
 `SH264E_ENABLE_JPEG_TEST_HOOKS`.
+`sh264e_encoder_get_memory_report` reports fixed-v1 encoder-owned memory
+without constructing an encoder. The current report is 191,048 bytes total:
+72 bytes of context/config, 126,976 bytes of bitstream scratch, 40,960 bytes of
+reconstructed luma slice storage, 20,480 bytes of reconstructed chroma slice
+storage, and 2,560 bytes of neighbor/nonzero state.
 
 NanoJPEG decodes baseline JPEG through MCU-row streaming. The library scales decoded component rows directly into one YUV420 encoder slice at a time:
 
@@ -549,6 +555,7 @@ The generated bitstream must:
     * Luma: `2560 * 16`
     * Chroma U: `1280 * 8`
     * Chroma V: `1280 * 8`
+    * Neighbor/nonzero state: `640 * 4`
 
 ---
 

--- a/include/sh264e.h
+++ b/include/sh264e.h
@@ -63,6 +63,15 @@ typedef struct sh264e_jpeg_allocation_stats_t {
     size_t peak_bytes;
 } sh264e_jpeg_allocation_stats_t;
 
+typedef struct sh264e_encoder_memory_report_t {
+    size_t context_bytes;
+    size_t bitstream_scratch_bytes;
+    size_t recon_luma_bytes;
+    size_t recon_chroma_bytes;
+    size_t neighbor_state_bytes;
+    size_t total_bytes;
+} sh264e_encoder_memory_report_t;
+
 typedef struct sh264e_encoder_t sh264e_encoder_t;
 
 typedef sh264e_status_t (*sh264e_output_consumer_t)(void *user,
@@ -82,6 +91,10 @@ sh264e_status_t sh264e_get_max_slice_output_size(const sh264e_config_t *config,
 
 sh264e_status_t sh264e_get_max_output_size(const sh264e_config_t *config,
                                            size_t *out_size);
+
+sh264e_status_t sh264e_encoder_get_memory_report(
+    const sh264e_config_t *config,
+    sh264e_encoder_memory_report_t *out_report);
 
 sh264e_status_t sh264e_begin_idr(sh264e_encoder_t *encoder,
                                  uint8_t *out,

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -388,6 +388,26 @@ static sh264e_status_t validate_config(const sh264e_config_t *config)
     return SH264E_OK;
 }
 
+static size_t encoder_recon_luma_bytes(void)
+{
+    return (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_LUMA_HEIGHT;
+}
+
+static size_t encoder_recon_chroma_plane_bytes(void)
+{
+    return (size_t)SH264E_CHROMA_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT;
+}
+
+static size_t encoder_recon_chroma_bytes(void)
+{
+    return encoder_recon_chroma_plane_bytes() * 2u;
+}
+
+static size_t encoder_neighbor_state_bytes(void)
+{
+    return (size_t)SH264E_LUMA4_X * SH264E_SLICE_LUMA4_Y;
+}
+
 static sh264e_status_t validate_frame(const sh264e_config_t *config, const sh264e_frame_t *frame)
 {
     if (config == NULL || frame == NULL) {
@@ -1950,10 +1970,10 @@ static sh264e_status_t write_idr_slice_rbsp(sh264e_encoder_t *encoder,
     sh264e_bit_writer_t bw;
     unsigned mb_x;
 
-    memset(encoder->recon_y, 0, (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_LUMA_HEIGHT);
-    memset(encoder->recon_u, 128, (size_t)SH264E_CHROMA_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT);
-    memset(encoder->recon_v, 128, (size_t)SH264E_CHROMA_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT);
-    memset(encoder->nz_luma, 0, (size_t)SH264E_LUMA4_X * SH264E_SLICE_LUMA4_Y);
+    memset(encoder->recon_y, 0, encoder_recon_luma_bytes());
+    memset(encoder->recon_u, 128, encoder_recon_chroma_plane_bytes());
+    memset(encoder->recon_v, 128, encoder_recon_chroma_plane_bytes());
+    memset(encoder->nz_luma, 0, encoder_neighbor_state_bytes());
 
     bw_init(&bw, encoder->rbsp, encoder->rbsp_capacity);
 
@@ -2421,10 +2441,10 @@ sh264e_status_t sh264e_encoder_create(const sh264e_config_t *config,
     encoder->config = normalized;
     encoder->rbsp_capacity = max_slice_output_size;
     encoder->rbsp = (uint8_t *)malloc(encoder->rbsp_capacity);
-    encoder->recon_y = (uint8_t *)malloc((size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_LUMA_HEIGHT);
-    encoder->recon_u = (uint8_t *)malloc((size_t)SH264E_CHROMA_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT);
-    encoder->recon_v = (uint8_t *)malloc((size_t)SH264E_CHROMA_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT);
-    encoder->nz_luma = (uint8_t *)malloc((size_t)SH264E_LUMA4_X * SH264E_SLICE_LUMA4_Y);
+    encoder->recon_y = (uint8_t *)malloc(encoder_recon_luma_bytes());
+    encoder->recon_u = (uint8_t *)malloc(encoder_recon_chroma_plane_bytes());
+    encoder->recon_v = (uint8_t *)malloc(encoder_recon_chroma_plane_bytes());
+    encoder->nz_luma = (uint8_t *)malloc(encoder_neighbor_state_bytes());
 
     if (encoder->rbsp == NULL || encoder->recon_y == NULL || encoder->recon_u == NULL ||
         encoder->recon_v == NULL || encoder->nz_luma == NULL) {
@@ -2510,6 +2530,44 @@ sh264e_status_t sh264e_get_max_output_size(const sh264e_config_t *config, size_t
         return status;
     }
     *out_size = header_size + slice_size * SH264E_MBS_Y;
+    return SH264E_OK;
+}
+
+sh264e_status_t sh264e_encoder_get_memory_report(
+    const sh264e_config_t *config,
+    sh264e_encoder_memory_report_t *out_report)
+{
+    sh264e_status_t status;
+    sh264e_config_t normalized;
+    size_t bitstream_scratch_bytes = 0u;
+
+    if (config == NULL || out_report == NULL) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+    normalized = *config;
+    if (normalized.qp == 0) {
+        normalized.qp = SH264E_DEFAULT_QP;
+    }
+    status = validate_config(&normalized);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    status = sh264e_get_max_slice_output_size(&normalized, &bitstream_scratch_bytes);
+    if (status != SH264E_OK) {
+        return status;
+    }
+
+    memset(out_report, 0, sizeof(*out_report));
+    out_report->context_bytes = sizeof(sh264e_encoder_t);
+    out_report->bitstream_scratch_bytes = bitstream_scratch_bytes;
+    out_report->recon_luma_bytes = encoder_recon_luma_bytes();
+    out_report->recon_chroma_bytes = encoder_recon_chroma_bytes();
+    out_report->neighbor_state_bytes = encoder_neighbor_state_bytes();
+    out_report->total_bytes = out_report->context_bytes +
+                              out_report->bitstream_scratch_bytes +
+                              out_report->recon_luma_bytes +
+                              out_report->recon_chroma_bytes +
+                              out_report->neighbor_state_bytes;
     return SH264E_OK;
 }
 

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -37,6 +37,12 @@ H264_OUTPUT_CONSUMER_CHUNKS_MIN = 1 + 90
 H264_OUTPUT_CHUNK_BYTES = 4_096
 H264_TINY_OUTPUT_CHUNK_BYTES = 7
 H264_ONE_SHOT_OUTPUT_BYTES = 11_428_864
+ENCODER_CONTEXT_BYTES = 72
+ENCODER_BITSTREAM_SCRATCH_BYTES = 126_976
+ENCODER_RECON_LUMA_BYTES = 40_960
+ENCODER_RECON_CHROMA_BYTES = 20_480
+ENCODER_NEIGHBOR_STATE_BYTES = 2_560
+ENCODER_MEMORY_TOTAL_BYTES = 191_048
 EMBEDDED_OUTPUT_BUFFER_TOTAL_1440P_420 = (
     PRODUCTION_MEMORY_1440P_420["work"]
     + JPEG_SLICE_WORK_BYTES
@@ -297,6 +303,36 @@ def parse_jpeg_metric(stdout, prefix):
     raise RuntimeError(f"JPEG encoder did not report {prefix!r}: {stdout!r}")
 
 
+def validate_encoder_memory_report(stdout):
+    report = {
+        "context": parse_jpeg_metric(stdout, "encoder context bytes:"),
+        "bitstream": parse_jpeg_metric(stdout, "encoder bitstream scratch bytes:"),
+        "luma": parse_jpeg_metric(stdout, "encoder recon luma bytes:"),
+        "chroma": parse_jpeg_metric(stdout, "encoder recon chroma bytes:"),
+        "neighbor": parse_jpeg_metric(stdout, "encoder neighbor state bytes:"),
+        "total": parse_jpeg_metric(stdout, "encoder memory total bytes:"),
+    }
+    expected = {
+        "context": ENCODER_CONTEXT_BYTES,
+        "bitstream": ENCODER_BITSTREAM_SCRATCH_BYTES,
+        "luma": ENCODER_RECON_LUMA_BYTES,
+        "chroma": ENCODER_RECON_CHROMA_BYTES,
+        "neighbor": ENCODER_NEIGHBOR_STATE_BYTES,
+        "total": ENCODER_MEMORY_TOTAL_BYTES,
+    }
+    if report != expected:
+        raise RuntimeError(f"encoder memory report changed: got {report}, expected {expected}")
+    subtotal = (
+        report["context"]
+        + report["bitstream"]
+        + report["luma"]
+        + report["chroma"]
+        + report["neighbor"]
+    )
+    if report["total"] != subtotal:
+        raise RuntimeError(f"encoder memory total {report['total']} != sub-block sum {subtotal}")
+
+
 def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
                 expected_cache_bytes=None, max_peak_bytes=None,
                 expected_work_bytes=None, expected_peak_bytes=None):
@@ -310,6 +346,7 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
     one_shot_h264_output = one_shot_output or heap_wrapper_output
     if "jpeg current allocation bytes: 0" not in result.stdout:
         raise RuntimeError(f"JPEG encoder did not release tracked allocations: {result.stdout!r}")
+    validate_encoder_memory_report(result.stdout)
     if "jpeg work arena bytes:" not in result.stdout:
         raise RuntimeError(f"JPEG encoder did not report work arena size: {result.stdout!r}")
     work = parse_jpeg_metric(result.stdout, "jpeg work arena bytes:")

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -165,6 +165,7 @@ int main(void)
     uint8_t *small_input = NULL;
     uint8_t *resize_work = NULL;
     sh264e_jpeg_allocation_stats_t jpeg_alloc_stats;
+    sh264e_encoder_memory_report_t encoder_memory_report;
     int ok = 1;
 
     memset(&config, 0, sizeof(config));
@@ -192,12 +193,52 @@ int main(void)
     ok &= expect_status("max slice output size",
                         sh264e_get_max_slice_output_size(&config, &slice_capacity),
                         SH264E_OK);
+    ok &= expect_status("null encoder memory config",
+                        sh264e_encoder_get_memory_report(NULL, &encoder_memory_report),
+                        SH264E_ERR_INVALID_ARGUMENT);
+    ok &= expect_status("null encoder memory report",
+                        sh264e_encoder_get_memory_report(&config, NULL),
+                        SH264E_ERR_INVALID_ARGUMENT);
+    bad_config = config;
+    bad_config.height = 720u;
+    ok &= expect_status("unsupported encoder memory config",
+                        sh264e_encoder_get_memory_report(&bad_config, &encoder_memory_report),
+                        SH264E_ERR_UNSUPPORTED_CONFIG);
+    ok &= expect_status("encoder memory report",
+                        sh264e_encoder_get_memory_report(&config, &encoder_memory_report),
+                        SH264E_OK);
     if (output_capacity == 0u) {
         fprintf(stderr, "max output size returned zero\n");
         ok = 0;
     }
     if (header_capacity == 0u || slice_capacity == 0u) {
         fprintf(stderr, "progressive max output size returned zero\n");
+        ok = 0;
+    }
+    if (encoder_memory_report.context_bytes != 72u ||
+        encoder_memory_report.bitstream_scratch_bytes != slice_capacity ||
+        encoder_memory_report.recon_luma_bytes != 40960u ||
+        encoder_memory_report.recon_chroma_bytes != 20480u ||
+        encoder_memory_report.neighbor_state_bytes != 2560u ||
+        encoder_memory_report.total_bytes != 191048u) {
+        fprintf(stderr,
+                "unexpected encoder memory report: context=%zu bitstream=%zu "
+                "luma=%zu chroma=%zu neighbor=%zu total=%zu\n",
+                encoder_memory_report.context_bytes,
+                encoder_memory_report.bitstream_scratch_bytes,
+                encoder_memory_report.recon_luma_bytes,
+                encoder_memory_report.recon_chroma_bytes,
+                encoder_memory_report.neighbor_state_bytes,
+                encoder_memory_report.total_bytes);
+        ok = 0;
+    }
+    if (encoder_memory_report.total_bytes !=
+        encoder_memory_report.context_bytes +
+        encoder_memory_report.bitstream_scratch_bytes +
+        encoder_memory_report.recon_luma_bytes +
+        encoder_memory_report.recon_chroma_bytes +
+        encoder_memory_report.neighbor_state_bytes) {
+        fprintf(stderr, "encoder memory total does not match sub-block sum\n");
         ok = 0;
     }
     ok &= expect_status("null JPEG allocation stats",

--- a/tools/sh264e_encode_jpeg.c
+++ b/tools/sh264e_encode_jpeg.c
@@ -147,6 +147,7 @@ int main(int argc, char **argv)
     const char *output_path;
     sh264e_pixfmt_t pixfmt;
     sh264e_config_t config;
+    sh264e_encoder_memory_report_t encoder_memory_report;
     sh264e_encoder_t *encoder = NULL;
     sh264e_status_t status;
     uint8_t *jpeg_data = NULL;
@@ -279,6 +280,11 @@ int main(int argc, char **argv)
     config.pixfmt = pixfmt;
     config.qp = SH264E_DEFAULT_QP;
 
+    status = sh264e_encoder_get_memory_report(&config, &encoder_memory_report);
+    if (status != SH264E_OK) {
+        fprintf(stderr, "sh264e_encoder_get_memory_report failed: %s\n", sh264e_status_string(status));
+        goto done;
+    }
     status = sh264e_jpeg_get_slice_buffer_size(&work_size);
     if (status != SH264E_OK) {
         fprintf(stderr, "sh264e_jpeg_get_slice_buffer_size failed: %s\n", sh264e_status_string(status));
@@ -456,6 +462,13 @@ int main(int argc, char **argv)
                    !output_consumer_test && output_chunk_capacity != 0u) {
             printf("jpeg output buffer bytes: %zu\n", output_chunk_capacity);
         }
+        printf("encoder memory total bytes: %zu\n", encoder_memory_report.total_bytes);
+        printf("encoder context bytes: %zu\n", encoder_memory_report.context_bytes);
+        printf("encoder bitstream scratch bytes: %zu\n",
+               encoder_memory_report.bitstream_scratch_bytes);
+        printf("encoder recon luma bytes: %zu\n", encoder_memory_report.recon_luma_bytes);
+        printf("encoder recon chroma bytes: %zu\n", encoder_memory_report.recon_chroma_bytes);
+        printf("encoder neighbor state bytes: %zu\n", encoder_memory_report.neighbor_state_bytes);
     }
     printf("encoded JPEG input to progressive IDR frame\n");
     rc = 0;


### PR DESCRIPTION
## Summary

Refs #50

- Add `sh264e_encoder_get_memory_report` as a documented diagnostic/stat API for the fixed v1 encoder heap.
- Print encoder memory sub-blocks from the JPEG tool alongside existing JPEG/output metrics.
- Add CTest-visible guards for the 191,048-byte encoder memory total and major sub-blocks.
- Document the measured context, bitstream scratch, reconstructed-slice, and neighbor/nonzero-state breakdown.

## Validation

- `cmake -S . -B build/issue50`
- `cmake --build build/issue50`
- `ctest --test-dir build/issue50 --output-on-failure -R 'sh264e_api|sh264e_ffmpeg_integration'`
- `ctest --test-dir build/issue50 --output-on-failure`
- `python3 -m py_compile tests/run_ffmpeg_integration.py`
- `build/issue50/sh264e_encode_jpeg --format i420 build/issue50/integration/input_1440p_yuvj420p.jpg build/issue50/issue50_1440_i420.h264`
- `ffmpeg -v error -xerror -i build/issue50/issue50_1440_i420.h264 -f null -`
- `git diff --check`

## Notes

- The prior `about 191,024` budget was approximate; the measured current 64-bit host report is 191,048 bytes.
- The report excludes caller-owned JPEG input, JPEG arena, scaler slice work, H.264 output buffers, and `.rodata`.
