### PR TITLE
jpeg: reduce direct slice work buffer

### DIFF
--- a/MEMORY_OPTIMIZATION_PLAN.md
+++ b/MEMORY_OPTIMIZATION_PLAN.md
@@ -18,11 +18,11 @@ Current `2560x1440` 4:2:0 embedded budget, excluding compressed JPEG input and
 | Block | Bytes | Notes |
 | --- | ---: | --- |
 | JPEG work arena | 123,024 | 1:1 4:2:0 path: one MCU-row cache plus NanoJPEG MCU-row temp buffers |
-| JPEG/scaler slice work | 61,440 | API capacity; 1:1 effective use is I420 0 bytes, NV12 20,480 bytes |
+| JPEG/scaler slice work | 0 I420 / 20,480 NV12 | Path-specific query for 1:1 4:2:0; conservative unknown-JPEG capacity remains 61,440 |
 | Reusable H.264 output chunk buffer | 4,096 | Byte-stream flush buffer |
 | Encoder heap | 191,048 | See `docs/ENCODER_MEMORY_REPORT.md` |
 | Static mutable RAM | about 4,529 | Excludes `.rodata` |
-| Total | about 390 KiB class | Excludes compressed JPEG input |
+| Total | about 330 KiB I420 / 350 KiB NV12 | Excludes compressed JPEG input |
 
 The old full decoded JPEG component-frame allocation was 5,529,600 bytes for
 `2560x1440` 4:2:0 and is no longer allowed for public JPEG APIs.
@@ -84,8 +84,9 @@ slices from the smallest valid row-cache/staging window.
 
 The implemented 1:1 path keeps one MCU row per component. I420 output feeds the
 encoder directly from the row cache, while NV12 still stages only the 20,480-byte
-interleaved chroma window. The public slice-work capacity remains 61,440 bytes
-until issue #53 narrows the caller-facing work-buffer contract.
+interleaved chroma window. Issue #53 added a path-specific slice-work query so
+callers with the JPEG bytes can allocate 0 bytes for I420 or 20,480 bytes for
+NV12; the conservative unknown-JPEG query remains 61,440 bytes.
 
 Acceptance focus:
 
@@ -178,13 +179,14 @@ Depends on or should follow #49.
 
 Target the current fixed slice work buffer:
 
-| Current | Target direction |
+| Previous | Implemented target |
 | ---: | --- |
-| 61,440 bytes | path-dependent reduction or documented reason it cannot shrink |
+| 61,440 bytes | 0 bytes for 1:1 I420, 20,480 bytes for 1:1 NV12 |
 
-The easiest first case is likely 1:1 I420 after #49. NV12 may still need chroma
-interleave staging. General scaled sources may require deeper encoder/scaler
-input refactoring.
+The 1:1 I420 case now accepts a `NULL`/zero-capacity caller slice work buffer
+after the JPEG parser confirms the compatible geometry. NV12 still needs only
+the 20,480-byte chroma interleave staging window. General scaled sources still
+need the conservative 61,440-byte scaler output slice.
 
 Acceptance focus:
 

--- a/MEMORY_REDUCTION_PLAN.md
+++ b/MEMORY_REDUCTION_PLAN.md
@@ -149,9 +149,9 @@ Implemented bridge contract:
   61,440 bytes for 1280x720 4:2:0, 81,920 bytes for 1280x720 4:2:2,
   122,880 bytes for 1280x720 4:4:4, and 61,440 bytes for the 2560x1440 4:2:0
   1:1 fast path.
-* The JPEG tool and integration matrix also assert the scaled output slice work
-  buffer remains 61,440 bytes. For the 1:1 fast path, effective slice staging
-  is 0 bytes for I420 and 20,480 bytes for NV12.
+* The JPEG tool and integration matrix assert path-specific slice work. The
+  general scaler still needs 61,440 bytes, while the 1:1 fast path needs 0 bytes
+  for I420 and 20,480 bytes for NV12.
 
 ### 3. Production API Switch
 
@@ -270,11 +270,11 @@ Memory target for `2560x1440` JPEG 4:2:0 embedded path:
 | Area | Bytes |
 | --- | ---: |
 | JPEG work arena | 123,024 |
-| JPEG/scaler slice work | 61,440 |
+| JPEG/scaler slice work | 0 for I420, 20,480 for NV12 |
 | Reusable H.264 output chunk buffer | 4,096 |
 | Encoder heap | 191,048 |
 | Static mutable RAM | about 4,529 |
-| Total, excluding compressed JPEG input and `.rodata` | about 390 KiB budget class |
+| Total, excluding compressed JPEG input and `.rodata` | about 330 KiB I420 / 350 KiB NV12 budget class |
 
 Acceptance criteria:
 

--- a/README.md
+++ b/README.md
@@ -124,11 +124,14 @@ Encode a baseline JPEG memory-input path through the library wrapper:
 The JPEG path uses NanoJPEG inside the core library. The tool only reads the JPEG file and writes the `.h264` output; the library API accepts a caller-provided JPEG byte buffer and emits Annex B byte-stream chunks through caller-owned output memory.
 The tool sizes a caller-provided JPEG decoder arena with `sh264e_jpeg_get_work_size`, passes that arena to `sh264e_encode_jpeg_idr_with_arena_stream`, and prints the arena requirement plus current and peak NanoJPEG allocation bytes reported by `sh264e_jpeg_get_last_allocation_stats`.
 The public diagnostic surface also exposes `sh264e_jpeg_get_last_streaming_cache_bytes` so tools and regression tests can report decoded-row cache usage without private declarations.
+`sh264e_jpeg_get_slice_work_size` reports the path-specific caller work buffer
+needed for a specific JPEG input and output pixel format; the older
+`sh264e_jpeg_get_slice_buffer_size` remains a conservative worst-case query for
+callers that have not parsed their JPEG yet.
 `sh264e_jpeg_get_last_slice_work_bytes` reports the effective slice staging
 used by the last JPEG encode. For `2560x1440` 4:2:0 source JPEGs, the 1:1 fast
-path reduces retained row cache to 61,440 bytes and effectively uses 0 bytes of
-slice staging for I420 or 20,480 bytes for NV12, while the public work-buffer
-capacity remains conservatively 61,440 bytes.
+path reduces retained row cache to 61,440 bytes and requires 0 bytes of
+caller slice work for I420 or 20,480 bytes for NV12.
 `sh264e_encoder_get_memory_report` reports the fixed-v1 encoder heap breakdown
 without creating an encoder; `docs/ENCODER_MEMORY_REPORT.md` records the current
 191,048-byte total and sub-block composition.
@@ -196,6 +199,7 @@ Resize entry points:
 JPEG pipeline entry points:
 
 * `sh264e_jpeg_get_slice_buffer_size`
+* `sh264e_jpeg_get_slice_work_size`
 * `sh264e_jpeg_get_work_size`
 * `sh264e_jpeg_get_last_allocation_stats`
 * `sh264e_encode_jpeg_idr`

--- a/SPACE_REDUCTION.md
+++ b/SPACE_REDUCTION.md
@@ -300,10 +300,12 @@ Approximate component-cache targets from the design note:
 | 5120x2880 4:2:0 | not yet measured | 491,520 |
 | 5120x2880 4:4:4 | not yet measured | 819,200 |
 
-These estimates exclude caller-owned JPEG input, the existing 61,440-byte
-encoder slice work buffer, and the H.264 output buffer. The streaming cache
-adds one MCU-row margin beyond the maximum fixed-point source window so slices
-at row-window boundaries can still sample the previous row.
+These estimates exclude caller-owned JPEG input, JPEG/scaler slice work, and the
+H.264 output buffer. The general scaler path still uses a 61,440-byte slice
+work buffer; the `2560x1440` 4:2:0 1:1 fast path needs 0 bytes for I420 or
+20,480 bytes for NV12. The streaming cache adds one MCU-row margin beyond the
+maximum fixed-point source window so slices at row-window boundaries can still
+sample the previous row.
 
 The production memory regression report is tracked in
 `docs/JPEG_STREAMING_MEMORY_REPORT.md`. The measured 4:2:0 arena-backed default

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -92,8 +92,9 @@ and the decoded component's native height.
 
 Decoded MCU rows are copied into the rolling cache. As soon as the source row
 window for the next output slice is available, the integration layer scales one
-YUV420 slice into the caller-provided 61,440-byte slice work buffer and calls
-`sh264e_encode_idr_slice`.
+YUV420 slice into caller-provided slice work memory and calls
+`sh264e_encode_idr_slice`. The general scaler path still requires the
+61,440-byte complete output slice.
 
 For `2560x1440` 4:2:0 source JPEGs encoded to the fixed `2560x1440` target,
 the pipeline uses a 1:1 fast path. It keeps exactly one MCU row per component,
@@ -120,15 +121,17 @@ image height:
 | 1280x720 4:2:0 | 61,440 | 61,440 |
 | 1280x720 4:2:2 | 81,920 | 61,440 |
 | 1280x720 4:4:4 | 122,880 | 61,440 |
-| 2560x1440 4:2:0, 1:1 fast path | 61,440 | 61,440 API capacity; effective I420 0, NV12 20,480 |
+| 2560x1440 4:2:0, 1:1 fast path, I420 | 61,440 | 0 |
+| 2560x1440 4:2:0, 1:1 fast path, NV12 | 61,440 | 20,480 |
 
 For the `2560x1440` 4:2:0 embedded path, excluding compressed JPEG input and
-`.rodata`, the current planning budget is about 390 KiB:
+`.rodata`, the current planning budget is about 330 KiB for I420 or about
+350 KiB for NV12:
 
 | Block | Bytes |
 | --- | ---: |
 | JPEG work arena | 123,024 |
-| JPEG/scaler slice work | 61,440 |
+| JPEG/scaler slice work | 0 for I420, 20,480 for NV12 |
 | Reusable H.264 output chunk buffer | 4,096 |
 | Encoder heap | 191,048 |
 | Static mutable RAM | about 4,529 |

--- a/docs/JPEG_STREAMING_MEMORY_REPORT.md
+++ b/docs/JPEG_STREAMING_MEMORY_REPORT.md
@@ -13,7 +13,8 @@ from the earlier allocation report. The production measurements below are from
 | Source JPEG | Previous full component planes | Production arena work | Production peak allocation | Streaming row cache | Slice work buffer |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | 1280x720 4:2:0 | 1,382,400 | 92,304 | 92,160 | 61,440 | 61,440 |
-| 2560x1440 4:2:0, 1:1 fast path | 5,529,600 | 123,024 | 122,880 | 61,440 | 61,440 API capacity |
+| 2560x1440 4:2:0, 1:1 fast path, I420 | 5,529,600 | 123,024 | 122,880 | 61,440 | 0 |
+| 2560x1440 4:2:0, 1:1 fast path, NV12 | 5,529,600 | 123,024 | 122,880 | 61,440 | 20,480 |
 
 `Production peak allocation` now excludes the previous dynamic NanoJPEG VLC
 lookup block. NanoJPEG decodes DHT tables into compact canonical Huffman
@@ -41,13 +42,14 @@ regressing to full component-plane decode. Issue #49 then added the 1:1
 `2560x1440` 4:2:0 fast path, reducing that row cache to one MCU/slice row.
 Custom DHT baseline JPEGs remain supported.
 
-For the 1:1 fast path, the public API still accepts the conservative
-61,440-byte slice work buffer returned by `sh264e_jpeg_get_slice_buffer_size`.
-The effective slice staging used by the implementation is lower:
+For callers that do not yet know JPEG geometry, `sh264e_jpeg_get_slice_buffer_size`
+still returns the conservative 61,440-byte worst-case slice work capacity.
+Callers that have the JPEG bytes should use `sh264e_jpeg_get_slice_work_size`
+to get the path-specific requirement before allocating the slice work buffer:
 
 | Output format | Effective slice work bytes | Notes |
 | --- | ---: | --- |
-| I420 | 0 | Encoder slice planes point directly into the retained MCU-row cache |
+| I420 | 0 | Encoder slice planes point directly into the retained MCU-row cache; `work_buffer` may be `NULL` with zero capacity |
 | NV12 | 20,480 | Luma points into the cache; chroma is interleaved into an 8-row UV staging window |
 
 ## Output Buffer Boundary
@@ -81,15 +83,16 @@ For the `2560x1440` 4:2:0 embedded path, excluding compressed JPEG input and
 | Block | Bytes |
 | --- | ---: |
 | JPEG work arena | 123,024 |
-| JPEG/scaler slice work | 61,440 |
+| JPEG/scaler slice work | 0 for I420, 20,480 for NV12 |
 | Reusable H.264 output chunk buffer | 4,096 |
 | Encoder heap | 191,048 |
 | Static mutable RAM | about 4,529 |
-| Rounded planning budget | about 390 KiB |
+| Rounded planning budget | about 330 KiB I420 / 350 KiB NV12 |
 
-The arithmetic subtotal of the rows above is about 384,113 bytes, or about
-375 KiB in binary units. The rounded planning budget is now about 390 KiB for
-this embedded path.
+The I420 arithmetic subtotal of the rows above is about 322,697 bytes, or about
+315 KiB in binary units. The equivalent NV12 subtotal is about 343,177 bytes,
+or about 335 KiB. The rounded planning budget is now about 330 KiB for I420 and
+about 350 KiB for NV12 on this embedded path.
 
 The encoder heap row is measured by `sh264e_encoder_get_memory_report`; see
 `docs/ENCODER_MEMORY_REPORT.md` for the context, bitstream scratch,
@@ -99,7 +102,7 @@ reconstructed-slice, and neighbor-state breakdown.
 
 `tests/run_ffmpeg_integration.py` asserts the exact production arena work,
 peak-allocation, row-cache, effective slice work, reusable output chunk, encoder
-memory report, and one-shot output capacity values for representative JPEG
+memory report, path-specific slice work, and one-shot output capacity values for representative JPEG
 fixtures. It also keeps broader
 color-subsampling coverage that fails if the production arena path regresses to
 full component-plane allocation or if the default JPEG tool path regresses to
@@ -153,7 +156,7 @@ jpeg output buffer bytes: 4096
 jpeg output consumer chunks: 92
 jpeg output chunk buffer bytes: 4096
 jpeg work arena bytes: 123024
-jpeg slice work bytes: 61440
+jpeg slice work bytes: 0
 jpeg effective slice work bytes: 0
 jpeg peak allocation bytes: 122880
 jpeg streaming cache bytes: 61440

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -92,6 +92,7 @@ Required API entry points:
 * `sh264e_resize_get_slice_buffer_size`
 * `sh264e_resize_make_slice`
 * `sh264e_jpeg_get_slice_buffer_size`
+* `sh264e_jpeg_get_slice_work_size`
 * `sh264e_encode_jpeg_idr`
 * `sh264e_encode_jpeg_idr_with_arena_stream`
 
@@ -324,6 +325,7 @@ H.264 IDR slice encode
 
 ```
 sh264e_jpeg_get_slice_buffer_size
+sh264e_jpeg_get_slice_work_size
 sh264e_encode_jpeg_idr
 sh264e_encode_jpeg_idr_with_arena
 sh264e_encode_jpeg_idr_with_arena_stream
@@ -368,6 +370,11 @@ may implement a consumer that writes to a file.
 JPEG allocations from the last JPEG work-size query or encode call.
 `sh264e_jpeg_get_last_streaming_cache_bytes` reports the decoded row-cache
 capacity retained by the last MCU-row streaming query or encode call.
+`sh264e_jpeg_get_slice_work_size` reports the path-specific caller work-buffer
+capacity for a specific JPEG input and output pixel format. This lets embedded
+callers use zero slice-work bytes for the `2560x1440` 4:2:0 1:1 I420 path and
+20,480 bytes for the equivalent NV12 path, while
+`sh264e_jpeg_get_slice_buffer_size` remains a conservative worst-case query.
 `sh264e_jpeg_get_last_slice_work_bytes` reports the effective slice staging used
 by the last JPEG encode. These are diagnostic/stat APIs for regression reporting; allocation-limit and
 streaming-prototype hooks remain private test hooks gated by

--- a/include/sh264e.h
+++ b/include/sh264e.h
@@ -126,6 +126,11 @@ sh264e_status_t sh264e_resize_make_slice(const sh264e_frame_t *src_frame,
 
 sh264e_status_t sh264e_jpeg_get_slice_buffer_size(size_t *out_size);
 
+sh264e_status_t sh264e_jpeg_get_slice_work_size(const uint8_t *jpeg_data,
+                                                size_t jpeg_size,
+                                                sh264e_pixfmt_t pixfmt,
+                                                size_t *out_size);
+
 sh264e_status_t sh264e_jpeg_get_work_size(const uint8_t *jpeg_data,
                                           size_t jpeg_size,
                                           size_t *out_size);

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -94,6 +94,7 @@ typedef struct sh264e_jpeg_stream_component_t {
 typedef struct sh264e_jpeg_stream_context_t {
     sh264e_encoder_t *encoder;
     uint8_t *work_buffer;
+    size_t work_buffer_capacity;
     uint8_t *out;
     size_t out_capacity;
     size_t offset;
@@ -105,6 +106,7 @@ typedef struct sh264e_jpeg_stream_context_t {
     unsigned idr_started;
     int component_count;
     int one_to_one_420;
+    sh264e_pixfmt_t output_pixfmt;
     int measure_only;
     int initialized;
     sh264e_status_t status;
@@ -389,6 +391,11 @@ static sh264e_status_t validate_config(const sh264e_config_t *config)
         return SH264E_ERR_UNSUPPORTED_CONFIG;
     }
     return SH264E_OK;
+}
+
+static int is_supported_pixfmt(sh264e_pixfmt_t pixfmt)
+{
+    return pixfmt == SH264E_PIXFMT_I420 || pixfmt == SH264E_PIXFMT_NV12;
 }
 
 static size_t encoder_recon_luma_bytes(void)
@@ -880,10 +887,6 @@ static void streaming_make_i420_slice(const sh264e_jpeg_stream_context_t *ctx,
                                       unsigned slice_index,
                                       sh264e_slice_t *slice)
 {
-    uint8_t *dst_y = ctx->work_buffer;
-    uint8_t *dst_u = dst_y + (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_LUMA_HEIGHT;
-    uint8_t *dst_v = dst_u + (size_t)SH264E_CHROMA_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT;
-
     memset(slice, 0, sizeof(*slice));
     slice->pixfmt = SH264E_PIXFMT_I420;
 
@@ -903,32 +906,38 @@ static void streaming_make_i420_slice(const sh264e_jpeg_stream_context_t *ctx,
         return;
     }
 
-    streaming_scale_component_slice(&ctx->components[0], dst_y,
-                                    SH264E_V1_WIDTH, SH264E_V1_HEIGHT,
-                                    slice_index * SH264E_V1_SLICE_LUMA_HEIGHT,
-                                    SH264E_V1_SLICE_LUMA_HEIGHT,
-                                    SH264E_V1_WIDTH);
-    if (ctx->component_count == 1) {
-        jpeg_fill_i420_neutral_chroma(dst_u, dst_v);
-    } else {
-        streaming_scale_component_slice(&ctx->components[1], dst_u,
-                                        SH264E_CHROMA_WIDTH, SH264E_V1_HEIGHT / 2u,
-                                        slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT,
-                                        SH264E_V1_SLICE_CHROMA_HEIGHT,
-                                        SH264E_CHROMA_WIDTH);
-        streaming_scale_component_slice(&ctx->components[2], dst_v,
-                                        SH264E_CHROMA_WIDTH, SH264E_V1_HEIGHT / 2u,
-                                        slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT,
-                                        SH264E_V1_SLICE_CHROMA_HEIGHT,
-                                        SH264E_CHROMA_WIDTH);
-    }
+    {
+        uint8_t *dst_y = ctx->work_buffer;
+        uint8_t *dst_u = dst_y + (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_LUMA_HEIGHT;
+        uint8_t *dst_v = dst_u + (size_t)SH264E_CHROMA_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT;
 
-    slice->plane[0] = dst_y;
-    slice->plane[1] = dst_u;
-    slice->plane[2] = dst_v;
-    slice->stride[0] = SH264E_V1_WIDTH;
-    slice->stride[1] = SH264E_CHROMA_WIDTH;
-    slice->stride[2] = SH264E_CHROMA_WIDTH;
+        streaming_scale_component_slice(&ctx->components[0], dst_y,
+                                        SH264E_V1_WIDTH, SH264E_V1_HEIGHT,
+                                        slice_index * SH264E_V1_SLICE_LUMA_HEIGHT,
+                                        SH264E_V1_SLICE_LUMA_HEIGHT,
+                                        SH264E_V1_WIDTH);
+        if (ctx->component_count == 1) {
+            jpeg_fill_i420_neutral_chroma(dst_u, dst_v);
+        } else {
+            streaming_scale_component_slice(&ctx->components[1], dst_u,
+                                            SH264E_CHROMA_WIDTH, SH264E_V1_HEIGHT / 2u,
+                                            slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                            SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                            SH264E_CHROMA_WIDTH);
+            streaming_scale_component_slice(&ctx->components[2], dst_v,
+                                            SH264E_CHROMA_WIDTH, SH264E_V1_HEIGHT / 2u,
+                                            slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                            SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                            SH264E_CHROMA_WIDTH);
+        }
+
+        slice->plane[0] = dst_y;
+        slice->plane[1] = dst_u;
+        slice->plane[2] = dst_v;
+        slice->stride[0] = SH264E_V1_WIDTH;
+        slice->stride[1] = SH264E_CHROMA_WIDTH;
+        slice->stride[2] = SH264E_CHROMA_WIDTH;
+    }
 }
 
 static void streaming_interleave_direct_nv12_chroma_slice(const sh264e_jpeg_stream_context_t *ctx,
@@ -959,17 +968,14 @@ static void streaming_make_nv12_slice(const sh264e_jpeg_stream_context_t *ctx,
                                       unsigned slice_index,
                                       sh264e_slice_t *slice)
 {
-    uint8_t *dst_y = ctx->work_buffer;
-    uint8_t *dst_uv = dst_y + (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_LUMA_HEIGHT;
-
     memset(slice, 0, sizeof(*slice));
     slice->pixfmt = SH264E_PIXFMT_NV12;
 
     if (ctx->one_to_one_420) {
         const sh264e_jpeg_stream_component_t *y = &ctx->components[0];
         const uint32_t luma_row = (uint32_t)slice_index * SH264E_V1_SLICE_LUMA_HEIGHT;
+        uint8_t *dst_uv = ctx->work_buffer;
 
-        dst_uv = ctx->work_buffer;
         streaming_interleave_direct_nv12_chroma_slice(ctx, slice_index, dst_uv);
 
         slice->plane[0] = y->pixels + (size_t)(luma_row - y->row0) * (size_t)y->stride;
@@ -979,23 +985,28 @@ static void streaming_make_nv12_slice(const sh264e_jpeg_stream_context_t *ctx,
         return;
     }
 
-    streaming_scale_component_slice(&ctx->components[0], dst_y,
-                                    SH264E_V1_WIDTH, SH264E_V1_HEIGHT,
-                                    slice_index * SH264E_V1_SLICE_LUMA_HEIGHT,
-                                    SH264E_V1_SLICE_LUMA_HEIGHT,
-                                    SH264E_V1_WIDTH);
-    if (ctx->component_count == 1) {
-        jpeg_fill_nv12_neutral_chroma(dst_uv);
-    } else {
-        streaming_scale_nv12_component_chroma_slice(&ctx->components[1], &ctx->components[2],
-                                                    dst_uv,
-                                                    slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT);
-    }
+    {
+        uint8_t *dst_y = ctx->work_buffer;
+        uint8_t *dst_uv = dst_y + (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_LUMA_HEIGHT;
 
-    slice->plane[0] = dst_y;
-    slice->plane[1] = dst_uv;
-    slice->stride[0] = SH264E_V1_WIDTH;
-    slice->stride[1] = SH264E_V1_WIDTH;
+        streaming_scale_component_slice(&ctx->components[0], dst_y,
+                                        SH264E_V1_WIDTH, SH264E_V1_HEIGHT,
+                                        slice_index * SH264E_V1_SLICE_LUMA_HEIGHT,
+                                        SH264E_V1_SLICE_LUMA_HEIGHT,
+                                        SH264E_V1_WIDTH);
+        if (ctx->component_count == 1) {
+            jpeg_fill_nv12_neutral_chroma(dst_uv);
+        } else {
+            streaming_scale_nv12_component_chroma_slice(&ctx->components[1], &ctx->components[2],
+                                                        dst_uv,
+                                                        slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT);
+        }
+
+        slice->plane[0] = dst_y;
+        slice->plane[1] = dst_uv;
+        slice->stride[0] = SH264E_V1_WIDTH;
+        slice->stride[1] = SH264E_V1_WIDTH;
+    }
 }
 
 static void streaming_free_cache(sh264e_jpeg_stream_context_t *ctx)
@@ -1016,6 +1027,8 @@ static sh264e_status_t streaming_init_cache(sh264e_jpeg_stream_context_t *ctx)
     const int image_height = njGetHeight();
     const int y_width = njGetComponentWidth(0);
     const int y_height = njGetComponentHeight(0);
+    const sh264e_pixfmt_t pixfmt = ctx->encoder != NULL ? ctx->encoder->config.pixfmt :
+                                                          ctx->output_pixfmt;
     unsigned i;
 
     if (component_count != 1 && component_count != 3) {
@@ -1045,10 +1058,17 @@ static sh264e_status_t streaming_init_cache(sh264e_jpeg_stream_context_t *ctx)
     ctx->one_to_one_420 = streaming_is_one_to_one_420();
     ctx->effective_slice_work_bytes = resize_scaled_slice_buffer_size();
     if (ctx->one_to_one_420) {
-        ctx->effective_slice_work_bytes =
-            ctx->encoder != NULL && ctx->encoder->config.pixfmt == SH264E_PIXFMT_NV12
-                ? (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT
-                : 0u;
+        ctx->effective_slice_work_bytes = pixfmt == SH264E_PIXFMT_NV12
+                                              ? (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT
+                                              : 0u;
+    }
+    if (!ctx->measure_only && ctx->effective_slice_work_bytes != 0u) {
+        if (ctx->work_buffer == NULL) {
+            return SH264E_ERR_INVALID_ARGUMENT;
+        }
+        if (ctx->work_buffer_capacity < ctx->effective_slice_work_bytes) {
+            return SH264E_ERR_BUFFER_TOO_SMALL;
+        }
     }
 
     for (i = 0u; i < (unsigned)component_count; i++) {
@@ -2278,17 +2298,27 @@ sh264e_status_t sh264e_jpeg_get_last_allocation_stats(sh264e_jpeg_allocation_sta
     return SH264E_OK;
 }
 
-static sh264e_status_t jpeg_get_streaming_work_size(const uint8_t *jpeg_data,
-                                                    size_t jpeg_size,
-                                                    size_t *out_size)
+static sh264e_status_t jpeg_measure_streaming_requirements(const uint8_t *jpeg_data,
+                                                           size_t jpeg_size,
+                                                           sh264e_pixfmt_t pixfmt,
+                                                           size_t *out_arena_size,
+                                                           size_t *out_slice_work_size)
 {
     sh264e_jpeg_stream_context_t ctx;
     sh264e_status_t status;
 
-    if (jpeg_data == NULL || out_size == NULL) {
+    if (jpeg_data == NULL || (out_arena_size == NULL && out_slice_work_size == NULL)) {
         return SH264E_ERR_INVALID_ARGUMENT;
     }
-    *out_size = 0u;
+    if (!is_supported_pixfmt(pixfmt)) {
+        return SH264E_ERR_UNSUPPORTED_CONFIG;
+    }
+    if (out_arena_size != NULL) {
+        *out_arena_size = 0u;
+    }
+    if (out_slice_work_size != NULL) {
+        *out_slice_work_size = 0u;
+    }
     sh264e_jpeg_streaming_last_cache_bytes = 0u;
     sh264e_jpeg_streaming_last_slice_work_bytes = 0u;
     if (jpeg_size == 0u || jpeg_size > (size_t)INT_MAX) {
@@ -2297,6 +2327,7 @@ static sh264e_status_t jpeg_get_streaming_work_size(const uint8_t *jpeg_data,
 
     memset(&ctx, 0, sizeof(ctx));
     ctx.measure_only = 1;
+    ctx.output_pixfmt = pixfmt;
     ctx.status = SH264E_OK;
 
     jpeg_allocation_begin_heap();
@@ -2307,7 +2338,13 @@ static sh264e_status_t jpeg_get_streaming_work_size(const uint8_t *jpeg_data,
         status = ctx.status;
     }
     if (status == SH264E_OK) {
-        *out_size = sh264e_jpeg_alloc_peak_arena_bytes;
+        if (out_arena_size != NULL) {
+            *out_arena_size = sh264e_jpeg_alloc_peak_arena_bytes;
+        }
+        if (out_slice_work_size != NULL) {
+            *out_slice_work_size = ctx.effective_slice_work_bytes;
+            sh264e_jpeg_streaming_last_slice_work_bytes = ctx.effective_slice_work_bytes;
+        }
     }
     sh264e_jpeg_streaming_last_cache_bytes = ctx.cache_bytes;
     streaming_free_cache(&ctx);
@@ -2316,11 +2353,30 @@ static sh264e_status_t jpeg_get_streaming_work_size(const uint8_t *jpeg_data,
     return status;
 }
 
+static sh264e_status_t jpeg_get_streaming_work_size(const uint8_t *jpeg_data,
+                                                    size_t jpeg_size,
+                                                    size_t *out_size)
+{
+    return jpeg_measure_streaming_requirements(jpeg_data, jpeg_size,
+                                               SH264E_PIXFMT_I420,
+                                               out_size, NULL);
+}
+
 sh264e_status_t sh264e_jpeg_get_work_size(const uint8_t *jpeg_data,
                                           size_t jpeg_size,
                                           size_t *out_size)
 {
     return jpeg_get_streaming_work_size(jpeg_data, jpeg_size, out_size);
+}
+
+sh264e_status_t sh264e_jpeg_get_slice_work_size(const uint8_t *jpeg_data,
+                                                size_t jpeg_size,
+                                                sh264e_pixfmt_t pixfmt,
+                                                size_t *out_size)
+{
+    return jpeg_measure_streaming_requirements(jpeg_data, jpeg_size,
+                                               pixfmt,
+                                               NULL, out_size);
 }
 
 #if SH264E_ENABLE_JPEG_TEST_HOOKS
@@ -2418,10 +2474,8 @@ static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *e
 {
     sh264e_jpeg_stream_context_t ctx;
     sh264e_status_t status;
-    size_t required_work = 0u;
 
-    if (encoder == NULL || jpeg_data == NULL || work_buffer == NULL ||
-        out == NULL || out_size == NULL) {
+    if (encoder == NULL || jpeg_data == NULL || out == NULL || out_size == NULL) {
         return SH264E_ERR_INVALID_ARGUMENT;
     }
     *out_size = 0u;
@@ -2436,17 +2490,11 @@ static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *e
     if (use_arena != 0 && (jpeg_arena == NULL || jpeg_arena_size == 0u)) {
         return SH264E_ERR_INVALID_ARGUMENT;
     }
-    status = sh264e_jpeg_get_slice_buffer_size(&required_work);
-    if (status != SH264E_OK) {
-        return status;
-    }
-    if (work_buffer_capacity < required_work) {
-        return SH264E_ERR_BUFFER_TOO_SMALL;
-    }
 
     memset(&ctx, 0, sizeof(ctx));
     ctx.encoder = encoder;
     ctx.work_buffer = work_buffer;
+    ctx.work_buffer_capacity = work_buffer_capacity;
     ctx.out = out;
     ctx.out_capacity = out_capacity;
     ctx.consumer = consumer;

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -11,6 +11,8 @@ SMALL_HEIGHT = 720
 LARGE_WIDTH = 2560
 LARGE_HEIGHT = 1440
 JPEG_SLICE_WORK_BYTES = WIDTH * 16 + (WIDTH // 2) * 8 * 2
+JPEG_DIRECT_I420_SLICE_WORK_BYTES = 0
+JPEG_DIRECT_NV12_SLICE_WORK_BYTES = WIDTH * 8
 JPEG_DIRECT_I420_EFFECTIVE_SLICE_WORK_BYTES = 0
 JPEG_DIRECT_NV12_EFFECTIVE_SLICE_WORK_BYTES = WIDTH * 8
 STREAMING_CACHE_BYTES_720P = {
@@ -47,7 +49,7 @@ ENCODER_NEIGHBOR_STATE_BYTES = 2_560
 ENCODER_MEMORY_TOTAL_BYTES = 191_048
 EMBEDDED_OUTPUT_BUFFER_TOTAL_1440P_420 = (
     PRODUCTION_MEMORY_1440P_420["work"]
-    + JPEG_SLICE_WORK_BYTES
+    + JPEG_DIRECT_I420_SLICE_WORK_BYTES
     + H264_OUTPUT_CHUNK_BYTES
 )
 
@@ -338,6 +340,7 @@ def validate_encoder_memory_report(stdout):
 def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
                 expected_cache_bytes=None, max_peak_bytes=None,
                 expected_work_bytes=None, expected_peak_bytes=None,
+                expected_slice_work_bytes=None,
                 expected_effective_slice_work_bytes=None):
     command = [args.jpeg_encoder]
     if extra_args:
@@ -358,13 +361,15 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
             f"JPEG encoder default work arena changed for {jpeg_input}: got {work}, expected {expected_work_bytes}"
         )
     slice_work = parse_jpeg_metric(result.stdout, "jpeg slice work bytes:")
-    if slice_work != JPEG_SLICE_WORK_BYTES:
+    if expected_slice_work_bytes is None:
+        expected_slice_work_bytes = JPEG_SLICE_WORK_BYTES
+    if slice_work != expected_slice_work_bytes:
         raise RuntimeError(
-            f"JPEG encoder slice work changed: got {slice_work}, expected {JPEG_SLICE_WORK_BYTES}"
+            f"JPEG encoder slice work changed: got {slice_work}, expected {expected_slice_work_bytes}"
         )
     effective_slice_work = parse_jpeg_metric(result.stdout, "jpeg effective slice work bytes:")
     if expected_effective_slice_work_bytes is None:
-        expected_effective_slice_work_bytes = JPEG_SLICE_WORK_BYTES
+        expected_effective_slice_work_bytes = expected_slice_work_bytes
     if effective_slice_work != expected_effective_slice_work_bytes:
         raise RuntimeError(
             "JPEG encoder effective slice work changed: "
@@ -416,7 +421,9 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
             )
 
 
-def encode_jpeg_streaming_prototype(args, fmt, jpeg_input, bitstream, expected_cache_bytes=None):
+def encode_jpeg_streaming_prototype(args, fmt, jpeg_input, bitstream,
+                                    expected_cache_bytes=None,
+                                    expected_slice_work_bytes=None):
     result = run_capture([
         args.jpeg_encoder,
         "--streaming-prototype",
@@ -431,9 +438,11 @@ def encode_jpeg_streaming_prototype(args, fmt, jpeg_input, bitstream, expected_c
     if work == 0:
         raise RuntimeError(f"streaming JPEG prototype did not report arena work size: {result.stdout!r}")
     slice_work = parse_jpeg_metric(result.stdout, "jpeg slice work bytes:")
-    if slice_work != JPEG_SLICE_WORK_BYTES:
+    if expected_slice_work_bytes is None:
+        expected_slice_work_bytes = JPEG_SLICE_WORK_BYTES
+    if slice_work != expected_slice_work_bytes:
         raise RuntimeError(
-            f"streaming JPEG prototype slice work changed: got {slice_work}, expected {JPEG_SLICE_WORK_BYTES}"
+            f"streaming JPEG prototype slice work changed: got {slice_work}, expected {expected_slice_work_bytes}"
         )
     peak = parse_jpeg_metric(result.stdout, "jpeg peak allocation bytes:")
     if peak >= 1382400:
@@ -657,6 +666,7 @@ def main():
                 max_peak_bytes=FULL_COMPONENT_BYTES_1440P_420,
                 expected_work_bytes=PRODUCTION_MEMORY_1440P_420["work"],
                 expected_peak_bytes=PRODUCTION_MEMORY_1440P_420["peak"],
+                expected_slice_work_bytes=JPEG_DIRECT_I420_SLICE_WORK_BYTES,
                 expected_effective_slice_work_bytes=JPEG_DIRECT_I420_EFFECTIVE_SLICE_WORK_BYTES)
     large_jpeg_output_nv12 = workdir / "output_jpeg_1440p_yuvj420p_nv12.h264"
     encode_jpeg(args, "nv12", large_jpeg_input, large_jpeg_output_nv12,
@@ -664,6 +674,7 @@ def main():
                 max_peak_bytes=FULL_COMPONENT_BYTES_1440P_420,
                 expected_work_bytes=PRODUCTION_MEMORY_1440P_420["work"],
                 expected_peak_bytes=PRODUCTION_MEMORY_1440P_420["peak"],
+                expected_slice_work_bytes=JPEG_DIRECT_NV12_SLICE_WORK_BYTES,
                 expected_effective_slice_work_bytes=JPEG_DIRECT_NV12_EFFECTIVE_SLICE_WORK_BYTES)
     validate_bitstream(args.ffprobe, args.ffmpeg, large_jpeg_output_nv12)
     large_heap_wrapper_output = workdir / "output_jpeg_heap_wrapper_1440p_yuvj420p_i420.h264"
@@ -672,17 +683,19 @@ def main():
                 expected_cache_bytes=STREAMING_CACHE_BYTES_1440P_420,
                 max_peak_bytes=FULL_COMPONENT_BYTES_1440P_420,
                 expected_peak_bytes=PRODUCTION_MEMORY_1440P_420["peak"],
+                expected_slice_work_bytes=JPEG_DIRECT_I420_SLICE_WORK_BYTES,
                 expected_effective_slice_work_bytes=JPEG_DIRECT_I420_EFFECTIVE_SLICE_WORK_BYTES)
     validate_bitstream(args.ffprobe, args.ffmpeg, large_heap_wrapper_output)
     if large_heap_wrapper_output.read_bytes() != large_jpeg_output.read_bytes():
         raise RuntimeError("JPEG heap wrapper bitstream differs from arena streaming output")
-    if EMBEDDED_OUTPUT_BUFFER_TOTAL_1440P_420 != 188_560:
+    if EMBEDDED_OUTPUT_BUFFER_TOTAL_1440P_420 != 127_120:
         raise RuntimeError(
             "2560x1440 JPEG streaming memory subtotal changed: "
-            f"got {EMBEDDED_OUTPUT_BUFFER_TOTAL_1440P_420}, expected 188560"
+            f"got {EMBEDDED_OUTPUT_BUFFER_TOTAL_1440P_420}, expected 127120"
         )
     encode_jpeg_streaming_prototype(args, "i420", large_jpeg_input, large_streaming_output,
-                                    STREAMING_CACHE_BYTES_1440P_420)
+                                    STREAMING_CACHE_BYTES_1440P_420,
+                                    JPEG_DIRECT_I420_SLICE_WORK_BYTES)
     validate_bitstream(args.ffprobe, args.ffmpeg, large_streaming_output)
     compare_decoded_i420(args, large_jpeg_output, large_streaming_output,
                          "output_jpeg_1440p_yuvj420p_i420_streaming_compare")

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -250,6 +250,17 @@ int main(void)
     ok &= expect_status("null JPEG work-size output",
                         sh264e_jpeg_get_work_size((const uint8_t *)"x", 1u, NULL),
                         SH264E_ERR_INVALID_ARGUMENT);
+    ok &= expect_status("null JPEG slice-work input",
+                        sh264e_jpeg_get_slice_work_size(NULL, 1u, SH264E_PIXFMT_I420, &jpeg_work_size),
+                        SH264E_ERR_INVALID_ARGUMENT);
+    ok &= expect_status("null JPEG slice-work output",
+                        sh264e_jpeg_get_slice_work_size((const uint8_t *)"x", 1u,
+                                                        SH264E_PIXFMT_I420, NULL),
+                        SH264E_ERR_INVALID_ARGUMENT);
+    ok &= expect_status("unsupported JPEG slice-work format",
+                        sh264e_jpeg_get_slice_work_size((const uint8_t *)"x", 1u,
+                                                        (sh264e_pixfmt_t)99, &jpeg_work_size),
+                        SH264E_ERR_UNSUPPORTED_CONFIG);
     ok &= expect_status("null JPEG arena encode",
                         sh264e_encode_jpeg_idr_with_arena(NULL, NULL, 0u, NULL, 0u,
                                                           NULL, 0u, NULL, 0u, NULL),

--- a/tools/sh264e_encode_jpeg.c
+++ b/tools/sh264e_encode_jpeg.c
@@ -285,9 +285,9 @@ int main(int argc, char **argv)
         fprintf(stderr, "sh264e_encoder_get_memory_report failed: %s\n", sh264e_status_string(status));
         goto done;
     }
-    status = sh264e_jpeg_get_slice_buffer_size(&work_size);
+    status = sh264e_jpeg_get_slice_work_size(jpeg_data, jpeg_size, pixfmt, &work_size);
     if (status != SH264E_OK) {
-        fprintf(stderr, "sh264e_jpeg_get_slice_buffer_size failed: %s\n", sh264e_status_string(status));
+        fprintf(stderr, "sh264e_jpeg_get_slice_work_size failed: %s\n", sh264e_status_string(status));
         goto done;
     }
     if (allocation_limit != (size_t)-1 || streaming_prototype ||
@@ -319,14 +319,16 @@ int main(int argc, char **argv)
         }
         jpeg_arena = jpeg_arena_alloc + arena_offset;
     }
-    work = (uint8_t *)malloc(work_size);
+    if (work_size != 0u) {
+        work = (uint8_t *)malloc(work_size);
+    }
     if (output_capacity != 0u) {
         output_buf = (uint8_t *)malloc(output_capacity);
     }
     if (output_chunk_capacity != 0u) {
         output_chunk_buf = (uint8_t *)malloc(output_chunk_capacity);
     }
-    if (work == NULL ||
+    if ((work_size != 0u && work == NULL) ||
         (output_capacity != 0u && output_buf == NULL) ||
         (output_chunk_capacity != 0u && output_chunk_buf == NULL)) {
         fprintf(stderr, "failed to allocate work/output buffers\n");


### PR DESCRIPTION
## Summary

Refs #53

- Add `sh264e_jpeg_get_slice_work_size` so callers can query path-specific JPEG slice work from JPEG bytes and output pixel format.
- Defer JPEG work-buffer validation until the MCU-row parser knows whether the path is direct I420, direct NV12, or the general scaler.
- Allow the `2560x1440` 4:2:0 1:1 I420 path to pass a `NULL`/zero-capacity slice work buffer; keep NV12 to the 20,480-byte chroma interleave staging window.
- Migrate the JPEG tool and integration assertions from conservative slice capacity to path-specific slice work.
- Update memory reports/plans for 0-byte I420 slice work, 20,480-byte NV12 slice work, and the new about-330 KiB/about-350 KiB embedded planning budgets.

## Validation

- `cmake -S . -B build/issue53`
- `cmake --build build/issue53`
- `ctest --test-dir build/issue53 --output-on-failure -R 'sh264e_api|sh264e_ffmpeg_integration'`
- `ctest --test-dir build/issue53 --output-on-failure`
- `python3 -m py_compile tests/run_ffmpeg_integration.py`
- `git diff --check`
- `build/issue53/sh264e_encode_jpeg --format i420 build/issue53/integration/input_1440p_yuvj420p.jpg build/issue53/issue53_1440_i420.h264`
- `build/issue53/sh264e_encode_jpeg --format nv12 build/issue53/integration/input_1440p_yuvj420p.jpg build/issue53/issue53_1440_nv12.h264`
- `ffmpeg -v error -xerror -i build/issue53/issue53_1440_i420.h264 -f null -`
- `ffmpeg -v error -xerror -i build/issue53/issue53_1440_nv12.h264 -f null -`

## Manual metrics

```text
I420 1440p:
jpeg work arena bytes: 123024
jpeg slice work bytes: 0
jpeg effective slice work bytes: 0
jpeg peak allocation bytes: 122880
jpeg streaming cache bytes: 61440
jpeg output buffer bytes: 4096

NV12 1440p:
jpeg work arena bytes: 123024
jpeg slice work bytes: 20480
jpeg effective slice work bytes: 20480
jpeg peak allocation bytes: 122880
jpeg streaming cache bytes: 61440
jpeg output buffer bytes: 4096
```

## Notes

`sh264e_jpeg_get_slice_buffer_size` remains available as the conservative 61,440-byte unknown-JPEG query. The new query is for callers that already have JPEG bytes and can afford the header/MCU-row measurement pass before allocating slice work.
