### PR TITLE
jpeg: add 1:1 streaming fast path

### DIFF
--- a/MEMORY_OPTIMIZATION_PLAN.md
+++ b/MEMORY_OPTIMIZATION_PLAN.md
@@ -17,12 +17,12 @@ Current `2560x1440` 4:2:0 embedded budget, excluding compressed JPEG input and
 
 | Block | Bytes | Notes |
 | --- | ---: | --- |
-| JPEG work arena | 245,904 | Includes streaming row cache and NanoJPEG MCU-row temp buffers |
-| JPEG/scaler slice work | 61,440 | One encoder-sized YUV420 slice |
+| JPEG work arena | 123,024 | 1:1 4:2:0 path: one MCU-row cache plus NanoJPEG MCU-row temp buffers |
+| JPEG/scaler slice work | 61,440 | API capacity; 1:1 effective use is I420 0 bytes, NV12 20,480 bytes |
 | Reusable H.264 output chunk buffer | 4,096 | Byte-stream flush buffer |
 | Encoder heap | about 191,024 | Needs detailed breakdown |
 | Static mutable RAM | about 4,529 | Excludes `.rodata` |
-| Total | about 510 KiB class | Excludes compressed JPEG input |
+| Total | about 390 KiB class | Excludes compressed JPEG input |
 
 The old full decoded JPEG component-frame allocation was 5,529,600 bytes for
 `2560x1440` 4:2:0 and is no longer allowed for public JPEG APIs.
@@ -75,12 +75,17 @@ identical:
 
 | Current | Target direction |
 | ---: | ---: |
-| 184,320 bytes | toward one MCU/slice row class, around 61,440 bytes if feasible |
+| 184,320 bytes | implemented at 61,440 bytes for 1:1 4:2:0 |
 
 When the source JPEG is already `2560x1440` 4:2:0, bilinear scaling should be
 unnecessary for I420 output and partly avoidable for NV12 output. The pipeline
 should detect this case, skip fixed-point scaling where safe, and feed encoder
 slices from the smallest valid row-cache/staging window.
+
+The implemented 1:1 path keeps one MCU row per component. I420 output feeds the
+encoder directly from the row cache, while NV12 still stages only the 20,480-byte
+interleaved chroma window. The public slice-work capacity remains 61,440 bytes
+until issue #53 narrows the caller-facing work-buffer contract.
 
 Acceptance focus:
 

--- a/MEMORY_REDUCTION_PLAN.md
+++ b/MEMORY_REDUCTION_PLAN.md
@@ -72,8 +72,8 @@ Target decoded-image working memory for `2560x1440` 4:2:0:
 | Path | Decoded-image working memory |
 | --- | ---: |
 | Current full component planes | 5,529,600 |
-| Target MCU-row streaming cache | about 184,320 |
-| Expected reduction | about 5.10 MiB |
+| MCU-row streaming cache after 1:1 fast path | 61,440 |
+| Expected reduction | about 5.21 MiB |
 
 The target excludes compressed JPEG input, encoder state, H.264 output buffers,
 and the existing 61,440-byte output slice work buffer.
@@ -147,9 +147,11 @@ Implemented bridge contract:
   geometry and the scaler's per-slice source row window.
 * The integration matrix asserts exact row-cache bytes for color JPEG inputs:
   61,440 bytes for 1280x720 4:2:0, 81,920 bytes for 1280x720 4:2:2,
-  122,880 bytes for 1280x720 4:4:4, and 184,320 bytes for 2560x1440 4:2:0.
+  122,880 bytes for 1280x720 4:4:4, and 61,440 bytes for the 2560x1440 4:2:0
+  1:1 fast path.
 * The JPEG tool and integration matrix also assert the scaled output slice work
-  buffer remains 61,440 bytes.
+  buffer remains 61,440 bytes. For the 1:1 fast path, effective slice staging
+  is 0 bytes for I420 and 20,480 bytes for NV12.
 
 ### 3. Production API Switch
 
@@ -214,10 +216,10 @@ a configurable small fast table. With default `NJ_VLC_FAST_BITS=8`, the
 `2560x1440` 4:2:0 production peak is now:
 
 ```text
-184,320 bytes  streaming retained row cache
+ 61,440 bytes  streaming retained row cache
  61,440 bytes  NanoJPEG MCU-row temp buffers
 ----------
-245,760 bytes  tracked peak allocation
+122,880 bytes  tracked peak allocation
 ```
 
 Implemented direction:
@@ -230,8 +232,8 @@ Implemented direction:
 
 Acceptance criteria:
 
-* `2560x1440` 4:2:0 production peak allocation is 245,760 bytes, below 270 KiB.
-* `jpeg streaming cache bytes` remains 184,320.
+* `2560x1440` 4:2:0 production peak allocation is 122,880 bytes, below 270 KiB.
+* `jpeg streaming cache bytes` is 61,440 for the 1:1 fast path.
 * Production encode does not regress to the old 5,529,600-byte full
   component-plane allocation.
 * Strict ffmpeg decode and full CTest remain green.
@@ -267,12 +269,12 @@ Memory target for `2560x1440` JPEG 4:2:0 embedded path:
 
 | Area | Bytes |
 | --- | ---: |
-| JPEG work arena | 245,904 |
+| JPEG work arena | 123,024 |
 | JPEG/scaler slice work | 61,440 |
 | Reusable H.264 output chunk buffer | 4,096 |
 | Encoder heap | about 191,024 |
 | Static mutable RAM | about 4,529 |
-| Total, excluding compressed JPEG input and `.rodata` | about 510 KiB budget class |
+| Total, excluding compressed JPEG input and `.rodata` | about 390 KiB budget class |
 
 Acceptance criteria:
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ Encode a baseline JPEG memory-input path through the library wrapper:
 The JPEG path uses NanoJPEG inside the core library. The tool only reads the JPEG file and writes the `.h264` output; the library API accepts a caller-provided JPEG byte buffer and emits Annex B byte-stream chunks through caller-owned output memory.
 The tool sizes a caller-provided JPEG decoder arena with `sh264e_jpeg_get_work_size`, passes that arena to `sh264e_encode_jpeg_idr_with_arena_stream`, and prints the arena requirement plus current and peak NanoJPEG allocation bytes reported by `sh264e_jpeg_get_last_allocation_stats`.
 The public diagnostic surface also exposes `sh264e_jpeg_get_last_streaming_cache_bytes` so tools and regression tests can report decoded-row cache usage without private declarations.
+`sh264e_jpeg_get_last_slice_work_bytes` reports the effective slice staging
+used by the last JPEG encode. For `2560x1440` 4:2:0 source JPEGs, the 1:1 fast
+path reduces retained row cache to 61,440 bytes and effectively uses 0 bytes of
+slice staging for I420 or 20,480 bytes for NV12, while the public work-buffer
+capacity remains conservatively 61,440 bytes.
 The arena-backed production path now uses MCU-row streaming by default. It keeps only NanoJPEG's current MCU-row buffers and the retained row cache, then feeds one scaled output slice at a time to the progressive encoder.
 The printed peak allocation includes the streaming row cache and MCU-row temp buffers; it excludes caller-owned JPEG input, arena header overhead, slice-work, H.264 output buffers, and NanoJPEG's compact in-context Huffman metadata.
 Diagnostic-only JPEG allocation-limit and streaming-prototype hooks are gated by `SH264E_ENABLE_JPEG_TEST_HOOKS` and declared in `tests/sh264e_jpeg_test_hooks.h`; they are not normal application APIs.

--- a/SPACE_REDUCTION.md
+++ b/SPACE_REDUCTION.md
@@ -296,7 +296,7 @@ Approximate component-cache targets from the design note:
 | 1280x720 4:2:0 | 1,382,400 | 61,440 |
 | 1280x720 4:2:2 | 1,843,200 | 81,920 |
 | 1280x720 4:4:4 | 2,764,800 | 122,880 |
-| 2560x1440 4:2:0 | 5,529,600 | 184,320 |
+| 2560x1440 4:2:0, 1:1 fast path | 5,529,600 | 61,440 |
 | 5120x2880 4:2:0 | not yet measured | 491,520 |
 | 5120x2880 4:4:4 | not yet measured | 819,200 |
 
@@ -312,7 +312,7 @@ path no longer requires the previous full decoded component planes:
 | Source JPEG | Previous full component planes | Production arena work | Production peak allocation | Streaming row cache |
 | --- | ---: | ---: | ---: | ---: |
 | 1280x720 4:2:0 | 1,382,400 | 92,304 | 92,160 | 61,440 |
-| 2560x1440 4:2:0 | 5,529,600 | 245,904 | 245,760 | 184,320 |
+| 2560x1440 4:2:0, 1:1 fast path | 5,529,600 | 123,024 | 122,880 | 61,440 |
 
 The production peak no longer includes the previous 524,288-byte NanoJPEG VLC
 lookup block. NanoJPEG stores compact canonical Huffman metadata in its decoder
@@ -323,12 +323,13 @@ Current `2560x1440` 4:2:0 production peak allocation breaks down as:
 
 | Block | Bytes |
 | --- | ---: |
-| Streaming retained row cache | 184,320 |
+| Streaming retained row cache | 61,440 |
 | NanoJPEG MCU-row temp buffers | 61,440 |
-| Total tracked peak allocation | 245,760 |
+| Total tracked peak allocation | 122,880 |
 
-Issue #31 reduced the `2560x1440` 4:2:0 production peak below the 270 KiB target
-without increasing the 184,320-byte row cache or regressing to full
+Issue #31 reduced the `2560x1440` 4:2:0 production peak below the 270 KiB
+target. Issue #49 added the source-equals-destination 4:2:0 fast path and
+reduced the 2560x1440 row cache to one MCU/slice row without regressing to full
 component-plane decode.
 
 The next reduced embedded RAM risk after JPEG decode memory was the one-shot

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -31,7 +31,8 @@ compressed JPEG byte buffer
 -> parse JPEG headers
 -> decode one MCU row into NanoJPEG temporary component rows
 -> copy the MCU row into a rolling component row cache
--> scale the available source row window into one 2560x16 encoder slice
+-> scale the available source row window into one 2560x16 encoder slice,
+   or use the 2560x1440 4:2:0 1:1 direct path
 -> encode one H.264 IDR slice
 -> repeat until all 90 H.264 slices are emitted
 ```
@@ -94,6 +95,12 @@ window for the next output slice is available, the integration layer scales one
 YUV420 slice into the caller-provided 61,440-byte slice work buffer and calls
 `sh264e_encode_idr_slice`.
 
+For `2560x1440` 4:2:0 source JPEGs encoded to the fixed `2560x1440` target,
+the pipeline uses a 1:1 fast path. It keeps exactly one MCU row per component,
+feeds I420 slices directly from the retained cache, and only stages the 8-row
+interleaved chroma window required for NV12 output. Non-1:1 sources keep the
+general bilinear scaler cache and slice-work behavior.
+
 ## Memory Contract
 
 Historical full component-plane decoded-image sizes were:
@@ -113,14 +120,14 @@ image height:
 | 1280x720 4:2:0 | 61,440 | 61,440 |
 | 1280x720 4:2:2 | 81,920 | 61,440 |
 | 1280x720 4:4:4 | 122,880 | 61,440 |
-| 2560x1440 4:2:0 | 184,320 | 61,440 |
+| 2560x1440 4:2:0, 1:1 fast path | 61,440 | 61,440 API capacity; effective I420 0, NV12 20,480 |
 
 For the `2560x1440` 4:2:0 embedded path, excluding compressed JPEG input and
-`.rodata`, the current planning budget is about 510 KiB:
+`.rodata`, the current planning budget is about 390 KiB:
 
 | Block | Bytes |
 | --- | ---: |
-| JPEG work arena | 245,904 |
+| JPEG work arena | 123,024 |
 | JPEG/scaler slice work | 61,440 |
 | Reusable H.264 output chunk buffer | 4,096 |
 | Encoder heap | about 191,024 |
@@ -136,6 +143,7 @@ The normal public diagnostic surface includes:
 
 * `sh264e_jpeg_get_last_allocation_stats`
 * `sh264e_jpeg_get_last_streaming_cache_bytes`
+* `sh264e_jpeg_get_last_slice_work_bytes`
 
 Private regression hooks such as allocation-limit fault injection and the
 streaming prototype entry points are declared in

--- a/docs/JPEG_STREAMING_MEMORY_REPORT.md
+++ b/docs/JPEG_STREAMING_MEMORY_REPORT.md
@@ -13,7 +13,7 @@ from the earlier allocation report. The production measurements below are from
 | Source JPEG | Previous full component planes | Production arena work | Production peak allocation | Streaming row cache | Slice work buffer |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | 1280x720 4:2:0 | 1,382,400 | 92,304 | 92,160 | 61,440 | 61,440 |
-| 2560x1440 4:2:0 | 5,529,600 | 245,904 | 245,760 | 184,320 | 61,440 |
+| 2560x1440 4:2:0, 1:1 fast path | 5,529,600 | 123,024 | 122,880 | 61,440 | 61,440 API capacity |
 
 `Production peak allocation` now excludes the previous dynamic NanoJPEG VLC
 lookup block. NanoJPEG decodes DHT tables into compact canonical Huffman
@@ -28,17 +28,27 @@ Regression tools read tracked allocation stats through
 and streaming-prototype comparison entry points are private test hooks gated by
 `SH264E_ENABLE_JPEG_TEST_HOOKS`, not production application APIs.
 
-For the `2560x1440` 4:2:0 row, the measured peak breaks down as:
+For the `2560x1440` 4:2:0 1:1 row, the measured peak breaks down as:
 
 | Block | Bytes |
 | --- | ---: |
-| Streaming retained row cache | 184,320 |
+| Streaming retained row cache | 61,440 |
 | NanoJPEG MCU-row temp buffers | 61,440 |
-| Total tracked peak allocation | 245,760 |
+| Total tracked peak allocation | 122,880 |
 
 Issue #31 reduced production peak allocation below the 270 KiB target without
-increasing the 184,320-byte row cache or regressing to full component-plane
-decode. Custom DHT baseline JPEGs remain supported.
+regressing to full component-plane decode. Issue #49 then added the 1:1
+`2560x1440` 4:2:0 fast path, reducing that row cache to one MCU/slice row.
+Custom DHT baseline JPEGs remain supported.
+
+For the 1:1 fast path, the public API still accepts the conservative
+61,440-byte slice work buffer returned by `sh264e_jpeg_get_slice_buffer_size`.
+The effective slice staging used by the implementation is lower:
+
+| Output format | Effective slice work bytes | Notes |
+| --- | ---: | --- |
+| I420 | 0 | Encoder slice planes point directly into the retained MCU-row cache |
+| NV12 | 20,480 | Luma points into the cache; chroma is interleaved into an 8-row UV staging window |
 
 ## Output Buffer Boundary
 
@@ -70,22 +80,22 @@ For the `2560x1440` 4:2:0 embedded path, excluding compressed JPEG input and
 
 | Block | Bytes |
 | --- | ---: |
-| JPEG work arena | 245,904 |
+| JPEG work arena | 123,024 |
 | JPEG/scaler slice work | 61,440 |
 | Reusable H.264 output chunk buffer | 4,096 |
 | Encoder heap | about 191,024 |
 | Static mutable RAM | about 4,529 |
-| Rounded planning budget | about 510 KiB |
+| Rounded planning budget | about 390 KiB |
 
-The arithmetic subtotal of the rows above is about 506,993 bytes, or about
-495 KiB in binary units. The rounded planning budget is now about 510 KiB for
+The arithmetic subtotal of the rows above is about 384,113 bytes, or about
+375 KiB in binary units. The rounded planning budget is now about 390 KiB for
 this embedded path.
 
 ## Regression Coverage
 
 `tests/run_ffmpeg_integration.py` asserts the exact production arena work,
-peak-allocation, row-cache, reusable output chunk, and one-shot output capacity
-values for representative JPEG fixtures. It also keeps broader
+peak-allocation, row-cache, effective slice work, reusable output chunk, and
+one-shot output capacity values for representative JPEG fixtures. It also keeps broader
 color-subsampling coverage that fails if the production arena path regresses to
 full component-plane allocation or if the default JPEG tool path regresses to
 allocating `sh264e_get_max_output_size()` for H.264 output.
@@ -129,6 +139,7 @@ jpeg output consumer chunks: 92
 jpeg output chunk buffer bytes: 4096
 jpeg work arena bytes: 92304
 jpeg slice work bytes: 61440
+jpeg effective slice work bytes: 61440
 jpeg peak allocation bytes: 92160
 jpeg streaming cache bytes: 61440
 jpeg output buffer bytes: 4096
@@ -136,10 +147,11 @@ jpeg output buffer bytes: 4096
 2560x1440:
 jpeg output consumer chunks: 92
 jpeg output chunk buffer bytes: 4096
-jpeg work arena bytes: 245904
+jpeg work arena bytes: 123024
 jpeg slice work bytes: 61440
-jpeg peak allocation bytes: 245760
-jpeg streaming cache bytes: 184320
+jpeg effective slice work bytes: 0
+jpeg peak allocation bytes: 122880
+jpeg streaming cache bytes: 61440
 jpeg output buffer bytes: 4096
 ```
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -329,6 +329,7 @@ sh264e_encode_jpeg_idr_with_arena
 sh264e_encode_jpeg_idr_with_arena_stream
 sh264e_jpeg_get_last_allocation_stats
 sh264e_jpeg_get_last_streaming_cache_bytes
+sh264e_jpeg_get_last_slice_work_bytes
 ```
 
 The JPEG APIs accept a caller-provided JPEG byte buffer. File I/O remains outside the library.
@@ -365,12 +366,18 @@ may implement a consumer that writes to a file.
 `sh264e_jpeg_get_last_allocation_stats` reports the current and peak tracked
 JPEG allocations from the last JPEG work-size query or encode call.
 `sh264e_jpeg_get_last_streaming_cache_bytes` reports the decoded row-cache
-capacity retained by the last MCU-row streaming query or encode call. These are
-diagnostic/stat APIs for regression reporting; allocation-limit and
+capacity retained by the last MCU-row streaming query or encode call.
+`sh264e_jpeg_get_last_slice_work_bytes` reports the effective slice staging used
+by the last JPEG encode. These are diagnostic/stat APIs for regression reporting; allocation-limit and
 streaming-prototype hooks remain private test hooks gated by
 `SH264E_ENABLE_JPEG_TEST_HOOKS`.
 
 NanoJPEG decodes baseline JPEG through MCU-row streaming. The library scales decoded component rows directly into one YUV420 encoder slice at a time:
+
+For `2560x1440` 4:2:0 source JPEGs encoded to the fixed target, the JPEG path
+uses a 1:1 fast path. It skips bilinear scaling, keeps one MCU row per
+component, feeds I420 slices directly from the retained rows, and stages only
+the 20,480-byte interleaved UV window needed for NV12.
 
 * I420 encoder config: Y, U, and V slice planes
 * NV12 encoder config: Y and interleaved UV slice planes

--- a/include/sh264e.h
+++ b/include/sh264e.h
@@ -121,6 +121,8 @@ sh264e_status_t sh264e_jpeg_get_last_allocation_stats(sh264e_jpeg_allocation_sta
 
 size_t sh264e_jpeg_get_last_streaming_cache_bytes(void);
 
+size_t sh264e_jpeg_get_last_slice_work_bytes(void);
+
 sh264e_status_t sh264e_encode_jpeg_idr(sh264e_encoder_t *encoder,
                                        const uint8_t *jpeg_data,
                                        size_t jpeg_size,

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -100,9 +100,11 @@ typedef struct sh264e_jpeg_stream_context_t {
     sh264e_output_consumer_t consumer;
     void *consumer_user;
     size_t cache_bytes;
+    size_t effective_slice_work_bytes;
     unsigned next_slice;
     unsigned idr_started;
     int component_count;
+    int one_to_one_420;
     int measure_only;
     int initialized;
     sh264e_status_t status;
@@ -140,6 +142,7 @@ static sh264e_jpeg_alloc_mode_t sh264e_jpeg_alloc_mode = SH264E_JPEG_ALLOC_HEAP;
 static uint8_t *sh264e_jpeg_alloc_arena;
 static size_t sh264e_jpeg_alloc_arena_capacity;
 static size_t sh264e_jpeg_streaming_last_cache_bytes;
+static size_t sh264e_jpeg_streaming_last_slice_work_bytes;
 
 static void reset_progressive_state(sh264e_encoder_t *encoder);
 static sh264e_status_t sh264e_begin_idr_to_consumer(sh264e_encoder_t *encoder,
@@ -779,30 +782,72 @@ static uint32_t streaming_cache_rows_for_slice_window(uint32_t src_height,
     return max_rows + rows_per_mcu;
 }
 
+static int streaming_is_one_to_one_420(void)
+{
+    if (njGetComponentCount() != 3 ||
+        njGetWidth() != (int)SH264E_V1_WIDTH ||
+        njGetHeight() != (int)SH264E_V1_HEIGHT) {
+        return 0;
+    }
+    return njGetComponentWidth(0) == (int)SH264E_V1_WIDTH &&
+           njGetComponentHeight(0) == (int)SH264E_V1_HEIGHT &&
+           njGetComponentWidth(1) == (int)SH264E_CHROMA_WIDTH &&
+           njGetComponentHeight(1) == (int)(SH264E_V1_HEIGHT / 2u) &&
+           njGetComponentWidth(2) == (int)SH264E_CHROMA_WIDTH &&
+           njGetComponentHeight(2) == (int)(SH264E_V1_HEIGHT / 2u) &&
+           njGetComponentSsx(0) == 2 &&
+           njGetComponentSsy(0) == 2 &&
+           njGetComponentSsx(1) == 1 &&
+           njGetComponentSsy(1) == 1 &&
+           njGetComponentSsx(2) == 1 &&
+           njGetComponentSsy(2) == 1;
+}
+
+static void streaming_direct_source_range(unsigned component_index,
+                                          unsigned slice_index,
+                                          uint32_t *out_min_y,
+                                          uint32_t *out_max_y)
+{
+    const uint32_t rows = component_index == 0u ? SH264E_V1_SLICE_LUMA_HEIGHT :
+                                                 SH264E_V1_SLICE_CHROMA_HEIGHT;
+    const uint32_t min_y = (uint32_t)slice_index * rows;
+
+    *out_min_y = min_y;
+    *out_max_y = min_y + rows - 1u;
+}
+
 static int streaming_slice_available(const sh264e_jpeg_stream_context_t *ctx, unsigned slice_index)
 {
     uint32_t min_y;
     uint32_t max_y;
     unsigned i;
 
-    streaming_source_range(ctx->components[0].height,
-                           SH264E_V1_HEIGHT,
-                           slice_index * SH264E_V1_SLICE_LUMA_HEIGHT,
-                           SH264E_V1_SLICE_LUMA_HEIGHT,
-                           &min_y,
-                           &max_y);
+    if (ctx->one_to_one_420) {
+        streaming_direct_source_range(0u, slice_index, &min_y, &max_y);
+    } else {
+        streaming_source_range(ctx->components[0].height,
+                               SH264E_V1_HEIGHT,
+                               slice_index * SH264E_V1_SLICE_LUMA_HEIGHT,
+                               SH264E_V1_SLICE_LUMA_HEIGHT,
+                               &min_y,
+                               &max_y);
+    }
     if (min_y < ctx->components[0].row0 ||
         max_y >= ctx->components[0].row0 + ctx->components[0].rows) {
         return 0;
     }
 
     for (i = 1u; i < (unsigned)ctx->component_count; i++) {
-        streaming_source_range(ctx->components[i].height,
-                               SH264E_V1_HEIGHT / 2u,
-                               slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT,
-                               SH264E_V1_SLICE_CHROMA_HEIGHT,
-                               &min_y,
-                               &max_y);
+        if (ctx->one_to_one_420) {
+            streaming_direct_source_range(i, slice_index, &min_y, &max_y);
+        } else {
+            streaming_source_range(ctx->components[i].height,
+                                   SH264E_V1_HEIGHT / 2u,
+                                   slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                   SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                   &min_y,
+                                   &max_y);
+        }
         if (min_y < ctx->components[i].row0 ||
             max_y >= ctx->components[i].row0 + ctx->components[i].rows) {
             return 0;
@@ -818,6 +863,25 @@ static void streaming_make_i420_slice(const sh264e_jpeg_stream_context_t *ctx,
     uint8_t *dst_y = ctx->work_buffer;
     uint8_t *dst_u = dst_y + (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_LUMA_HEIGHT;
     uint8_t *dst_v = dst_u + (size_t)SH264E_CHROMA_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT;
+
+    memset(slice, 0, sizeof(*slice));
+    slice->pixfmt = SH264E_PIXFMT_I420;
+
+    if (ctx->one_to_one_420) {
+        const sh264e_jpeg_stream_component_t *y = &ctx->components[0];
+        const sh264e_jpeg_stream_component_t *cb = &ctx->components[1];
+        const sh264e_jpeg_stream_component_t *cr = &ctx->components[2];
+        const uint32_t luma_row = (uint32_t)slice_index * SH264E_V1_SLICE_LUMA_HEIGHT;
+        const uint32_t chroma_row = (uint32_t)slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT;
+
+        slice->plane[0] = y->pixels + (size_t)(luma_row - y->row0) * (size_t)y->stride;
+        slice->plane[1] = cb->pixels + (size_t)(chroma_row - cb->row0) * (size_t)cb->stride;
+        slice->plane[2] = cr->pixels + (size_t)(chroma_row - cr->row0) * (size_t)cr->stride;
+        slice->stride[0] = y->stride;
+        slice->stride[1] = cb->stride;
+        slice->stride[2] = cr->stride;
+        return;
+    }
 
     streaming_scale_component_slice(&ctx->components[0], dst_y,
                                     SH264E_V1_WIDTH, SH264E_V1_HEIGHT,
@@ -839,8 +903,6 @@ static void streaming_make_i420_slice(const sh264e_jpeg_stream_context_t *ctx,
                                         SH264E_CHROMA_WIDTH);
     }
 
-    memset(slice, 0, sizeof(*slice));
-    slice->pixfmt = SH264E_PIXFMT_I420;
     slice->plane[0] = dst_y;
     slice->plane[1] = dst_u;
     slice->plane[2] = dst_v;
@@ -849,12 +911,53 @@ static void streaming_make_i420_slice(const sh264e_jpeg_stream_context_t *ctx,
     slice->stride[2] = SH264E_CHROMA_WIDTH;
 }
 
+static void streaming_interleave_direct_nv12_chroma_slice(const sh264e_jpeg_stream_context_t *ctx,
+                                                          unsigned slice_index,
+                                                          uint8_t *dst_uv)
+{
+    const sh264e_jpeg_stream_component_t *cb = &ctx->components[1];
+    const sh264e_jpeg_stream_component_t *cr = &ctx->components[2];
+    const uint32_t chroma_row = (uint32_t)slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT;
+    const uint8_t *src_cb = cb->pixels + (size_t)(chroma_row - cb->row0) * (size_t)cb->stride;
+    const uint8_t *src_cr = cr->pixels + (size_t)(chroma_row - cr->row0) * (size_t)cr->stride;
+    uint32_t y;
+
+    for (y = 0; y < SH264E_V1_SLICE_CHROMA_HEIGHT; y++) {
+        const uint8_t *row_cb = src_cb + (size_t)y * (size_t)cb->stride;
+        const uint8_t *row_cr = src_cr + (size_t)y * (size_t)cr->stride;
+        uint8_t *row = dst_uv + (size_t)y * SH264E_V1_WIDTH;
+        uint32_t x;
+
+        for (x = 0; x < SH264E_CHROMA_WIDTH; x++) {
+            row[(size_t)x * 2u] = row_cb[x];
+            row[(size_t)x * 2u + 1u] = row_cr[x];
+        }
+    }
+}
+
 static void streaming_make_nv12_slice(const sh264e_jpeg_stream_context_t *ctx,
                                       unsigned slice_index,
                                       sh264e_slice_t *slice)
 {
     uint8_t *dst_y = ctx->work_buffer;
     uint8_t *dst_uv = dst_y + (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_LUMA_HEIGHT;
+
+    memset(slice, 0, sizeof(*slice));
+    slice->pixfmt = SH264E_PIXFMT_NV12;
+
+    if (ctx->one_to_one_420) {
+        const sh264e_jpeg_stream_component_t *y = &ctx->components[0];
+        const uint32_t luma_row = (uint32_t)slice_index * SH264E_V1_SLICE_LUMA_HEIGHT;
+
+        dst_uv = ctx->work_buffer;
+        streaming_interleave_direct_nv12_chroma_slice(ctx, slice_index, dst_uv);
+
+        slice->plane[0] = y->pixels + (size_t)(luma_row - y->row0) * (size_t)y->stride;
+        slice->plane[1] = dst_uv;
+        slice->stride[0] = y->stride;
+        slice->stride[1] = SH264E_V1_WIDTH;
+        return;
+    }
 
     streaming_scale_component_slice(&ctx->components[0], dst_y,
                                     SH264E_V1_WIDTH, SH264E_V1_HEIGHT,
@@ -869,8 +972,6 @@ static void streaming_make_nv12_slice(const sh264e_jpeg_stream_context_t *ctx,
                                                     slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT);
     }
 
-    memset(slice, 0, sizeof(*slice));
-    slice->pixfmt = SH264E_PIXFMT_NV12;
     slice->plane[0] = dst_y;
     slice->plane[1] = dst_uv;
     slice->stride[0] = SH264E_V1_WIDTH;
@@ -921,6 +1022,14 @@ static sh264e_status_t streaming_init_cache(sh264e_jpeg_stream_context_t *ctx)
         }
     }
     ctx->component_count = component_count;
+    ctx->one_to_one_420 = streaming_is_one_to_one_420();
+    ctx->effective_slice_work_bytes = resize_scaled_slice_buffer_size();
+    if (ctx->one_to_one_420) {
+        ctx->effective_slice_work_bytes =
+            ctx->encoder != NULL && ctx->encoder->config.pixfmt == SH264E_PIXFMT_NV12
+                ? (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT
+                : 0u;
+    }
 
     for (i = 0u; i < (unsigned)component_count; i++) {
         sh264e_jpeg_stream_component_t *component = &ctx->components[i];
@@ -939,11 +1048,14 @@ static sh264e_status_t streaming_init_cache(sh264e_jpeg_stream_context_t *ctx)
         component->rows_per_mcu = (uint32_t)rows_per_mcu;
         component->row0 = 0u;
         component->rows = 0u;
-        component->cache_rows = streaming_cache_rows_for_slice_window(
-            component->height,
-            i == 0u ? SH264E_V1_HEIGHT : SH264E_V1_HEIGHT / 2u,
-            i == 0u ? SH264E_V1_SLICE_LUMA_HEIGHT : SH264E_V1_SLICE_CHROMA_HEIGHT,
-            component->rows_per_mcu);
+        component->cache_rows = ctx->one_to_one_420
+                                    ? component->rows_per_mcu
+                                    : streaming_cache_rows_for_slice_window(
+                                          component->height,
+                                          i == 0u ? SH264E_V1_HEIGHT : SH264E_V1_HEIGHT / 2u,
+                                          i == 0u ? SH264E_V1_SLICE_LUMA_HEIGHT :
+                                                    SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                          component->rows_per_mcu);
         bytes = (size_t)stride * (size_t)component->cache_rows;
         if (bytes > (size_t)INT_MAX) {
             streaming_free_cache(ctx);
@@ -2158,6 +2270,7 @@ static sh264e_status_t jpeg_get_streaming_work_size(const uint8_t *jpeg_data,
     }
     *out_size = 0u;
     sh264e_jpeg_streaming_last_cache_bytes = 0u;
+    sh264e_jpeg_streaming_last_slice_work_bytes = 0u;
     if (jpeg_size == 0u || jpeg_size > (size_t)INT_MAX) {
         return SH264E_ERR_INVALID_ARGUMENT;
     }
@@ -2264,6 +2377,11 @@ size_t sh264e_jpeg_get_last_streaming_cache_bytes(void)
     return sh264e_jpeg_streaming_last_cache_bytes;
 }
 
+size_t sh264e_jpeg_get_last_slice_work_bytes(void)
+{
+    return sh264e_jpeg_streaming_last_slice_work_bytes;
+}
+
 static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *encoder,
                                                              const uint8_t *jpeg_data,
                                                              size_t jpeg_size,
@@ -2288,6 +2406,7 @@ static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *e
     }
     *out_size = 0u;
     sh264e_jpeg_streaming_last_cache_bytes = 0u;
+    sh264e_jpeg_streaming_last_slice_work_bytes = 0u;
     if (encoder->idr_active != 0u) {
         return SH264E_ERR_BAD_STATE;
     }
@@ -2340,6 +2459,7 @@ static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *e
         reset_progressive_state(encoder);
     }
     sh264e_jpeg_streaming_last_cache_bytes = ctx.cache_bytes;
+    sh264e_jpeg_streaming_last_slice_work_bytes = ctx.effective_slice_work_bytes;
     streaming_free_cache(&ctx);
     njDone();
     jpeg_allocation_end();

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -11,12 +11,14 @@ SMALL_HEIGHT = 720
 LARGE_WIDTH = 2560
 LARGE_HEIGHT = 1440
 JPEG_SLICE_WORK_BYTES = WIDTH * 16 + (WIDTH // 2) * 8 * 2
+JPEG_DIRECT_I420_EFFECTIVE_SLICE_WORK_BYTES = 0
+JPEG_DIRECT_NV12_EFFECTIVE_SLICE_WORK_BYTES = WIDTH * 8
 STREAMING_CACHE_BYTES_720P = {
     "yuvj420p": 61_440,
     "yuvj422p": 81_920,
     "yuvj444p": 122_880,
 }
-STREAMING_CACHE_BYTES_1440P_420 = 184_320
+STREAMING_CACHE_BYTES_1440P_420 = 61_440
 FULL_COMPONENT_BYTES_720P = {
     "yuvj420p": 1_382_400,
     "yuvj422p": 1_843_200,
@@ -29,8 +31,8 @@ PRODUCTION_MEMORY_720P_420 = {
     "cache": STREAMING_CACHE_BYTES_720P["yuvj420p"],
 }
 PRODUCTION_MEMORY_1440P_420 = {
-    "work": 245_904,
-    "peak": 245_760,
+    "work": 123_024,
+    "peak": 122_880,
     "cache": STREAMING_CACHE_BYTES_1440P_420,
 }
 H264_OUTPUT_CONSUMER_CHUNKS_MIN = 1 + 90
@@ -299,7 +301,8 @@ def parse_jpeg_metric(stdout, prefix):
 
 def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
                 expected_cache_bytes=None, max_peak_bytes=None,
-                expected_work_bytes=None, expected_peak_bytes=None):
+                expected_work_bytes=None, expected_peak_bytes=None,
+                expected_effective_slice_work_bytes=None):
     command = [args.jpeg_encoder]
     if extra_args:
         command.extend(extra_args)
@@ -321,6 +324,14 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
     if slice_work != JPEG_SLICE_WORK_BYTES:
         raise RuntimeError(
             f"JPEG encoder slice work changed: got {slice_work}, expected {JPEG_SLICE_WORK_BYTES}"
+        )
+    effective_slice_work = parse_jpeg_metric(result.stdout, "jpeg effective slice work bytes:")
+    if expected_effective_slice_work_bytes is None:
+        expected_effective_slice_work_bytes = JPEG_SLICE_WORK_BYTES
+    if effective_slice_work != expected_effective_slice_work_bytes:
+        raise RuntimeError(
+            "JPEG encoder effective slice work changed: "
+            f"got {effective_slice_work}, expected {expected_effective_slice_work_bytes}"
         )
     peak = parse_jpeg_metric(result.stdout, "jpeg peak allocation bytes:")
     if peak == 0:
@@ -608,20 +619,30 @@ def main():
                 expected_cache_bytes=STREAMING_CACHE_BYTES_1440P_420,
                 max_peak_bytes=FULL_COMPONENT_BYTES_1440P_420,
                 expected_work_bytes=PRODUCTION_MEMORY_1440P_420["work"],
-                expected_peak_bytes=PRODUCTION_MEMORY_1440P_420["peak"])
+                expected_peak_bytes=PRODUCTION_MEMORY_1440P_420["peak"],
+                expected_effective_slice_work_bytes=JPEG_DIRECT_I420_EFFECTIVE_SLICE_WORK_BYTES)
+    large_jpeg_output_nv12 = workdir / "output_jpeg_1440p_yuvj420p_nv12.h264"
+    encode_jpeg(args, "nv12", large_jpeg_input, large_jpeg_output_nv12,
+                expected_cache_bytes=STREAMING_CACHE_BYTES_1440P_420,
+                max_peak_bytes=FULL_COMPONENT_BYTES_1440P_420,
+                expected_work_bytes=PRODUCTION_MEMORY_1440P_420["work"],
+                expected_peak_bytes=PRODUCTION_MEMORY_1440P_420["peak"],
+                expected_effective_slice_work_bytes=JPEG_DIRECT_NV12_EFFECTIVE_SLICE_WORK_BYTES)
+    validate_bitstream(args.ffprobe, args.ffmpeg, large_jpeg_output_nv12)
     large_heap_wrapper_output = workdir / "output_jpeg_heap_wrapper_1440p_yuvj420p_i420.h264"
     encode_jpeg(args, "i420", large_jpeg_input, large_heap_wrapper_output,
                 ["--test-allocation-limit", "999999999"],
                 expected_cache_bytes=STREAMING_CACHE_BYTES_1440P_420,
                 max_peak_bytes=FULL_COMPONENT_BYTES_1440P_420,
-                expected_peak_bytes=PRODUCTION_MEMORY_1440P_420["peak"])
+                expected_peak_bytes=PRODUCTION_MEMORY_1440P_420["peak"],
+                expected_effective_slice_work_bytes=JPEG_DIRECT_I420_EFFECTIVE_SLICE_WORK_BYTES)
     validate_bitstream(args.ffprobe, args.ffmpeg, large_heap_wrapper_output)
     if large_heap_wrapper_output.read_bytes() != large_jpeg_output.read_bytes():
         raise RuntimeError("JPEG heap wrapper bitstream differs from arena streaming output")
-    if EMBEDDED_OUTPUT_BUFFER_TOTAL_1440P_420 != 311_440:
+    if EMBEDDED_OUTPUT_BUFFER_TOTAL_1440P_420 != 188_560:
         raise RuntimeError(
             "2560x1440 JPEG streaming memory subtotal changed: "
-            f"got {EMBEDDED_OUTPUT_BUFFER_TOTAL_1440P_420}, expected 311440"
+            f"got {EMBEDDED_OUTPUT_BUFFER_TOTAL_1440P_420}, expected 188560"
         )
     encode_jpeg_streaming_prototype(args, "i420", large_jpeg_input, large_streaming_output,
                                     STREAMING_CACHE_BYTES_1440P_420)

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -226,6 +226,10 @@ int main(void)
         fprintf(stderr, "initial JPEG allocation stats should be zero\n");
         ok = 0;
     }
+    if (sh264e_jpeg_get_last_slice_work_bytes() != 0u) {
+        fprintf(stderr, "initial JPEG effective slice work should be zero\n");
+        ok = 0;
+    }
 
     status = sh264e_encoder_create(&config, &encoder);
     ok &= expect_status("create encoder", status, SH264E_OK);

--- a/tools/sh264e_encode_jpeg.c
+++ b/tools/sh264e_encode_jpeg.c
@@ -445,6 +445,7 @@ int main(int argc, char **argv)
         }
         printf("jpeg work arena bytes: %zu\n", jpeg_work_size);
         printf("jpeg slice work bytes: %zu\n", work_size);
+        printf("jpeg effective slice work bytes: %zu\n", sh264e_jpeg_get_last_slice_work_bytes());
         printf("jpeg current allocation bytes: %zu\n", stats.current_bytes);
         printf("jpeg peak allocation bytes: %zu\n", stats.peak_bytes);
         if (streaming_prototype || sh264e_jpeg_get_last_streaming_cache_bytes() != 0u) {


### PR DESCRIPTION
## Summary

Refs #49

- Detect `2560x1440` 4:2:0 JPEG inputs and use a 1:1 MCU-row fast path instead of the bilinear scaler window.
- Reduce the 1440p 4:2:0 retained row cache from 184,320 bytes to 61,440 bytes.
- Feed I420 slices directly from the retained MCU-row cache and stage only the 20,480-byte UV interleave window for NV12.
- Add `sh264e_jpeg_get_last_slice_work_bytes` so tools/tests can report effective slice staging separately from the conservative public 61,440-byte work-buffer capacity.
- Update memory docs and regression assertions for the new 123,024-byte arena work and 122,880-byte peak allocation values.

## Validation

- `cmake -S . -B build/issue49`
- `cmake --build build/issue49`
- `ctest --test-dir build/issue49 --output-on-failure -R 'sh264e_api|sh264e_ffmpeg_integration|sh264e_jpeg_diagnostics_boundary'`
- `ctest --test-dir build/issue49 --output-on-failure`
- `python3 -m py_compile tests/run_ffmpeg_integration.py`
- `build/issue49/sh264e_encode_jpeg --format i420 build/issue49/integration/input_1440p_yuvj420p.jpg build/issue49/issue49_1440_i420.h264`
- `build/issue49/sh264e_encode_jpeg --format nv12 build/issue49/integration/input_1440p_yuvj420p.jpg build/issue49/issue49_1440_nv12.h264`
- `ffmpeg -v error -xerror -i build/issue49/issue49_1440_i420.h264 -f null -`
- `ffmpeg -v error -xerror -i build/issue49/issue49_1440_nv12.h264 -f null -`
- `git diff --check`

## Manual metrics

```text
I420 1440p:
jpeg work arena bytes: 123024
jpeg slice work bytes: 61440
jpeg effective slice work bytes: 0
jpeg peak allocation bytes: 122880
jpeg streaming cache bytes: 61440

NV12 1440p:
jpeg work arena bytes: 123024
jpeg slice work bytes: 61440
jpeg effective slice work bytes: 20480
jpeg peak allocation bytes: 122880
jpeg streaming cache bytes: 61440
```

## Notes

The public slice-work capacity remains `61,440` bytes because the current API cannot know source geometry before parsing the JPEG. The new effective-slice-work metric documents the actual staging used by the 1:1 fast path; narrowing the caller-facing work-buffer contract remains suitable for #53.
