### PR TITLE
build: validate embedded production profile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,20 @@ if(SH264E_BUILD_TESTS)
             -DSH264E_PROJECT_DIR=${CMAKE_CURRENT_SOURCE_DIR}
             -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/check_jpeg_diagnostics_boundary.cmake
     )
+    find_program(SH264E_NM nm llvm-nm)
+    if(SH264E_NM)
+        add_test(
+            NAME sh264e_production_profile_symbols
+            COMMAND ${CMAKE_COMMAND}
+                -DSH264E_PROJECT_DIR=${CMAKE_CURRENT_SOURCE_DIR}
+                -DSH264E_PRODUCTION_BINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}/production_profile
+                -DSH264E_NM=${SH264E_NM}
+                -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/check_production_profile_symbols.cmake
+        )
+        set_tests_properties(sh264e_production_profile_symbols PROPERTIES TIMEOUT 60)
+    else()
+        message(STATUS "Skipping production profile symbol test: nm or llvm-nm was not found")
+    endif()
 
     find_package(Python3 COMPONENTS Interpreter)
     find_program(SH264E_FFPROBE ffprobe)

--- a/MEMORY_OPTIMIZATION_PLAN.md
+++ b/MEMORY_OPTIMIZATION_PLAN.md
@@ -208,6 +208,7 @@ cmake -S . -B build-prod \
   -DSH264E_BUILD_TESTS=OFF \
   -DSH264E_ENABLE_JPEG_TEST_HOOKS=OFF
 cmake --build build-prod
+nm -g build-prod/libsimple_h264_enc_i.a | rg "sh264e_jpeg_set_test|streaming_prototype|njDecode([^A-Za-z0-9_]|$)|njDecodeComponents|njGetImage|njGetImageSize|njIsColor" && exit 1 || true
 ```
 
 Acceptance focus:
@@ -216,6 +217,8 @@ Acceptance focus:
 * NanoJPEG full-image decode remains disabled.
 * Public diagnostics are intentionally documented.
 * Production build command and symbol-inspection command are documented.
+* `sh264e_production_profile_symbols` validates the profile during normal CTest
+  when `nm` or `llvm-nm` is available.
 
 ## Validation Baseline
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,28 @@ cmake -S . -B build
 cmake --build build
 ```
 
+Embedded production builds should compile only the static library and leave
+private JPEG fault-injection/prototype hooks disabled:
+
+```sh
+cmake -S . -B build-prod \
+  -DSH264E_BUILD_TOOLS=OFF \
+  -DSH264E_BUILD_TESTS=OFF \
+  -DSH264E_ENABLE_JPEG_TEST_HOOKS=OFF
+cmake --build build-prod
+```
+
+The intended production symbol surface can be audited with:
+
+```sh
+nm -g build-prod/libsimple_h264_enc_i.a | rg "sh264e_jpeg_set_test|streaming_prototype|njDecode([^A-Za-z0-9_]|$)|njDecodeComponents|njGetImage|njGetImageSize|njIsColor" && exit 1 || true
+nm -g build-prod/libsimple_h264_enc_i.a | rg "sh264e_jpeg_get_last_(allocation_stats|streaming_cache_bytes|slice_work_bytes)|sh264e_encoder_get_memory_report"
+```
+
+The first command must find no private test hooks or NanoJPEG full-image decode
+symbols. The second command documents the public diagnostic/stat APIs that stay
+available in production for memory reporting.
+
 The main library target is:
 
 ```text
@@ -79,6 +101,7 @@ The test suite covers:
 * ffmpeg/ffprobe integration when those tools are available
 * Cortex-M QEMU scaler smoke tests when `arm-none-eabi-gcc` and `qemu-system-arm` are available and usable
 * Cortex-M QEMU scaler benchmark firmware correctness for default DSP-capable and portable C variants when those tools are available and usable
+* production-profile symbol audit when `nm` or `llvm-nm` is available
 
 ## CLI Example
 
@@ -201,10 +224,16 @@ JPEG pipeline entry points:
 * `sh264e_jpeg_get_slice_buffer_size`
 * `sh264e_jpeg_get_slice_work_size`
 * `sh264e_jpeg_get_work_size`
-* `sh264e_jpeg_get_last_allocation_stats`
 * `sh264e_encode_jpeg_idr`
 * `sh264e_encode_jpeg_idr_with_arena`
 * `sh264e_encode_jpeg_idr_with_arena_stream`
+
+Diagnostic/stat entry points:
+
+* `sh264e_jpeg_get_last_allocation_stats`
+* `sh264e_jpeg_get_last_streaming_cache_bytes`
+* `sh264e_jpeg_get_last_slice_work_bytes`
+* `sh264e_encoder_get_memory_report`
 
 Frame-mode convenience entry points:
 

--- a/docs/JPEG_MCU_ROW_STREAMING.md
+++ b/docs/JPEG_MCU_ROW_STREAMING.md
@@ -158,6 +158,21 @@ streaming prototype entry points are declared in
 `SH264E_ENABLE_JPEG_TEST_HOOKS=1`. Production builds should leave those hooks
 disabled.
 
+The embedded production profile keeps that boundary explicit:
+
+```sh
+cmake -S . -B build-prod \
+  -DSH264E_BUILD_TOOLS=OFF \
+  -DSH264E_BUILD_TESTS=OFF \
+  -DSH264E_ENABLE_JPEG_TEST_HOOKS=OFF
+cmake --build build-prod
+nm -g build-prod/libsimple_h264_enc_i.a | rg "sh264e_jpeg_set_test|streaming_prototype|njDecode([^A-Za-z0-9_]|$)|njDecodeComponents|njGetImage|njGetImageSize|njIsColor" && exit 1 || true
+```
+
+Normal CTest runs include a production-profile symbol audit when `nm` or
+`llvm-nm` is available, so hook leakage and NanoJPEG full-image decode exports
+fail before firmware integration.
+
 ## Validation
 
 The expected validation command is:

--- a/docs/JPEG_STREAMING_MEMORY_REPORT.md
+++ b/docs/JPEG_STREAMING_MEMORY_REPORT.md
@@ -108,6 +108,12 @@ color-subsampling coverage that fails if the production arena path regresses to
 full component-plane allocation or if the default JPEG tool path regresses to
 allocating `sh264e_get_max_output_size()` for H.264 output.
 
+The normal CTest suite also includes `sh264e_production_profile_symbols` when
+`nm` or `llvm-nm` is available. That check configures the embedded production
+profile with tools, tests, and JPEG test hooks disabled, then verifies the
+public diagnostic/stat APIs remain exported while private hooks and NanoJPEG
+full-image decode symbols stay absent.
+
 The expected closeout is stricter: every public JPEG API, including the
 heap-backed one-shot wrapper, must use MCU-row streaming and must not touch the
 old full decoded component-frame path. Regression coverage should fail if

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -385,6 +385,32 @@ without constructing an encoder. The current report is 191,048 bytes total:
 reconstructed luma slice storage, 20,480 bytes of reconstructed chroma slice
 storage, and 2,560 bytes of neighbor/nonzero state.
 
+## Embedded Production Profile
+
+The recommended firmware-facing production profile builds only the static
+library and disables tests, tools, and private JPEG hooks:
+
+```sh
+cmake -S . -B build-prod \
+  -DSH264E_BUILD_TOOLS=OFF \
+  -DSH264E_BUILD_TESTS=OFF \
+  -DSH264E_ENABLE_JPEG_TEST_HOOKS=OFF
+cmake --build build-prod
+```
+
+Production symbol inspection should show public encode and diagnostic/stat APIs
+but no private JPEG test hooks or NanoJPEG full-image decode entry points:
+
+```sh
+nm -g build-prod/libsimple_h264_enc_i.a | rg "sh264e_jpeg_set_test|streaming_prototype|njDecode([^A-Za-z0-9_]|$)|njDecodeComponents|njGetImage|njGetImageSize|njIsColor" && exit 1 || true
+nm -g build-prod/libsimple_h264_enc_i.a | rg "sh264e_jpeg_get_last_(allocation_stats|streaming_cache_bytes|slice_work_bytes)|sh264e_encoder_get_memory_report"
+```
+
+The normal CTest suite includes `sh264e_production_profile_symbols` when `nm` or
+`llvm-nm` is available. That test configures this production profile, builds the
+library, verifies tools/tests are absent, confirms the public diagnostic APIs,
+and rejects private JPEG hooks plus NanoJPEG full-image decode symbols.
+
 NanoJPEG decodes baseline JPEG through MCU-row streaming. The library scales decoded component rows directly into one YUV420 encoder slice at a time:
 
 For `2560x1440` 4:2:0 source JPEGs encoded to the fixed target, the JPEG path

--- a/tests/check_production_profile_symbols.cmake
+++ b/tests/check_production_profile_symbols.cmake
@@ -1,0 +1,113 @@
+cmake_minimum_required(VERSION 3.20)
+
+if(NOT DEFINED SH264E_PROJECT_DIR)
+    message(FATAL_ERROR "SH264E_PROJECT_DIR is required")
+endif()
+if(NOT DEFINED SH264E_PRODUCTION_BINARY_DIR)
+    message(FATAL_ERROR "SH264E_PRODUCTION_BINARY_DIR is required")
+endif()
+if(NOT DEFINED SH264E_NM)
+    message(FATAL_ERROR "SH264E_NM is required")
+endif()
+
+execute_process(
+    COMMAND ${CMAKE_COMMAND}
+        -S ${SH264E_PROJECT_DIR}
+        -B ${SH264E_PRODUCTION_BINARY_DIR}
+        -DSH264E_BUILD_TOOLS=OFF
+        -DSH264E_BUILD_TESTS=OFF
+        -DSH264E_ENABLE_JPEG_TEST_HOOKS=OFF
+    RESULT_VARIABLE configure_result
+    OUTPUT_VARIABLE configure_stdout
+    ERROR_VARIABLE configure_stderr
+)
+if(NOT configure_result EQUAL 0)
+    message(FATAL_ERROR
+        "Production profile configure failed\n"
+        "${configure_stdout}\n${configure_stderr}")
+endif()
+
+execute_process(
+    COMMAND ${CMAKE_COMMAND}
+        --build ${SH264E_PRODUCTION_BINARY_DIR}
+        --target simple_h264_enc_i
+    RESULT_VARIABLE build_result
+    OUTPUT_VARIABLE build_stdout
+    ERROR_VARIABLE build_stderr
+)
+if(NOT build_result EQUAL 0)
+    message(FATAL_ERROR
+        "Production profile build failed\n"
+        "${build_stdout}\n${build_stderr}")
+endif()
+
+set(production_library_candidates
+    "${SH264E_PRODUCTION_BINARY_DIR}/libsimple_h264_enc_i.a"
+    "${SH264E_PRODUCTION_BINARY_DIR}/simple_h264_enc_i.lib"
+    "${SH264E_PRODUCTION_BINARY_DIR}/Debug/simple_h264_enc_i.lib"
+    "${SH264E_PRODUCTION_BINARY_DIR}/Release/simple_h264_enc_i.lib"
+)
+set(production_library "")
+foreach(candidate IN LISTS production_library_candidates)
+    if(EXISTS "${candidate}")
+        set(production_library "${candidate}")
+        break()
+    endif()
+endforeach()
+if(production_library STREQUAL "")
+    message(FATAL_ERROR "Production profile did not produce simple_h264_enc_i static library")
+endif()
+
+foreach(tool_name
+        sh264e_encode_file
+        sh264e_encode_file_progressive
+        sh264e_resize_encode_progressive
+        sh264e_encode_jpeg
+        sh264e_test_api
+        sh264e_test_jpeg_mcu_rows)
+    foreach(suffix "" ".exe")
+        if(EXISTS "${SH264E_PRODUCTION_BINARY_DIR}/${tool_name}${suffix}")
+            message(FATAL_ERROR "Production profile unexpectedly built ${tool_name}${suffix}")
+        endif()
+    endforeach()
+endforeach()
+
+execute_process(
+    COMMAND ${SH264E_NM} -g ${production_library}
+    RESULT_VARIABLE nm_result
+    OUTPUT_VARIABLE nm_stdout
+    ERROR_VARIABLE nm_stderr
+)
+if(NOT nm_result EQUAL 0)
+    message(FATAL_ERROR
+        "Production symbol inspection failed\n"
+        "${nm_stdout}\n${nm_stderr}")
+endif()
+
+foreach(required_symbol
+        sh264e_encode_jpeg_idr_with_arena_stream
+        sh264e_jpeg_get_last_allocation_stats
+        sh264e_jpeg_get_last_streaming_cache_bytes
+        sh264e_jpeg_get_last_slice_work_bytes
+        sh264e_encoder_get_memory_report)
+    if(NOT nm_stdout MATCHES "_?${required_symbol}([^A-Za-z0-9_]|$)")
+        message(FATAL_ERROR "Production symbols are missing public API ${required_symbol}")
+    endif()
+endforeach()
+
+foreach(forbidden_symbol
+        sh264e_jpeg_set_test_allocation_limit
+        sh264e_encode_jpeg_idr_streaming_prototype
+        sh264e_encode_jpeg_idr_streaming_prototype_with_arena
+        njDecodeComponents
+        njGetImage
+        njGetImageSize
+        njIsColor)
+    if(nm_stdout MATCHES "_?${forbidden_symbol}([^A-Za-z0-9_]|$)")
+        message(FATAL_ERROR "Production symbols expose private symbol ${forbidden_symbol}")
+    endif()
+endforeach()
+
+if(nm_stdout MATCHES "(^|[^A-Za-z0-9_])_?njDecode([^A-Za-z0-9_]|$)")
+    message(FATAL_ERROR "Production symbols expose NanoJPEG full-image njDecode")
+endif()


### PR DESCRIPTION
## Summary

Refs #54

- Add `sh264e_production_profile_symbols`, a CTest that configures the embedded production profile with tools, tests, and JPEG test hooks disabled.
- Build only the production static library in the nested profile and verify tool/test executables are absent.
- Audit production symbols with `nm` to keep public diagnostic/stat APIs exported while rejecting private JPEG hooks and NanoJPEG full-image decode symbols.
- Document the production CMake command, symbol-inspection command, public diagnostics, and hook/full-image-decode boundary in README and design docs.

## Validation

- `cmake -S . -B build/issue54`
- `cmake --build build/issue54`
- `ctest --test-dir build/issue54 --output-on-failure -R sh264e_production_profile_symbols`
- `ctest --test-dir build/issue54 --output-on-failure -R 'sh264e_jpeg_diagnostics_boundary|sh264e_production_profile_symbols|sh264e_api'`
- `ctest --test-dir build/issue54 --output-on-failure`
- `cmake -S . -B build/issue54-prod -DSH264E_BUILD_TOOLS=OFF -DSH264E_BUILD_TESTS=OFF -DSH264E_ENABLE_JPEG_TEST_HOOKS=OFF`
- `cmake --build build/issue54-prod`
- `nm -g build/issue54-prod/libsimple_h264_enc_i.a | rg "sh264e_jpeg_set_test|streaming_prototype|njDecode([^A-Za-z0-9_]|$)|njDecodeComponents|njGetImage|njGetImageSize|njIsColor" && exit 1 || true`
- `nm -g build/issue54-prod/libsimple_h264_enc_i.a | rg "sh264e_jpeg_get_last_(allocation_stats|streaming_cache_bytes|slice_work_bytes)|sh264e_encoder_get_memory_report"`
- `git diff --check`

## Notes

CMake still skips QEMU firmware tests in this environment because `arm-none-eabi-gcc` cannot compile `<stdlib.h>`.
