### PR TITLE
encoder: add caller arena creation API

### DIFF
--- a/MEMORY_OPTIMIZATION_PLAN.md
+++ b/MEMORY_OPTIMIZATION_PLAN.md
@@ -20,7 +20,7 @@ Current `2560x1440` 4:2:0 embedded budget, excluding compressed JPEG input and
 | JPEG work arena | 123,024 | 1:1 4:2:0 path: one MCU-row cache plus NanoJPEG MCU-row temp buffers |
 | JPEG/scaler slice work | 61,440 | API capacity; 1:1 effective use is I420 0 bytes, NV12 20,480 bytes |
 | Reusable H.264 output chunk buffer | 4,096 | Byte-stream flush buffer |
-| Encoder heap | 191,048 | See `docs/ENCODER_MEMORY_REPORT.md` |
+| Encoder arena | 191,055 | Caller-provided placement; see `docs/ENCODER_MEMORY_REPORT.md` |
 | Static mutable RAM | about 4,529 | Excludes `.rodata` |
 | Total | about 390 KiB class | Excludes compressed JPEG input |
 
@@ -99,7 +99,7 @@ Target the opaque encoder heap line item:
 
 | Current | Target |
 | ---: | --- |
-| about 191,024 bytes | measured 191,048-byte sub-block report |
+| about 191,024 bytes | measured 191,048-byte sub-block report; 191,055-byte arena |
 
 This is a measurement issue before optimization. The report should identify the
 major encoder state contributors such as reconstructed storage, neighbor/nonzero
@@ -148,6 +148,14 @@ Acceptance focus:
 * Existing heap-backed `sh264e_encoder_create` remains compatible.
 * Arena-backed creation has deterministic alignment and too-small behavior.
 * `sh264e_encoder_destroy` must not free caller-owned arena memory.
+
+Implemented arena contract:
+
+* `sh264e_encoder_get_work_size` reports 191,055 bytes for the fixed v1 config,
+  including worst-case opaque-control alignment padding.
+* `sh264e_encoder_create_with_arena` supports misaligned caller memory and
+  avoids production heap allocation for encoder-owned state.
+* Heap-backed creation remains available as a convenience wrapper.
 
 ### #52 Streaming Compressed JPEG Input Source
 

--- a/MEMORY_REDUCTION_PLAN.md
+++ b/MEMORY_REDUCTION_PLAN.md
@@ -272,7 +272,7 @@ Memory target for `2560x1440` JPEG 4:2:0 embedded path:
 | JPEG work arena | 123,024 |
 | JPEG/scaler slice work | 61,440 |
 | Reusable H.264 output chunk buffer | 4,096 |
-| Encoder heap | 191,048 |
+| Encoder arena | 191,055 |
 | Static mutable RAM | about 4,529 |
 | Total, excluding compressed JPEG input and `.rodata` | about 390 KiB budget class |
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,11 @@ capacity remains conservatively 61,440 bytes.
 `sh264e_encoder_get_memory_report` reports the fixed-v1 encoder heap breakdown
 without creating an encoder; `docs/ENCODER_MEMORY_REPORT.md` records the current
 191,048-byte total and sub-block composition.
+Embedded integrations can call `sh264e_encoder_get_work_size` and
+`sh264e_encoder_create_with_arena` to place the same encoder state in a
+caller-provided arena. The fixed-v1 arena size is currently 191,055 bytes,
+including worst-case control-structure alignment padding; `sh264e_encoder_destroy`
+does not free caller-owned arena memory.
 The arena-backed production path now uses MCU-row streaming by default. It keeps only NanoJPEG's current MCU-row buffers and the retained row cache, then feeds one scaled output slice at a time to the progressive encoder.
 The printed peak allocation includes the streaming row cache and MCU-row temp buffers; it excludes caller-owned JPEG input, arena header overhead, slice-work, H.264 output buffers, and NanoJPEG's compact in-context Huffman metadata.
 Diagnostic-only JPEG allocation-limit and streaming-prototype hooks are gated by `SH264E_ENABLE_JPEG_TEST_HOOKS` and declared in `tests/sh264e_jpeg_test_hooks.h`; they are not normal application APIs.
@@ -181,6 +186,8 @@ The public API is declared in `include/sh264e.h`.
 Progressive entry points:
 
 * `sh264e_encoder_create`
+* `sh264e_encoder_get_work_size`
+* `sh264e_encoder_create_with_arena`
 * `sh264e_encoder_destroy`
 * `sh264e_begin_idr`
 * `sh264e_encode_idr_slice`

--- a/docs/ENCODER_MEMORY_REPORT.md
+++ b/docs/ENCODER_MEMORY_REPORT.md
@@ -16,6 +16,7 @@ instance reports:
 | Reconstructed chroma slices | 20,480 | U and V, each `1280 * 8` |
 | Neighbor/nonzero state | 2,560 | 4x4 luma nonzero state for one slice |
 | Total encoder memory | 191,048 | Sum of the rows above |
+| Caller-provided encoder arena | 191,055 | Total plus worst-case control-structure alignment padding |
 
 The previously documented `about 191,024` byte budget was an estimate. The
 measured current 64-bit host total is `191,048` bytes.
@@ -36,10 +37,17 @@ This report is only encoder-owned memory. It excludes:
 validates the supplied encoder config and returns the sub-block sizes above
 without creating an encoder.
 
+`sh264e_encoder_get_work_size` reports the caller arena size needed by
+`sh264e_encoder_create_with_arena`. The arena-backed creation path accepts
+misaligned caller memory by aligning the opaque encoder control structure inside
+the supplied block, then carving the byte-addressed encoder work buffers after
+it. `sh264e_encoder_destroy` resets no caller memory and does not free the arena.
+
 The JPEG tool prints the same report:
 
 ```text
 encoder memory total bytes: 191048
+encoder arena work bytes: 191055
 encoder context bytes: 72
 encoder bitstream scratch bytes: 126976
 encoder recon luma bytes: 40960

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -130,11 +130,12 @@ For the `2560x1440` 4:2:0 embedded path, excluding compressed JPEG input and
 | JPEG work arena | 123,024 |
 | JPEG/scaler slice work | 61,440 |
 | Reusable H.264 output chunk buffer | 4,096 |
-| Encoder heap | 191,048 |
+| Encoder arena | 191,055 |
 | Static mutable RAM | about 4,529 |
 
-`docs/ENCODER_MEMORY_REPORT.md` breaks the encoder heap row into context,
-bitstream scratch, reconstructed-slice storage, and neighbor/nonzero state.
+`docs/ENCODER_MEMORY_REPORT.md` breaks the encoder arena row into context,
+bitstream scratch, reconstructed-slice storage, neighbor/nonzero state, and
+arena alignment padding.
 
 The hidden one-shot comparison path still reports the complete H.264 output
 capacity, `11,428,864` bytes, when testing one-shot APIs. That is caller-owned

--- a/docs/JPEG_STREAMING_MEMORY_REPORT.md
+++ b/docs/JPEG_STREAMING_MEMORY_REPORT.md
@@ -83,17 +83,17 @@ For the `2560x1440` 4:2:0 embedded path, excluding compressed JPEG input and
 | JPEG work arena | 123,024 |
 | JPEG/scaler slice work | 61,440 |
 | Reusable H.264 output chunk buffer | 4,096 |
-| Encoder heap | 191,048 |
+| Encoder arena | 191,055 |
 | Static mutable RAM | about 4,529 |
 | Rounded planning budget | about 390 KiB |
 
-The arithmetic subtotal of the rows above is about 384,113 bytes, or about
-375 KiB in binary units. The rounded planning budget is now about 390 KiB for
+The arithmetic subtotal of the rows above is about 384,120 bytes, or about
+375 KiB in binary units. The rounded planning budget remains about 390 KiB for
 this embedded path.
 
-The encoder heap row is measured by `sh264e_encoder_get_memory_report`; see
-`docs/ENCODER_MEMORY_REPORT.md` for the context, bitstream scratch,
-reconstructed-slice, and neighbor-state breakdown.
+The encoder arena row is reported by `sh264e_encoder_get_work_size`; see
+`docs/ENCODER_MEMORY_REPORT.md` for the raw context, bitstream scratch,
+reconstructed-slice, neighbor-state breakdown, and arena alignment padding.
 
 ## Regression Coverage
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -81,6 +81,8 @@ The public API uses the `sh264e_` prefix.
 Required API entry points:
 
 * `sh264e_encoder_create`
+* `sh264e_encoder_get_work_size`
+* `sh264e_encoder_create_with_arena`
 * `sh264e_encoder_destroy`
 * `sh264e_begin_idr`
 * `sh264e_encode_idr_slice`
@@ -377,6 +379,10 @@ without constructing an encoder. The current report is 191,048 bytes total:
 72 bytes of context/config, 126,976 bytes of bitstream scratch, 40,960 bytes of
 reconstructed luma slice storage, 20,480 bytes of reconstructed chroma slice
 storage, and 2,560 bytes of neighbor/nonzero state.
+`sh264e_encoder_get_work_size` reports the caller-provided arena requirement for
+the same fixed-v1 encoder state, currently 191,055 bytes including worst-case
+alignment padding. `sh264e_encoder_create_with_arena` constructs an encoder in
+that caller-owned block; `sh264e_encoder_destroy` does not free arena memory.
 
 NanoJPEG decodes baseline JPEG through MCU-row streaming. The library scales decoded component rows directly into one YUV420 encoder slice at a time:
 

--- a/include/sh264e.h
+++ b/include/sh264e.h
@@ -81,6 +81,14 @@ typedef sh264e_status_t (*sh264e_output_consumer_t)(void *user,
 sh264e_status_t sh264e_encoder_create(const sh264e_config_t *config,
                                       sh264e_encoder_t **out_encoder);
 
+sh264e_status_t sh264e_encoder_get_work_size(const sh264e_config_t *config,
+                                             size_t *out_size);
+
+sh264e_status_t sh264e_encoder_create_with_arena(const sh264e_config_t *config,
+                                                 void *arena,
+                                                 size_t arena_size,
+                                                 sh264e_encoder_t **out_encoder);
+
 void sh264e_encoder_destroy(sh264e_encoder_t *encoder);
 
 sh264e_status_t sh264e_get_max_header_output_size(const sh264e_config_t *config,

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -28,6 +28,9 @@
 #define SH264E_SCALE_FP_ONE (1u << SH264E_SCALE_FP_BITS)
 #define SH264E_SCALE_FP_HALF (SH264E_SCALE_FP_ONE >> 1u)
 #define SH264E_SCALE_FP_BLEND_ROUND ((uint64_t)1u << ((SH264E_SCALE_FP_BITS * 2u) - 1u))
+#define SH264E_ENCODER_FLAG_IDR_ACTIVE 1u
+#define SH264E_ENCODER_FLAG_OWNS_MEMORY 2u
+#define SH264E_ENCODER_ARENA_ALIGNMENT ((size_t)sizeof(void *))
 
 #if !defined(SH264E_DISABLE_ARM_DSP) && defined(__ARM_FEATURE_DSP) && defined(__GNUC__)
 #define SH264E_USE_ARM_DSP 1
@@ -58,7 +61,7 @@ struct sh264e_encoder_t {
     uint8_t *recon_u;
     uint8_t *recon_v;
     uint8_t *nz_luma;
-    unsigned idr_active;
+    unsigned flags;
     unsigned slices_encoded;
 };
 
@@ -389,6 +392,20 @@ static sh264e_status_t validate_config(const sh264e_config_t *config)
         return SH264E_ERR_UNSUPPORTED_CONFIG;
     }
     return SH264E_OK;
+}
+
+static int encoder_idr_active(const sh264e_encoder_t *encoder)
+{
+    return (encoder->flags & SH264E_ENCODER_FLAG_IDR_ACTIVE) != 0u;
+}
+
+static void encoder_set_idr_active(sh264e_encoder_t *encoder, int active)
+{
+    if (active) {
+        encoder->flags |= SH264E_ENCODER_FLAG_IDR_ACTIVE;
+    } else {
+        encoder->flags &= ~SH264E_ENCODER_FLAG_IDR_ACTIVE;
+    }
 }
 
 static size_t encoder_recon_luma_bytes(void)
@@ -2427,7 +2444,7 @@ static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *e
     *out_size = 0u;
     sh264e_jpeg_streaming_last_cache_bytes = 0u;
     sh264e_jpeg_streaming_last_slice_work_bytes = 0u;
-    if (encoder->idr_active != 0u) {
+    if (encoder_idr_active(encoder)) {
         return SH264E_ERR_BAD_STATE;
     }
     if (jpeg_size == 0u || jpeg_size > (size_t)INT_MAX) {
@@ -2524,22 +2541,17 @@ sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype_with_arena(sh264e_enc
 
 #endif
 
-sh264e_status_t sh264e_encoder_create(const sh264e_config_t *config,
-                                      sh264e_encoder_t **out_encoder)
+static sh264e_status_t normalize_encoder_config(const sh264e_config_t *config,
+                                                sh264e_config_t *out_normalized,
+                                                size_t *out_max_slice_output_size)
 {
     sh264e_status_t status;
-    sh264e_encoder_t *encoder;
-    size_t max_slice_output_size = 0;
     sh264e_config_t normalized;
+    size_t max_slice_output_size = 0u;
 
-    if (out_encoder == NULL) {
+    if (config == NULL || out_normalized == NULL || out_max_slice_output_size == NULL) {
         return SH264E_ERR_INVALID_ARGUMENT;
     }
-    *out_encoder = NULL;
-    if (config == NULL) {
-        return SH264E_ERR_INVALID_ARGUMENT;
-    }
-
     normalized = *config;
     if (normalized.qp == 0) {
         normalized.qp = SH264E_DEFAULT_QP;
@@ -2554,11 +2566,63 @@ sh264e_status_t sh264e_encoder_create(const sh264e_config_t *config,
         return status;
     }
 
+    *out_normalized = normalized;
+    *out_max_slice_output_size = max_slice_output_size;
+    return SH264E_OK;
+}
+
+static int checked_add_size(size_t a, size_t b, size_t *out)
+{
+    if (a > (size_t)-1 - b) {
+        return 0;
+    }
+    *out = a + b;
+    return 1;
+}
+
+static sh264e_status_t encoder_arena_work_size(size_t max_slice_output_size, size_t *out_size)
+{
+    size_t total = 0u;
+
+    if (!checked_add_size(total, sizeof(sh264e_encoder_t), &total) ||
+        !checked_add_size(total, max_slice_output_size, &total) ||
+        !checked_add_size(total, encoder_recon_luma_bytes(), &total) ||
+        !checked_add_size(total, encoder_recon_chroma_bytes(), &total) ||
+        !checked_add_size(total, encoder_neighbor_state_bytes(), &total) ||
+        !checked_add_size(total, SH264E_ENCODER_ARENA_ALIGNMENT - 1u, &total)) {
+        return SH264E_ERR_UNSUPPORTED_CONFIG;
+    }
+    *out_size = total;
+    return SH264E_OK;
+}
+
+sh264e_status_t sh264e_encoder_create(const sh264e_config_t *config,
+                                      sh264e_encoder_t **out_encoder)
+{
+    sh264e_status_t status;
+    sh264e_encoder_t *encoder;
+    size_t max_slice_output_size = 0u;
+    sh264e_config_t normalized;
+
+    if (out_encoder == NULL) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+    *out_encoder = NULL;
+    if (config == NULL) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+
+    status = normalize_encoder_config(config, &normalized, &max_slice_output_size);
+    if (status != SH264E_OK) {
+        return status;
+    }
+
     encoder = (sh264e_encoder_t *)calloc(1u, sizeof(*encoder));
     if (encoder == NULL) {
         return SH264E_ERR_ALLOCATION_FAILED;
     }
     encoder->config = normalized;
+    encoder->flags = SH264E_ENCODER_FLAG_OWNS_MEMORY;
     encoder->rbsp_capacity = max_slice_output_size;
     encoder->rbsp = (uint8_t *)malloc(encoder->rbsp_capacity);
     encoder->recon_y = (uint8_t *)malloc(encoder_recon_luma_bytes());
@@ -2576,17 +2640,137 @@ sh264e_status_t sh264e_encoder_create(const sh264e_config_t *config,
     return SH264E_OK;
 }
 
+sh264e_status_t sh264e_encoder_get_work_size(const sh264e_config_t *config,
+                                             size_t *out_size)
+{
+    sh264e_status_t status;
+    size_t max_slice_output_size = 0u;
+    sh264e_config_t normalized;
+
+    if (out_size == NULL) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+    *out_size = 0u;
+    status = normalize_encoder_config(config, &normalized, &max_slice_output_size);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    return encoder_arena_work_size(max_slice_output_size, out_size);
+}
+
+static sh264e_status_t encoder_arena_take(uint8_t **cursor,
+                                          uintptr_t end,
+                                          size_t size,
+                                          uint8_t **out)
+{
+    const uintptr_t current = (uintptr_t)*cursor;
+
+    if (current > end || size > end - current) {
+        return SH264E_ERR_BUFFER_TOO_SMALL;
+    }
+    *out = *cursor;
+    memset(*out, 0, size);
+    *cursor += size;
+    return SH264E_OK;
+}
+
+sh264e_status_t sh264e_encoder_create_with_arena(const sh264e_config_t *config,
+                                                 void *arena,
+                                                 size_t arena_size,
+                                                 sh264e_encoder_t **out_encoder)
+{
+    sh264e_status_t status;
+    sh264e_config_t normalized;
+    sh264e_encoder_t *encoder;
+    size_t max_slice_output_size = 0u;
+    size_t required_size = 0u;
+    uintptr_t start;
+    uintptr_t aligned;
+    uintptr_t end;
+    size_t remainder;
+    uint8_t *cursor;
+    uint8_t *block;
+
+    if (out_encoder == NULL) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+    *out_encoder = NULL;
+    if (config == NULL || arena == NULL) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+
+    status = normalize_encoder_config(config, &normalized, &max_slice_output_size);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    status = encoder_arena_work_size(max_slice_output_size, &required_size);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    if (arena_size < required_size) {
+        return SH264E_ERR_BUFFER_TOO_SMALL;
+    }
+
+    start = (uintptr_t)arena;
+    if (arena_size > UINTPTR_MAX - start) {
+        return SH264E_ERR_BUFFER_TOO_SMALL;
+    }
+    end = start + arena_size;
+    remainder = start % SH264E_ENCODER_ARENA_ALIGNMENT;
+    aligned = remainder == 0u ? start : start + (SH264E_ENCODER_ARENA_ALIGNMENT - remainder);
+    if (aligned < start || sizeof(*encoder) > end - aligned) {
+        return SH264E_ERR_BUFFER_TOO_SMALL;
+    }
+
+    encoder = (sh264e_encoder_t *)aligned;
+    memset(encoder, 0, sizeof(*encoder));
+    cursor = (uint8_t *)encoder + sizeof(*encoder);
+
+    status = encoder_arena_take(&cursor, end, max_slice_output_size, &block);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    encoder->rbsp = block;
+    status = encoder_arena_take(&cursor, end, encoder_recon_luma_bytes(), &block);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    encoder->recon_y = block;
+    status = encoder_arena_take(&cursor, end, encoder_recon_chroma_plane_bytes(), &block);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    encoder->recon_u = block;
+    status = encoder_arena_take(&cursor, end, encoder_recon_chroma_plane_bytes(), &block);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    encoder->recon_v = block;
+    status = encoder_arena_take(&cursor, end, encoder_neighbor_state_bytes(), &block);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    encoder->nz_luma = block;
+
+    encoder->config = normalized;
+    encoder->rbsp_capacity = max_slice_output_size;
+    *out_encoder = encoder;
+    return SH264E_OK;
+}
+
 void sh264e_encoder_destroy(sh264e_encoder_t *encoder)
 {
     if (encoder == NULL) {
         return;
     }
-    free(encoder->rbsp);
-    free(encoder->recon_y);
-    free(encoder->recon_u);
-    free(encoder->recon_v);
-    free(encoder->nz_luma);
-    free(encoder);
+    if ((encoder->flags & SH264E_ENCODER_FLAG_OWNS_MEMORY) != 0u) {
+        free(encoder->rbsp);
+        free(encoder->recon_y);
+        free(encoder->recon_u);
+        free(encoder->recon_v);
+        free(encoder->nz_luma);
+        free(encoder);
+    }
 }
 
 sh264e_status_t sh264e_get_max_header_output_size(const sh264e_config_t *config, size_t *out_size)
@@ -2703,7 +2887,7 @@ sh264e_status_t sh264e_begin_idr(sh264e_encoder_t *encoder,
         return SH264E_ERR_INVALID_ARGUMENT;
     }
     *out_size = 0;
-    if (encoder->idr_active != 0u) {
+    if (encoder_idr_active(encoder)) {
         return SH264E_ERR_BAD_STATE;
     }
     if (out_capacity == 0u) {
@@ -2719,7 +2903,7 @@ sh264e_status_t sh264e_begin_idr(sh264e_encoder_t *encoder,
         return status;
     }
 
-    encoder->idr_active = 1u;
+    encoder_set_idr_active(encoder, 1);
     encoder->slices_encoded = 0u;
     *out_size = offset;
     return SH264E_OK;
@@ -2738,7 +2922,7 @@ sh264e_status_t sh264e_encode_idr_slice(sh264e_encoder_t *encoder,
         return SH264E_ERR_INVALID_ARGUMENT;
     }
     *out_size = 0;
-    if (encoder->idr_active == 0u) {
+    if (!encoder_idr_active(encoder)) {
         return SH264E_ERR_BAD_STATE;
     }
     if (encoder->slices_encoded >= SH264E_MBS_Y) {
@@ -2777,7 +2961,7 @@ static sh264e_status_t sh264e_begin_idr_to_consumer(sh264e_encoder_t *encoder,
         return SH264E_ERR_INVALID_ARGUMENT;
     }
     *out_size = 0u;
-    if (encoder->idr_active != 0u) {
+    if (encoder_idr_active(encoder)) {
         return SH264E_ERR_BAD_STATE;
     }
     if (chunk_capacity == 0u) {
@@ -2808,7 +2992,7 @@ static sh264e_status_t sh264e_begin_idr_to_consumer(sh264e_encoder_t *encoder,
     }
     total += bytes;
 
-    encoder->idr_active = 1u;
+    encoder_set_idr_active(encoder, 1);
     encoder->slices_encoded = 0u;
     *out_size = total;
     return SH264E_OK;
@@ -2830,7 +3014,7 @@ static sh264e_status_t sh264e_encode_idr_slice_to_consumer(sh264e_encoder_t *enc
         return SH264E_ERR_INVALID_ARGUMENT;
     }
     *out_size = 0u;
-    if (encoder->idr_active == 0u) {
+    if (!encoder_idr_active(encoder)) {
         return SH264E_ERR_BAD_STATE;
     }
     if (encoder->slices_encoded >= SH264E_MBS_Y) {
@@ -2864,13 +3048,13 @@ sh264e_status_t sh264e_end_idr(sh264e_encoder_t *encoder)
     if (encoder == NULL) {
         return SH264E_ERR_INVALID_ARGUMENT;
     }
-    if (encoder->idr_active == 0u) {
+    if (!encoder_idr_active(encoder)) {
         return SH264E_ERR_BAD_STATE;
     }
     if (encoder->slices_encoded != SH264E_MBS_Y) {
         return SH264E_ERR_INCOMPLETE_FRAME;
     }
-    encoder->idr_active = 0u;
+    encoder_set_idr_active(encoder, 0);
     encoder->slices_encoded = 0u;
     return SH264E_OK;
 }
@@ -2899,7 +3083,7 @@ static void make_slice_from_frame(const sh264e_frame_t *frame, unsigned slice_in
 static void reset_progressive_state(sh264e_encoder_t *encoder)
 {
     if (encoder != NULL) {
-        encoder->idr_active = 0u;
+        encoder_set_idr_active(encoder, 0);
         encoder->slices_encoded = 0u;
     }
 }
@@ -2919,7 +3103,7 @@ sh264e_status_t sh264e_encode_idr(sh264e_encoder_t *encoder,
         return SH264E_ERR_INVALID_ARGUMENT;
     }
     *out_size = 0;
-    if (encoder->idr_active != 0u) {
+    if (encoder_idr_active(encoder)) {
         return SH264E_ERR_BAD_STATE;
     }
     status = validate_frame(&encoder->config, frame);

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -45,6 +45,7 @@ ENCODER_RECON_LUMA_BYTES = 40_960
 ENCODER_RECON_CHROMA_BYTES = 20_480
 ENCODER_NEIGHBOR_STATE_BYTES = 2_560
 ENCODER_MEMORY_TOTAL_BYTES = 191_048
+ENCODER_ARENA_WORK_BYTES = 191_055
 EMBEDDED_OUTPUT_BUFFER_TOTAL_1440P_420 = (
     PRODUCTION_MEMORY_1440P_420["work"]
     + JPEG_SLICE_WORK_BYTES
@@ -333,6 +334,11 @@ def validate_encoder_memory_report(stdout):
     )
     if report["total"] != subtotal:
         raise RuntimeError(f"encoder memory total {report['total']} != sub-block sum {subtotal}")
+    arena_work = parse_jpeg_metric(stdout, "encoder arena work bytes:")
+    if arena_work != ENCODER_ARENA_WORK_BYTES:
+        raise RuntimeError(
+            f"encoder arena work size changed: got {arena_work}, expected {ENCODER_ARENA_WORK_BYTES}"
+        )
 
 
 def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -161,9 +161,12 @@ int main(void)
     size_t slice_capacity = 0;
     size_t output_size = 0;
     size_t jpeg_work_size = 0;
+    size_t encoder_work_size = 0;
     uint8_t *slice_output = NULL;
     uint8_t *small_input = NULL;
     uint8_t *resize_work = NULL;
+    uint8_t *encoder_arena_alloc = NULL;
+    sh264e_encoder_t *arena_encoder = NULL;
     sh264e_jpeg_allocation_stats_t jpeg_alloc_stats;
     sh264e_encoder_memory_report_t encoder_memory_report;
     int ok = 1;
@@ -207,6 +210,15 @@ int main(void)
     ok &= expect_status("encoder memory report",
                         sh264e_encoder_get_memory_report(&config, &encoder_memory_report),
                         SH264E_OK);
+    ok &= expect_status("null encoder work-size config",
+                        sh264e_encoder_get_work_size(NULL, &encoder_work_size),
+                        SH264E_ERR_INVALID_ARGUMENT);
+    ok &= expect_status("null encoder work-size output",
+                        sh264e_encoder_get_work_size(&config, NULL),
+                        SH264E_ERR_INVALID_ARGUMENT);
+    ok &= expect_status("encoder work size",
+                        sh264e_encoder_get_work_size(&config, &encoder_work_size),
+                        SH264E_OK);
     if (output_capacity == 0u) {
         fprintf(stderr, "max output size returned zero\n");
         ok = 0;
@@ -241,6 +253,18 @@ int main(void)
         fprintf(stderr, "encoder memory total does not match sub-block sum\n");
         ok = 0;
     }
+    if (encoder_work_size != encoder_memory_report.total_bytes + sizeof(void *) - 1u) {
+        fprintf(stderr, "unexpected encoder arena work size: %zu\n", encoder_work_size);
+        ok = 0;
+    }
+    ok &= expect_status("null encoder arena",
+                        sh264e_encoder_create_with_arena(&config, NULL,
+                                                         encoder_work_size, &arena_encoder),
+                        SH264E_ERR_INVALID_ARGUMENT);
+    ok &= expect_status("null encoder arena output",
+                        sh264e_encoder_create_with_arena(&config, input,
+                                                         encoder_work_size, NULL),
+                        SH264E_ERR_INVALID_ARGUMENT);
     ok &= expect_status("null JPEG allocation stats",
                         sh264e_jpeg_get_last_allocation_stats(NULL),
                         SH264E_ERR_INVALID_ARGUMENT);
@@ -383,6 +407,36 @@ int main(void)
     frame.stride[1] = SH264E_V1_WIDTH / 2u;
     frame.stride[2] = SH264E_V1_WIDTH / 2u;
 
+    encoder_arena_alloc = (uint8_t *)malloc(encoder_work_size + 1u);
+    if (encoder_arena_alloc == NULL) {
+        fprintf(stderr, "encoder arena allocation failed\n");
+        ok = 0;
+    } else {
+        ok &= expect_status("encoder arena too small",
+                            sh264e_encoder_create_with_arena(&config,
+                                                             encoder_arena_alloc + 1u,
+                                                             encoder_work_size - 1u,
+                                                             &arena_encoder),
+                            SH264E_ERR_BUFFER_TOO_SMALL);
+        ok &= expect_status("create arena encoder",
+                            sh264e_encoder_create_with_arena(&config,
+                                                             encoder_arena_alloc + 1u,
+                                                             encoder_work_size,
+                                                             &arena_encoder),
+                            SH264E_OK);
+        if (arena_encoder != NULL) {
+            output_size = 0u;
+            status = sh264e_encode_idr(arena_encoder, &frame, output, output_capacity, &output_size);
+            ok &= expect_status("arena encode idr", status, SH264E_OK);
+            if (status == SH264E_OK && !expect_wrapper_nal_sequence(output, output_size)) {
+                ok = 0;
+            }
+            sh264e_encoder_destroy(arena_encoder);
+            arena_encoder = NULL;
+            encoder_arena_alloc[0] = 0xa5u;
+        }
+    }
+
     ok &= expect_status("small output buffer",
                         sh264e_encode_idr(encoder, &frame, output, 8u, &output_size),
                         SH264E_ERR_BUFFER_TOO_SMALL);
@@ -444,11 +498,13 @@ int main(void)
                             SH264E_ERR_BAD_STATE);
     }
 
+    sh264e_encoder_destroy(arena_encoder);
     sh264e_encoder_destroy(encoder);
     free(input);
     free(output);
     free(slice_output);
     free(resize_work);
     free(small_input);
+    free(encoder_arena_alloc);
     return ok ? 0 : 1;
 }

--- a/tools/sh264e_encode_jpeg.c
+++ b/tools/sh264e_encode_jpeg.c
@@ -160,6 +160,7 @@ int main(int argc, char **argv)
     size_t jpeg_size = 0;
     size_t jpeg_work_size = 0;
     size_t jpeg_arena_size = 0;
+    size_t encoder_work_size = 0;
     size_t work_size = 0;
     size_t output_capacity = 0;
     size_t output_chunk_capacity = 0;
@@ -283,6 +284,11 @@ int main(int argc, char **argv)
     status = sh264e_encoder_get_memory_report(&config, &encoder_memory_report);
     if (status != SH264E_OK) {
         fprintf(stderr, "sh264e_encoder_get_memory_report failed: %s\n", sh264e_status_string(status));
+        goto done;
+    }
+    status = sh264e_encoder_get_work_size(&config, &encoder_work_size);
+    if (status != SH264E_OK) {
+        fprintf(stderr, "sh264e_encoder_get_work_size failed: %s\n", sh264e_status_string(status));
         goto done;
     }
     status = sh264e_jpeg_get_slice_buffer_size(&work_size);
@@ -464,6 +470,7 @@ int main(int argc, char **argv)
             printf("jpeg output buffer bytes: %zu\n", output_chunk_capacity);
         }
         printf("encoder memory total bytes: %zu\n", encoder_memory_report.total_bytes);
+        printf("encoder arena work bytes: %zu\n", encoder_work_size);
         printf("encoder context bytes: %zu\n", encoder_memory_report.context_bytes);
         printf("encoder bitstream scratch bytes: %zu\n",
                encoder_memory_report.bitstream_scratch_bytes);


### PR DESCRIPTION
## Summary

Refs #51

- Add `sh264e_encoder_get_work_size` and `sh264e_encoder_create_with_arena` for deterministic caller-owned encoder placement.
- Preserve the existing heap-backed `sh264e_encoder_create` API and keep the fixed-v1 encoder memory report at 191,048 bytes.
- Support misaligned caller arenas by aligning the opaque encoder control structure inside the arena, then carving byte-addressed work buffers after it.
- Make `sh264e_encoder_destroy` free only heap-owned encoders and leave caller-owned arena memory untouched.
- Add API and integration regression coverage for arena sizing, too-small behavior, misaligned arena creation, encode correctness, and the 191,055-byte arena metric.
- Update encoder/JPEG memory docs and roadmap tables for the caller-provided encoder arena.
- Merge current `main` and preserve the 1:1 I420 slice-work bypass from PR #58.

## Validation

- `cmake -S . -B build/issue51`
- `cmake --build build/issue51`
- `ctest --test-dir build/issue51 --output-on-failure -R sh264e_api`
- `ctest --test-dir build/issue51 --output-on-failure -R 'sh264e_api|sh264e_ffmpeg_integration'`
- `ctest --test-dir build/issue51 --output-on-failure`
- `python3 -m py_compile tests/run_ffmpeg_integration.py`
- `git diff --check`
- `cmake -S . -B build/issue51-prod -DSH264E_BUILD_TESTS=OFF -DSH264E_ENABLE_JPEG_TEST_HOOKS=OFF`
- `cmake --build build/issue51-prod`
- `build/issue51/sh264e_encode_jpeg --format i420 build/issue51/integration/input_1440p_yuvj420p.jpg build/issue51/issue51_1440_i420_after_merge.h264`
- `ffmpeg -v error -xerror -i build/issue51/issue51_1440_i420_after_merge.h264 -f null -`

## Manual metrics

```text
encoder memory total bytes: 191048
encoder arena work bytes: 191055
jpeg work arena bytes: 123024
jpeg slice work bytes: 0
jpeg effective slice work bytes: 0
jpeg peak allocation bytes: 122880
jpeg streaming cache bytes: 61440
jpeg output buffer bytes: 4096
```

## Notes

The 191,055-byte arena is the 191,048-byte fixed-v1 encoder state plus worst-case pointer-alignment padding for the opaque control structure. QEMU firmware tests remain skipped in this environment because `arm-none-eabi-gcc` cannot compile `<stdlib.h>`.
