### PR TITLE
jpeg: add streaming compressed input source

### DIFF
--- a/MEMORY_OPTIMIZATION_PLAN.md
+++ b/MEMORY_OPTIMIZATION_PLAN.md
@@ -12,8 +12,8 @@ implementation.
 
 ## Current Budget
 
-Current `2560x1440` 4:2:0 embedded budget, excluding compressed JPEG input and
-`.rodata`:
+Current `2560x1440` 4:2:0 embedded budget, excluding compressed JPEG input
+storage and `.rodata`:
 
 | Block | Bytes | Notes |
 | --- | ---: | --- |
@@ -21,7 +21,7 @@ Current `2560x1440` 4:2:0 embedded budget, excluding compressed JPEG input and
 | JPEG/scaler slice work | 0 I420 / 20,480 NV12 | Path-specific query for 1:1 4:2:0; conservative unknown-JPEG capacity remains 61,440 |
 | Reusable H.264 output chunk buffer | 4,096 | Byte-stream flush buffer |
 | Encoder arena | 191,055 | Caller-provided placement; see `docs/ENCODER_MEMORY_REPORT.md` |
-| Static mutable RAM | about 4,529 | Excludes `.rodata` |
+| Static mutable RAM | about 5,041 | Excludes `.rodata`; includes NanoJPEG's 512-byte compressed-input window |
 | Total | about 330 KiB I420 / 350 KiB NV12 | Excludes compressed JPEG input |
 
 The old full decoded JPEG component-frame allocation was 5,529,600 bytes for
@@ -160,19 +160,35 @@ Implemented arena contract:
 
 ### #52 Streaming Compressed JPEG Input Source
 
-This is a v2 item. It targets memory currently excluded from the budget: the
-caller-owned compressed JPEG input buffer.
+This is a v2 item. It targets memory previously excluded from the budget: the
+caller-owned contiguous compressed JPEG input buffer.
 
-Current public JPEG APIs accept:
+The original public JPEG APIs still accept:
 
 ```c
 const uint8_t *jpeg_data, size_t jpeg_size
 ```
 
-A future source abstraction may read from flash, storage, camera FIFO, DMA ring,
-or application chunks. This touches NanoJPEG's parser and entropy reader, so it
-should be scheduled after the lower-risk memory reductions unless compressed
-input storage becomes the dominant product constraint.
+The implemented source abstraction reads from flash, storage, camera FIFO, DMA
+ring, or application chunks through:
+
+```c
+typedef sh264e_status_t (*sh264e_jpeg_read_fn)(
+    void *user,
+    uint8_t *dst,
+    size_t requested,
+    size_t *out_read);
+
+typedef struct sh264e_jpeg_source_t {
+    sh264e_jpeg_read_fn read;
+    void *user;
+} sh264e_jpeg_source_t;
+```
+
+The source callback is pull-only and sequential. `0` read bytes signals EOF,
+and work-size/slice-work queries consume the source, so callers must reset or
+recreate it before encode. NanoJPEG now uses a 512-byte compressed-input window
+for source-backed parser and entropy reads.
 
 Acceptance focus:
 
@@ -253,5 +269,6 @@ When an issue changes memory behavior, update the relevant report:
 3. Do #51 after #50.
 4. Do #53 after #49 unless scoped narrowly.
 5. Do #54 any time before firmware integration.
-6. Keep #52 as v2 unless compressed JPEG input storage becomes the top product
-   blocker.
+6. #52 is now the v2 source-input path: follow-up work should focus on
+   production callers that can provide a resettable source around flash,
+   storage, camera FIFO, or DMA-ring input.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is intentionally small and narrow in scope:
 * No file I/O inside the encoder library
 * Progressive slice API for lower SRAM footprint and input bandwidth
 * Core fixed-point bilinear scaler for resizing source YUV420 into encoder slices
-* Core memory-input baseline JPEG decode path via NanoJPEG
+* Core memory-input and source-input baseline JPEG decode path via NanoJPEG
 
 The encoder is designed for validation and offline experiments, not compression efficiency.
 
@@ -144,8 +144,16 @@ Encode a baseline JPEG memory-input path through the library wrapper:
 ./build/sh264e_encode_jpeg --format nv12 input.jpg output.h264
 ```
 
-The JPEG path uses NanoJPEG inside the core library. The tool only reads the JPEG file and writes the `.h264` output; the library API accepts a caller-provided JPEG byte buffer and emits Annex B byte-stream chunks through caller-owned output memory.
+The JPEG path uses NanoJPEG inside the core library. The tool only reads the JPEG file and writes the `.h264` output; the library API accepts either a caller-provided JPEG byte buffer or a sequential `sh264e_jpeg_source_t` reader and emits Annex B byte-stream chunks through caller-owned output memory.
 The tool sizes a caller-provided JPEG decoder arena with `sh264e_jpeg_get_work_size`, passes that arena to `sh264e_encode_jpeg_idr_with_arena_stream`, and prints the arena requirement plus current and peak NanoJPEG allocation bytes reported by `sh264e_jpeg_get_last_allocation_stats`.
+Embedded callers that cannot provide one contiguous compressed JPEG can use
+`sh264e_jpeg_source_get_work_size`, `sh264e_jpeg_source_get_slice_work_size`,
+and `sh264e_encode_jpeg_source_idr_with_arena_stream`. The source callback is
+pull-only and sequential: it fills up to the requested byte count, reports the
+actual bytes read, and returns `0` bytes at EOF. Work-size queries consume the
+source, so callers must reset or recreate the source before the slice-work query
+and encode call. File I/O, flash drivers, DMA-ring handling, and retry policy
+remain outside the library.
 The public diagnostic surface also exposes `sh264e_jpeg_get_last_streaming_cache_bytes` so tools and regression tests can report decoded-row cache usage without private declarations.
 `sh264e_jpeg_get_slice_work_size` reports the path-specific caller work buffer
 needed for a specific JPEG input and output pixel format; the older
@@ -164,7 +172,7 @@ caller-provided arena. The fixed-v1 arena size is currently 191,055 bytes,
 including worst-case control-structure alignment padding; `sh264e_encoder_destroy`
 does not free caller-owned arena memory.
 The arena-backed production path now uses MCU-row streaming by default. It keeps only NanoJPEG's current MCU-row buffers and the retained row cache, then feeds one scaled output slice at a time to the progressive encoder.
-The printed peak allocation includes the streaming row cache and MCU-row temp buffers; it excludes caller-owned JPEG input, arena header overhead, slice-work, H.264 output buffers, and NanoJPEG's compact in-context Huffman metadata.
+The printed peak allocation includes the streaming row cache and MCU-row temp buffers; it excludes caller-owned JPEG input, arena header overhead, slice-work, H.264 output buffers, NanoJPEG's compact in-context Huffman metadata, and the fixed 512-byte compressed-input parser window in the NanoJPEG context.
 Diagnostic-only JPEG allocation-limit and streaming-prototype hooks are gated by `SH264E_ENABLE_JPEG_TEST_HOOKS` and declared in `tests/sh264e_jpeg_test_hooks.h`; they are not normal application APIs.
 All public JPEG entry points must use the MCU-row streaming decode path. The
 heap-backed convenience wrapper may remain non-deterministic in allocation
@@ -230,10 +238,13 @@ JPEG pipeline entry points:
 
 * `sh264e_jpeg_get_slice_buffer_size`
 * `sh264e_jpeg_get_slice_work_size`
+* `sh264e_jpeg_source_get_slice_work_size`
 * `sh264e_jpeg_get_work_size`
+* `sh264e_jpeg_source_get_work_size`
 * `sh264e_encode_jpeg_idr`
 * `sh264e_encode_jpeg_idr_with_arena`
 * `sh264e_encode_jpeg_idr_with_arena_stream`
+* `sh264e_encode_jpeg_source_idr_with_arena_stream`
 
 Diagnostic/stat entry points:
 

--- a/docs/JPEG_STREAMING_MEMORY_REPORT.md
+++ b/docs/JPEG_STREAMING_MEMORY_REPORT.md
@@ -54,9 +54,19 @@ to get the path-specific requirement before allocating the slice work buffer:
 
 ## Output Buffer Boundary
 
-The measurements above separate JPEG decoder/scaler memory from H.264 output
-buffering. A one-shot JPEG API may still require the maximum complete-frame
-H.264 output capacity:
+The measurements above separate JPEG decoder/scaler memory from compressed JPEG
+input storage and H.264 output buffering. The memory-buffer APIs still accept a
+caller-owned contiguous `jpeg_data/jpeg_size` block. The source-backed APIs
+(`sh264e_jpeg_source_get_work_size`,
+`sh264e_jpeg_source_get_slice_work_size`, and
+`sh264e_encode_jpeg_source_idr_with_arena_stream`) let callers stream the
+compressed JPEG through a sequential read callback instead. NanoJPEG holds only
+a fixed 512-byte compressed-input parser/entropy window in its context; callers
+must reset or recreate the source between the work-size query, slice-work query,
+and encode call because each call consumes the source.
+
+A one-shot JPEG API may still require the maximum complete-frame H.264 output
+capacity:
 
 ```text
 header max = 1,024 bytes
@@ -77,8 +87,8 @@ instead of the 11,428,864-byte one-shot maximum output buffer or the old
 file consumer outside the library; tests also cover tiny chunk boundaries to
 lock emulation-prevention behavior across flushes.
 
-For the `2560x1440` 4:2:0 embedded path, excluding compressed JPEG input and
-`.rodata`, the current budget is:
+For the `2560x1440` 4:2:0 embedded path, excluding compressed JPEG input
+storage and `.rodata`, the current budget is:
 
 | Block | Bytes |
 | --- | ---: |
@@ -86,12 +96,12 @@ For the `2560x1440` 4:2:0 embedded path, excluding compressed JPEG input and
 | JPEG/scaler slice work | 0 for I420, 20,480 for NV12 |
 | Reusable H.264 output chunk buffer | 4,096 |
 | Encoder arena | 191,055 |
-| Static mutable RAM | about 4,529 |
+| Static mutable RAM | about 5,041 |
 | Rounded planning budget | about 330 KiB I420 / 350 KiB NV12 |
 
-The I420 arithmetic subtotal of the rows above is about 322,704 bytes, or about
-315 KiB in binary units. The equivalent NV12 subtotal is about 343,184 bytes,
-or about 335 KiB. The rounded planning budget is now about 330 KiB for I420 and
+The I420 arithmetic subtotal of the rows above is about 323,216 bytes, or about
+316 KiB in binary units. The equivalent NV12 subtotal is about 343,696 bytes,
+or about 336 KiB. The rounded planning budget remains about 330 KiB for I420 and
 about 350 KiB for NV12 on this embedded path.
 
 The encoder arena row is reported by `sh264e_encoder_get_work_size`; see
@@ -102,11 +112,16 @@ reconstructed-slice, neighbor-state breakdown, and arena alignment padding.
 
 `tests/run_ffmpeg_integration.py` asserts the exact production arena work,
 peak-allocation, row-cache, effective slice work, reusable output chunk, encoder
-memory report, path-specific slice work, and one-shot output capacity values for representative JPEG
-fixtures. It also keeps broader
+memory report, path-specific slice work, source-input chunking, and one-shot
+output capacity values for representative JPEG fixtures. It also keeps broader
 color-subsampling coverage that fails if the production arena path regresses to
 full component-plane allocation or if the default JPEG tool path regresses to
 allocating `sh264e_get_max_output_size()` for H.264 output.
+
+The source-input stress cases feed generated JPEGs through chunk limits of 1, 2,
+7, 64, and 1024 bytes. Those cases force marker parsing and entropy decode
+across caller chunk boundaries. When `cjpeg` is available, the restart-marker
+fixture is also encoded through the source API to cover DRI/RST handling.
 
 The normal CTest suite also includes `sh264e_production_profile_symbols` when
 `nm` or `llvm-nm` is available. That check configures the embedded production
@@ -167,6 +182,21 @@ jpeg effective slice work bytes: 0
 jpeg peak allocation bytes: 122880
 jpeg streaming cache bytes: 61440
 jpeg output buffer bytes: 4096
+```
+
+The tool has a hidden integration-test switch for source-backed compressed
+input:
+
+```sh
+build/sh264e_encode_jpeg --test-jpeg-source-chunk-size 7 --format i420 \
+  build/integration/input_720p_yuvj420p.jpg \
+  build/issue52_source_chunk_7.h264
+```
+
+Expected additional metric:
+
+```text
+jpeg source chunk bytes: 7
 ```
 
 The hidden one-shot comparison path remains available for regression tests and

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -95,6 +95,8 @@ Required API entry points:
 * `sh264e_resize_make_slice`
 * `sh264e_jpeg_get_slice_buffer_size`
 * `sh264e_jpeg_get_slice_work_size`
+* `sh264e_jpeg_source_get_slice_work_size`
+* `sh264e_jpeg_source_get_work_size`
 * `sh264e_encode_jpeg_idr`
 * `sh264e_encode_jpeg_idr_with_arena_stream`
 
@@ -110,7 +112,7 @@ Required public API concepts:
 
 The output bitstream buffer is provided by the caller. The library reports bytes written or returns a buffer-too-small error.
 
-Progressive slice mode is the preferred v1 library interface. Frame mode (`sh264e_encode_idr`) remains available as a convenience wrapper around progressive mode. The resize API is part of the core library and produces encoder-sized progressive slices from supported YUV420 source frames. The JPEG API is also part of the core library and decodes memory-input baseline JPEG before resize and IDR encode.
+Progressive slice mode is the preferred v1 library interface. Frame mode (`sh264e_encode_idr`) remains available as a convenience wrapper around progressive mode. The resize API is part of the core library and produces encoder-sized progressive slices from supported YUV420 source frames. The JPEG API is also part of the core library and decodes baseline JPEG from either caller-owned memory or a caller-provided sequential source before resize and IDR encode.
 
 ---
 
@@ -312,7 +314,7 @@ Each scaled output slice is passed directly to `sh264e_encode_idr_slice`.
 The project includes NanoJPEG in the core static library for a direct pipeline:
 
 ```
-JPEG byte buffer
+JPEG byte buffer or sequential source
    ↓
 NanoJPEG MCU-row baseline decode
    ↓
@@ -328,16 +330,45 @@ H.264 IDR slice encode
 ```
 sh264e_jpeg_get_slice_buffer_size
 sh264e_jpeg_get_slice_work_size
+sh264e_jpeg_source_get_slice_work_size
+sh264e_jpeg_get_work_size
+sh264e_jpeg_source_get_work_size
 sh264e_encode_jpeg_idr
 sh264e_encode_jpeg_idr_with_arena
 sh264e_encode_jpeg_idr_with_arena_stream
+sh264e_encode_jpeg_source_idr_with_arena_stream
 sh264e_jpeg_get_last_allocation_stats
 sh264e_jpeg_get_last_streaming_cache_bytes
 sh264e_jpeg_get_last_slice_work_bytes
 sh264e_encoder_get_memory_report
 ```
 
-The JPEG APIs accept a caller-provided JPEG byte buffer. File I/O remains outside the library.
+The JPEG APIs accept either a caller-provided JPEG byte buffer or a sequential
+`sh264e_jpeg_source_t`. File I/O remains outside the library.
+
+The source form is intended for compressed JPEG data stored in flash, storage,
+camera FIFOs, DMA rings, or application-managed chunks. The callback contract is
+pull-only and sequential:
+
+```c
+typedef sh264e_status_t (*sh264e_jpeg_read_fn)(
+    void *user,
+    uint8_t *dst,
+    size_t requested,
+    size_t *out_read);
+```
+
+The callback must write at most `requested` bytes, set `*out_read` to the
+number of bytes copied, and return `SH264E_OK` for successful reads. A successful
+read of `0` bytes means EOF. Returning any other status aborts JPEG decode and
+propagates that status to the caller when possible. Work-size and slice-work
+queries consume the source, so callers must reset or recreate the source before
+each query and before `sh264e_encode_jpeg_source_idr_with_arena_stream`.
+
+NanoJPEG keeps a fixed 512-byte compressed-input window for source-backed
+decode. That window is separate from caller-owned compressed JPEG storage,
+decoded row cache, JPEG arena allocation, slice-work staging, and H.264 output
+buffering.
 
 All public JPEG APIs must decode through MCU-row streaming and must not allocate
 or depend on a full decoded JPEG component frame. `sh264e_encode_jpeg_idr`,
@@ -372,10 +403,11 @@ may implement a consumer that writes to a file.
 JPEG allocations from the last JPEG work-size query or encode call.
 `sh264e_jpeg_get_last_streaming_cache_bytes` reports the decoded row-cache
 capacity retained by the last MCU-row streaming query or encode call.
-`sh264e_jpeg_get_slice_work_size` reports the path-specific caller work-buffer
-capacity for a specific JPEG input and output pixel format. This lets embedded
-callers use zero slice-work bytes for the `2560x1440` 4:2:0 1:1 I420 path and
-20,480 bytes for the equivalent NV12 path, while
+`sh264e_jpeg_get_slice_work_size` and
+`sh264e_jpeg_source_get_slice_work_size` report the path-specific caller
+work-buffer capacity for a specific JPEG input and output pixel format. This
+lets embedded callers use zero slice-work bytes for the `2560x1440` 4:2:0 1:1
+I420 path and 20,480 bytes for the equivalent NV12 path, while
 `sh264e_jpeg_get_slice_buffer_size` remains a conservative worst-case query.
 `sh264e_jpeg_get_last_slice_work_bytes` reports the effective slice staging used
 by the last JPEG encode. These are diagnostic/stat APIs for regression reporting; allocation-limit and
@@ -409,7 +441,7 @@ but no private JPEG test hooks or NanoJPEG full-image decode entry points:
 
 ```sh
 nm -g build-prod/libsimple_h264_enc_i.a | rg "sh264e_jpeg_set_test|streaming_prototype|njDecode([^A-Za-z0-9_]|$)|njDecodeComponents|njGetImage|njGetImageSize|njIsColor" && exit 1 || true
-nm -g build-prod/libsimple_h264_enc_i.a | rg "sh264e_jpeg_get_last_(allocation_stats|streaming_cache_bytes|slice_work_bytes)|sh264e_encoder_get_memory_report"
+nm -g build-prod/libsimple_h264_enc_i.a | rg "sh264e_(jpeg(_source)?_get|encode_jpeg(_source)?).*|sh264e_encoder_get_memory_report"
 ```
 
 The normal CTest suite includes `sh264e_production_profile_symbols` when `nm` or

--- a/include/sh264e.h
+++ b/include/sh264e.h
@@ -78,6 +78,16 @@ typedef sh264e_status_t (*sh264e_output_consumer_t)(void *user,
                                                     const uint8_t *data,
                                                     size_t size);
 
+typedef sh264e_status_t (*sh264e_jpeg_read_fn)(void *user,
+                                               uint8_t *dst,
+                                               size_t requested,
+                                               size_t *out_read);
+
+typedef struct sh264e_jpeg_source_t {
+    sh264e_jpeg_read_fn read;
+    void *user;
+} sh264e_jpeg_source_t;
+
 sh264e_status_t sh264e_encoder_create(const sh264e_config_t *config,
                                       sh264e_encoder_t **out_encoder);
 
@@ -139,9 +149,16 @@ sh264e_status_t sh264e_jpeg_get_slice_work_size(const uint8_t *jpeg_data,
                                                 sh264e_pixfmt_t pixfmt,
                                                 size_t *out_size);
 
+sh264e_status_t sh264e_jpeg_source_get_slice_work_size(const sh264e_jpeg_source_t *source,
+                                                       sh264e_pixfmt_t pixfmt,
+                                                       size_t *out_size);
+
 sh264e_status_t sh264e_jpeg_get_work_size(const uint8_t *jpeg_data,
                                           size_t jpeg_size,
                                           size_t *out_size);
+
+sh264e_status_t sh264e_jpeg_source_get_work_size(const sh264e_jpeg_source_t *source,
+                                                 size_t *out_size);
 
 sh264e_status_t sh264e_jpeg_get_last_allocation_stats(sh264e_jpeg_allocation_stats_t *out_stats);
 
@@ -173,6 +190,18 @@ sh264e_status_t sh264e_encode_jpeg_idr_with_arena_stream(
     sh264e_encoder_t *encoder,
     const uint8_t *jpeg_data,
     size_t jpeg_size,
+    uint8_t *jpeg_arena,
+    size_t jpeg_arena_size,
+    uint8_t *work_buffer,
+    size_t work_buffer_capacity,
+    uint8_t *out_buffer,
+    size_t out_buffer_capacity,
+    sh264e_output_consumer_t consumer,
+    void *consumer_user);
+
+sh264e_status_t sh264e_encode_jpeg_source_idr_with_arena_stream(
+    sh264e_encoder_t *encoder,
+    const sh264e_jpeg_source_t *source,
     uint8_t *jpeg_arena,
     size_t jpeg_arena_size,
     uint8_t *work_buffer,

--- a/src/nanojpeg.c
+++ b/src/nanojpeg.c
@@ -166,6 +166,20 @@ nj_result_t njDecodeComponents(const void* jpeg, const int size);
 typedef int (*nj_mcu_row_callback_t)(int mcu_y, void* user);
 nj_result_t njDecodeMcuRows(const void* jpeg, const int size, nj_mcu_row_callback_t callback, void* user);
 
+typedef int (*nj_input_read_callback_t)(void *user,
+                                        unsigned char *dst,
+                                        int requested,
+                                        int *out_read);
+
+typedef struct _nj_input_source {
+    nj_input_read_callback_t read;
+    void *user;
+} nj_input_source_t;
+
+nj_result_t njDecodeMcuRowsFromSource(const nj_input_source_t *source,
+                                      nj_mcu_row_callback_t callback,
+                                      void* user);
+
 // njGetWidth: Return the width (in pixels) of the most recently decoded
 // image. If njDecode() failed, the result of njGetWidth() is undefined.
 int njGetWidth(void);
@@ -352,6 +366,7 @@ typedef struct _nj_code {
 
 #define NJ_VLC_TABLE_COUNT 4
 #define NJ_VLC_FAST_SIZE (1 << NJ_VLC_FAST_BITS)
+#define NJ_INPUT_BUFFER_SIZE 512
 
 typedef struct _nj_huff {
     unsigned char symbols[256];
@@ -376,6 +391,10 @@ typedef struct _nj_ctx {
     nj_result_t error;
     const unsigned char *pos;
     int size;
+    unsigned char input_buffer[NJ_INPUT_BUFFER_SIZE];
+    nj_input_read_callback_t input_read;
+    void *input_user;
+    int input_eof;
     int length;
     int width, height;
     int mbwidth, mbheight;
@@ -520,28 +539,106 @@ NJ_INLINE void njResetHuffTable(nj_huff_table_t *tab) {
         tab->maxcode[i] = -1;
 }
 
+static int njFillInput(int needed) {
+    if (needed < 0 || needed > NJ_INPUT_BUFFER_SIZE) {
+        nj.error = NJ_INTERNAL_ERR;
+        return 0;
+    }
+    if (!nj.input_read) {
+        return nj.size >= needed;
+    }
+    if (nj.size > 0 && nj.pos != nj.input_buffer) {
+        njCopyMem(nj.input_buffer, nj.pos, nj.size);
+    }
+    nj.pos = nj.input_buffer;
+    while (nj.size < needed && !nj.input_eof && !nj.error) {
+        int read_bytes = 0;
+        const int capacity = NJ_INPUT_BUFFER_SIZE - nj.size;
+        if (capacity <= 0) {
+            nj.error = NJ_INTERNAL_ERR;
+            return 0;
+        }
+        if (nj.input_read(nj.input_user,
+                          &nj.input_buffer[nj.size],
+                          capacity,
+                          &read_bytes) != 0) {
+            nj.error = NJ_SYNTAX_ERROR;
+            return 0;
+        }
+        if (read_bytes < 0 || read_bytes > capacity) {
+            nj.error = NJ_SYNTAX_ERROR;
+            return 0;
+        }
+        if (read_bytes == 0) {
+            nj.input_eof = 1;
+            break;
+        }
+        nj.size += read_bytes;
+    }
+    return nj.size >= needed;
+}
+
+NJ_INLINE int njEnsure(int count) {
+    return njFillInput(count);
+}
+
+NJ_INLINE unsigned char njPeek(int offset) {
+    if (!njEnsure(offset + 1)) {
+        nj.error = NJ_SYNTAX_ERROR;
+        return 0;
+    }
+    return nj.pos[offset];
+}
+
+NJ_INLINE unsigned short njPeek16(int offset) {
+    unsigned int high;
+    unsigned int low;
+    if (!njEnsure(offset + 2)) {
+        nj.error = NJ_SYNTAX_ERROR;
+        return 0;
+    }
+    high = nj.pos[offset];
+    low = nj.pos[offset + 1];
+    return (unsigned short)((high << 8) | low);
+}
+
+static unsigned char njReadByte(void) {
+    unsigned char value;
+    if (!njEnsure(1)) {
+        nj.error = NJ_SYNTAX_ERROR;
+        return 0;
+    }
+    value = *nj.pos++;
+    nj.size--;
+    return value;
+}
+
 static int njShowBits(int bits) {
     unsigned char newbyte;
     if (!bits) return 0;
     while (nj.bufbits < bits) {
-        if (nj.size <= 0) {
+        if (!njEnsure(1)) {
+            if (nj.error) return 0;
             nj.buf = (nj.buf << 8) | 0xFF;
             nj.bufbits += 8;
             continue;
         }
-        newbyte = *nj.pos++;
-        nj.size--;
+        newbyte = njReadByte();
+        if (nj.error) return 0;
         nj.bufbits += 8;
         nj.buf = (nj.buf << 8) | newbyte;
         if (newbyte == 0xFF) {
-            if (nj.size) {
-                unsigned char marker = *nj.pos++;
-                nj.size--;
+            if (njEnsure(1)) {
+                unsigned char marker = njReadByte();
+                if (nj.error) return 0;
                 switch (marker) {
                     case 0x00:
                     case 0xFF:
                         break;
-                    case 0xD9: nj.size = 0; break;
+                    case 0xD9:
+                        nj.size = 0;
+                        nj.input_eof = 1;
+                        break;
                     default:
                         if ((marker & 0xF8) != 0xD0)
                             nj.error = NJ_SYNTAX_ERROR;
@@ -550,8 +647,9 @@ static int njShowBits(int bits) {
                             nj.bufbits += 8;
                         }
                 }
-            } else
+            } else {
                 nj.error = NJ_SYNTAX_ERROR;
+            }
         }
     }
     return (nj.buf >> (nj.bufbits - bits)) & ((1 << bits) - 1);
@@ -574,10 +672,22 @@ NJ_INLINE void njByteAlign(void) {
 }
 
 static void njSkip(int count) {
-    nj.pos += count;
-    nj.size -= count;
-    nj.length -= count;
-    if (nj.size < 0) nj.error = NJ_SYNTAX_ERROR;
+    if (count < 0) {
+        nj.error = NJ_SYNTAX_ERROR;
+        return;
+    }
+    while (count > 0 && !nj.error) {
+        int chunk;
+        if (!njEnsure(1)) {
+            nj.error = NJ_SYNTAX_ERROR;
+            return;
+        }
+        chunk = (count < nj.size) ? count : nj.size;
+        nj.pos += chunk;
+        nj.size -= chunk;
+        nj.length -= chunk;
+        count -= chunk;
+    }
 }
 
 NJ_INLINE unsigned short njDecode16(const unsigned char *pos) {
@@ -585,9 +695,9 @@ NJ_INLINE unsigned short njDecode16(const unsigned char *pos) {
 }
 
 static void njDecodeLength(void) {
-    if (nj.size < 2) njThrow(NJ_SYNTAX_ERROR);
+    if (!njEnsure(2)) njThrow(NJ_SYNTAX_ERROR);
     nj.length = njDecode16(nj.pos);
-    if (nj.length > nj.size) njThrow(NJ_SYNTAX_ERROR);
+    if (nj.length < 2) njThrow(NJ_SYNTAX_ERROR);
     njSkip(2);
 }
 
@@ -602,11 +712,12 @@ NJ_INLINE void njDecodeSOF(void) {
     njDecodeLength();
     njCheckError();
     if (nj.length < 9) njThrow(NJ_SYNTAX_ERROR);
-    if (nj.pos[0] != 8) njThrow(NJ_UNSUPPORTED);
-    nj.height = njDecode16(nj.pos+1);
-    nj.width = njDecode16(nj.pos+3);
+    if (!njEnsure(6)) njThrow(NJ_SYNTAX_ERROR);
+    if (njPeek(0) != 8) njThrow(NJ_UNSUPPORTED);
+    nj.height = njPeek16(1);
+    nj.width = njPeek16(3);
     if (!nj.width || !nj.height) njThrow(NJ_SYNTAX_ERROR);
-    nj.ncomp = nj.pos[5];
+    nj.ncomp = njPeek(5);
     njSkip(6);
     switch (nj.ncomp) {
         case 1:
@@ -617,12 +728,13 @@ NJ_INLINE void njDecodeSOF(void) {
     }
     if (nj.length < (nj.ncomp * 3)) njThrow(NJ_SYNTAX_ERROR);
     for (i = 0, c = nj.comp;  i < nj.ncomp;  ++i, ++c) {
-        c->cid = nj.pos[0];
-        if (!(c->ssx = nj.pos[1] >> 4)) njThrow(NJ_SYNTAX_ERROR);
+        if (!njEnsure(3)) njThrow(NJ_SYNTAX_ERROR);
+        c->cid = njPeek(0);
+        if (!(c->ssx = njPeek(1) >> 4)) njThrow(NJ_SYNTAX_ERROR);
         if (c->ssx & (c->ssx - 1)) njThrow(NJ_UNSUPPORTED);  // non-power of two
-        if (!(c->ssy = nj.pos[1] & 15)) njThrow(NJ_SYNTAX_ERROR);
+        if (!(c->ssy = njPeek(1) & 15)) njThrow(NJ_SYNTAX_ERROR);
         if (c->ssy & (c->ssy - 1)) njThrow(NJ_UNSUPPORTED);  // non-power of two
-        if ((c->qtsel = nj.pos[2]) & 0xFC) njThrow(NJ_SYNTAX_ERROR);
+        if ((c->qtsel = njPeek(2)) & 0xFC) njThrow(NJ_SYNTAX_ERROR);
         njSkip(3);
         nj.qtused |= 1 << c->qtsel;
         if (c->ssx > ssxmax) ssxmax = c->ssx;
@@ -659,12 +771,13 @@ NJ_INLINE void njDecodeDHT(void) {
     njDecodeLength();
     njCheckError();
     while (nj.length >= 17) {
-        table = nj.pos[0];
+        if (!njEnsure(17)) njThrow(NJ_SYNTAX_ERROR);
+        table = njPeek(0);
         if (table & 0xEC) njThrow(NJ_SYNTAX_ERROR);
         if (table & 0x02) njThrow(NJ_UNSUPPORTED);
         table = (table | (table >> 3)) & 3;  // combined DC/AC + tableid value
         for (codelen = 1;  codelen <= 16;  ++codelen)
-            counts[codelen - 1] = nj.pos[codelen];
+            counts[codelen - 1] = njPeek(codelen);
         njSkip(17);
         huff = &nj.vlctab[table];
         njResetHuffTable(huff);
@@ -680,12 +793,13 @@ NJ_INLINE void njDecodeDHT(void) {
                 continue;
             }
             if (nj.length < currcnt) njThrow(NJ_SYNTAX_ERROR);
+            if (!njEnsure(currcnt)) njThrow(NJ_SYNTAX_ERROR);
             if (symbol_index > 256 - currcnt) njThrow(NJ_SYNTAX_ERROR);
             huff->mincode[codelen] = code;
             huff->maxcode[codelen] = code + currcnt - 1;
             huff->first_symbol[codelen] = (unsigned short)symbol_index;
             for (i = 0;  i < currcnt;  ++i) {
-                register unsigned char symbol = nj.pos[i];
+                register unsigned char symbol = njPeek(i);
                 const int huff_code = huff->mincode[codelen] + i;
                 huff->symbols[symbol_index + i] = symbol;
                 if (codelen <= NJ_VLC_FAST_BITS) {
@@ -712,12 +826,13 @@ NJ_INLINE void njDecodeDQT(void) {
     njDecodeLength();
     njCheckError();
     while (nj.length >= 65) {
-        i = nj.pos[0];
+        if (!njEnsure(65)) njThrow(NJ_SYNTAX_ERROR);
+        i = njPeek(0);
         if (i & 0xFC) njThrow(NJ_SYNTAX_ERROR);
         nj.qtavail |= 1 << i;
         t = &nj.qtab[i][0];
         for (i = 0;  i < 64;  ++i)
-            t[i] = nj.pos[i + 1];
+            t[i] = njPeek(i + 1);
         njSkip(65);
     }
     if (nj.length) njThrow(NJ_SYNTAX_ERROR);
@@ -727,7 +842,7 @@ NJ_INLINE void njDecodeDRI(void) {
     njDecodeLength();
     njCheckError();
     if (nj.length < 2) njThrow(NJ_SYNTAX_ERROR);
-    nj.rstinterval = njDecode16(nj.pos);
+    nj.rstinterval = njPeek16(0);
     njSkip(nj.length);
 }
 
@@ -793,18 +908,21 @@ NJ_INLINE void njDecodeScan(void) {
     njDecodeLength();
     njCheckError();
     if (nj.length < (4 + 2 * nj.ncomp)) njThrow(NJ_SYNTAX_ERROR);
-    if (nj.pos[0] != nj.ncomp) njThrow(NJ_UNSUPPORTED);
+    if (!njEnsure(1)) njThrow(NJ_SYNTAX_ERROR);
+    if (njPeek(0) != nj.ncomp) njThrow(NJ_UNSUPPORTED);
     njSkip(1);
     for (i = 0, c = nj.comp;  i < nj.ncomp;  ++i, ++c) {
-        if (nj.pos[0] != c->cid) njThrow(NJ_SYNTAX_ERROR);
-        if (nj.pos[1] & 0xEE) njThrow(NJ_SYNTAX_ERROR);
-        c->dctabsel = nj.pos[1] >> 4;
-        c->actabsel = (nj.pos[1] & 1) | 2;
+        if (!njEnsure(2)) njThrow(NJ_SYNTAX_ERROR);
+        if (njPeek(0) != c->cid) njThrow(NJ_SYNTAX_ERROR);
+        if (njPeek(1) & 0xEE) njThrow(NJ_SYNTAX_ERROR);
+        c->dctabsel = njPeek(1) >> 4;
+        c->actabsel = (njPeek(1) & 1) | 2;
         if (!(nj.vlctab_avail & (1u << c->dctabsel))) njThrow(NJ_SYNTAX_ERROR);
         if (!(nj.vlctab_avail & (1u << c->actabsel))) njThrow(NJ_SYNTAX_ERROR);
         njSkip(2);
     }
-    if (nj.pos[0] || (nj.pos[1] != 63) || nj.pos[2]) njThrow(NJ_UNSUPPORTED);
+    if (!njEnsure(3)) njThrow(NJ_SYNTAX_ERROR);
+    if (njPeek(0) || (njPeek(1) != 63) || njPeek(2)) njThrow(NJ_UNSUPPORTED);
     njSkip(nj.length);
     for (mbx = mby = 0;;) {
         for (i = 0, c = nj.comp;  i < nj.ncomp;  ++i, ++c)
@@ -1001,6 +1119,7 @@ void njDone(void) {
 
 static nj_result_t njDecodeInternal(const void* jpeg,
                                     const int size,
+                                    const nj_input_source_t *source,
                                     int components_only,
                                     int mcu_rows_only,
                                     nj_mcu_row_callback_t callback,
@@ -1010,15 +1129,25 @@ static nj_result_t njDecodeInternal(const void* jpeg,
     nj.decode_mcu_rows_only = mcu_rows_only;
     nj.mcu_row_callback = callback;
     nj.mcu_row_user = user;
-    nj.pos = (const unsigned char*) jpeg;
-    nj.size = size & 0x7FFFFFFF;
-    if (nj.size < 2) return NJ_NO_JPEG;
-    if ((nj.pos[0] ^ 0xFF) | (nj.pos[1] ^ 0xD8)) return NJ_NO_JPEG;
+    if (source) {
+        if (!source->read) return NJ_INTERNAL_ERR;
+        nj.input_read = source->read;
+        nj.input_user = source->user;
+        nj.pos = nj.input_buffer;
+        nj.size = 0;
+    } else {
+        nj.pos = (const unsigned char*) jpeg;
+        nj.size = size & 0x7FFFFFFF;
+    }
+    if (!njEnsure(2)) return NJ_NO_JPEG;
+    if ((njPeek(0) ^ 0xFF) | (njPeek(1) ^ 0xD8)) return NJ_NO_JPEG;
     njSkip(2);
     while (!nj.error) {
-        if ((nj.size < 2) || (nj.pos[0] != 0xFF)) return NJ_SYNTAX_ERROR;
+        unsigned char marker;
+        if (!njEnsure(2) || (njPeek(0) != 0xFF)) return NJ_SYNTAX_ERROR;
         njSkip(2);
-        switch (nj.pos[-1]) {
+        marker = nj.pos[-1];
+        switch (marker) {
             case 0xC0: njDecodeSOF();  break;
             case 0xC4: njDecodeDHT();  break;
             case 0xDB: njDecodeDQT();  break;
@@ -1026,7 +1155,7 @@ static nj_result_t njDecodeInternal(const void* jpeg,
             case 0xDA: njDecodeScan(); break;
             case 0xFE: njSkipMarker(); break;
             default:
-                if ((nj.pos[-1] & 0xF0) == 0xE0)
+                if ((marker & 0xF0) == 0xE0)
                     njSkipMarker();
                 else
                     return NJ_UNSUPPORTED;
@@ -1047,18 +1176,25 @@ static nj_result_t njDecodeInternal(const void* jpeg,
 #if NJ_ENABLE_FULL_IMAGE_DECODE
 
 nj_result_t njDecode(const void* jpeg, const int size) {
-    return njDecodeInternal(jpeg, size, 0, 0, NULL, NULL);
+    return njDecodeInternal(jpeg, size, NULL, 0, 0, NULL, NULL);
 }
 
 nj_result_t njDecodeComponents(const void* jpeg, const int size) {
-    return njDecodeInternal(jpeg, size, 1, 0, NULL, NULL);
+    return njDecodeInternal(jpeg, size, NULL, 1, 0, NULL, NULL);
 }
 
 #endif
 
 nj_result_t njDecodeMcuRows(const void* jpeg, const int size, nj_mcu_row_callback_t callback, void* user) {
     if (!callback) return NJ_INTERNAL_ERR;
-    return njDecodeInternal(jpeg, size, 1, 1, callback, user);
+    return njDecodeInternal(jpeg, size, NULL, 1, 1, callback, user);
+}
+
+nj_result_t njDecodeMcuRowsFromSource(const nj_input_source_t *source,
+                                      nj_mcu_row_callback_t callback,
+                                      void* user) {
+    if (!source || !callback) return NJ_INTERNAL_ERR;
+    return njDecodeInternal(NULL, 0, source, 1, 1, callback, user);
 }
 
 int njGetWidth(void)            { return nj.width; }

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -123,9 +123,20 @@ typedef struct sh264e_jpeg_alloc_header_t {
 } sh264e_jpeg_alloc_header_t;
 
 typedef int (*nj_mcu_row_callback_t)(int mcu_y, void *user);
+typedef int (*nj_input_read_callback_t)(void *user,
+                                        unsigned char *dst,
+                                        int requested,
+                                        int *out_read);
+typedef struct nj_input_source_t {
+    nj_input_read_callback_t read;
+    void *user;
+} nj_input_source_t;
 
 void njInit(void);
 int njDecodeMcuRows(const void *jpeg, const int size, nj_mcu_row_callback_t callback, void *user);
+int njDecodeMcuRowsFromSource(const nj_input_source_t *source,
+                              nj_mcu_row_callback_t callback,
+                              void *user);
 int njGetWidth(void);
 int njGetHeight(void);
 int njGetComponentCount(void);
@@ -166,6 +177,7 @@ static sh264e_status_t sh264e_encode_idr_slice_to_consumer(sh264e_encoder_t *enc
 static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *encoder,
                                                              const uint8_t *jpeg_data,
                                                              size_t jpeg_size,
+                                                             const sh264e_jpeg_source_t *jpeg_source,
                                                              uint8_t *jpeg_arena,
                                                              size_t jpeg_arena_size,
                                                              int use_arena,
@@ -2315,8 +2327,90 @@ sh264e_status_t sh264e_jpeg_get_last_allocation_stats(sh264e_jpeg_allocation_sta
     return SH264E_OK;
 }
 
+typedef struct sh264e_nj_source_adapter_t {
+    const sh264e_jpeg_source_t *source;
+    sh264e_status_t status;
+} sh264e_nj_source_adapter_t;
+
+static int sh264e_nj_source_read(void *user,
+                                 unsigned char *dst,
+                                 int requested,
+                                 int *out_read)
+{
+    sh264e_nj_source_adapter_t *adapter = (sh264e_nj_source_adapter_t *)user;
+    sh264e_jpeg_read_fn source_reader;
+    size_t read_bytes = 0u;
+    sh264e_status_t status;
+
+    if (adapter == NULL || adapter->source == NULL || adapter->source->read == NULL ||
+        dst == NULL || requested <= 0 || out_read == NULL) {
+        if (adapter != NULL) {
+            adapter->status = SH264E_ERR_INVALID_ARGUMENT;
+        }
+        return -1;
+    }
+
+    source_reader = adapter->source->read;
+    status = source_reader(adapter->source->user,
+                           dst,
+                           (size_t)requested,
+                           &read_bytes);
+    if (status != SH264E_OK) {
+        adapter->status = status;
+        return -1;
+    }
+    if (read_bytes > (size_t)requested) {
+        adapter->status = SH264E_ERR_INVALID_ARGUMENT;
+        return -1;
+    }
+    *out_read = (int)read_bytes;
+    return 0;
+}
+
+static sh264e_status_t decode_mcu_rows_from_input(const uint8_t *jpeg_data,
+                                                  size_t jpeg_size,
+                                                  const sh264e_jpeg_source_t *jpeg_source,
+                                                  nj_mcu_row_callback_t callback,
+                                                  void *user,
+                                                  sh264e_status_t *source_status)
+{
+    if (source_status != NULL) {
+        *source_status = SH264E_OK;
+    }
+    if (jpeg_source != NULL) {
+        sh264e_nj_source_adapter_t adapter;
+        nj_input_source_t nj_source;
+
+        if (jpeg_source->read == NULL) {
+            return SH264E_ERR_INVALID_ARGUMENT;
+        }
+        adapter.source = jpeg_source;
+        adapter.status = SH264E_OK;
+        nj_source.read = sh264e_nj_source_read;
+        nj_source.user = &adapter;
+        {
+            sh264e_status_t status = map_jpeg_result(
+                njDecodeMcuRowsFromSource(&nj_source, callback, user));
+            if (adapter.status != SH264E_OK) {
+                status = adapter.status;
+            }
+            if (source_status != NULL) {
+                *source_status = adapter.status;
+            }
+            return status;
+        }
+    }
+
+    if (jpeg_data == NULL || jpeg_size == 0u || jpeg_size > (size_t)INT_MAX) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+    return map_jpeg_result(njDecodeMcuRows(jpeg_data, (int)jpeg_size,
+                                           callback, user));
+}
+
 static sh264e_status_t jpeg_measure_streaming_requirements(const uint8_t *jpeg_data,
                                                            size_t jpeg_size,
+                                                           const sh264e_jpeg_source_t *jpeg_source,
                                                            sh264e_pixfmt_t pixfmt,
                                                            size_t *out_arena_size,
                                                            size_t *out_slice_work_size)
@@ -2324,7 +2418,8 @@ static sh264e_status_t jpeg_measure_streaming_requirements(const uint8_t *jpeg_d
     sh264e_jpeg_stream_context_t ctx;
     sh264e_status_t status;
 
-    if (jpeg_data == NULL || (out_arena_size == NULL && out_slice_work_size == NULL)) {
+    if ((jpeg_data == NULL && jpeg_source == NULL) ||
+        (out_arena_size == NULL && out_slice_work_size == NULL)) {
         return SH264E_ERR_INVALID_ARGUMENT;
     }
     if (!is_supported_pixfmt(pixfmt)) {
@@ -2338,7 +2433,7 @@ static sh264e_status_t jpeg_measure_streaming_requirements(const uint8_t *jpeg_d
     }
     sh264e_jpeg_streaming_last_cache_bytes = 0u;
     sh264e_jpeg_streaming_last_slice_work_bytes = 0u;
-    if (jpeg_size == 0u || jpeg_size > (size_t)INT_MAX) {
+    if (jpeg_source == NULL && (jpeg_size == 0u || jpeg_size > (size_t)INT_MAX)) {
         return SH264E_ERR_INVALID_ARGUMENT;
     }
 
@@ -2349,8 +2444,8 @@ static sh264e_status_t jpeg_measure_streaming_requirements(const uint8_t *jpeg_d
 
     jpeg_allocation_begin_heap();
     njInit();
-    status = map_jpeg_result(njDecodeMcuRows(jpeg_data, (int)jpeg_size,
-                                             streaming_mcu_row_ready, &ctx));
+    status = decode_mcu_rows_from_input(jpeg_data, jpeg_size, jpeg_source,
+                                        streaming_mcu_row_ready, &ctx, NULL);
     if (ctx.status != SH264E_OK) {
         status = ctx.status;
     }
@@ -2375,6 +2470,7 @@ static sh264e_status_t jpeg_get_streaming_work_size(const uint8_t *jpeg_data,
                                                     size_t *out_size)
 {
     return jpeg_measure_streaming_requirements(jpeg_data, jpeg_size,
+                                               NULL,
                                                SH264E_PIXFMT_I420,
                                                out_size, NULL);
 }
@@ -2392,6 +2488,26 @@ sh264e_status_t sh264e_jpeg_get_slice_work_size(const uint8_t *jpeg_data,
                                                 size_t *out_size)
 {
     return jpeg_measure_streaming_requirements(jpeg_data, jpeg_size,
+                                               NULL,
+                                               pixfmt,
+                                               NULL, out_size);
+}
+
+sh264e_status_t sh264e_jpeg_source_get_work_size(const sh264e_jpeg_source_t *source,
+                                                 size_t *out_size)
+{
+    return jpeg_measure_streaming_requirements(NULL, 0u,
+                                               source,
+                                               SH264E_PIXFMT_I420,
+                                               out_size, NULL);
+}
+
+sh264e_status_t sh264e_jpeg_source_get_slice_work_size(const sh264e_jpeg_source_t *source,
+                                                       sh264e_pixfmt_t pixfmt,
+                                                       size_t *out_size)
+{
+    return jpeg_measure_streaming_requirements(NULL, 0u,
+                                               source,
                                                pixfmt,
                                                NULL, out_size);
 }
@@ -2415,6 +2531,7 @@ sh264e_status_t sh264e_encode_jpeg_idr(sh264e_encoder_t *encoder,
                                        size_t *out_size)
 {
     return sh264e_encode_jpeg_idr_streaming_impl(encoder, jpeg_data, jpeg_size,
+                                                 NULL,
                                                  NULL, 0u, 0,
                                                  work_buffer, work_buffer_capacity,
                                                  out, out_capacity, out_size,
@@ -2433,6 +2550,7 @@ sh264e_status_t sh264e_encode_jpeg_idr_with_arena(sh264e_encoder_t *encoder,
                                                   size_t *out_size)
 {
     return sh264e_encode_jpeg_idr_streaming_impl(encoder, jpeg_data, jpeg_size,
+                                                 NULL,
                                                  jpeg_arena, jpeg_arena_size, 1,
                                                  work_buffer, work_buffer_capacity,
                                                  out, out_capacity, out_size,
@@ -2458,6 +2576,33 @@ sh264e_status_t sh264e_encode_jpeg_idr_with_arena_stream(
         return SH264E_ERR_INVALID_ARGUMENT;
     }
     return sh264e_encode_jpeg_idr_streaming_impl(encoder, jpeg_data, jpeg_size,
+                                                 NULL,
+                                                 jpeg_arena, jpeg_arena_size, 1,
+                                                 work_buffer, work_buffer_capacity,
+                                                 out_buffer, out_buffer_capacity,
+                                                 &ignored_size,
+                                                 consumer, consumer_user);
+}
+
+sh264e_status_t sh264e_encode_jpeg_source_idr_with_arena_stream(
+    sh264e_encoder_t *encoder,
+    const sh264e_jpeg_source_t *source,
+    uint8_t *jpeg_arena,
+    size_t jpeg_arena_size,
+    uint8_t *work_buffer,
+    size_t work_buffer_capacity,
+    uint8_t *out_buffer,
+    size_t out_buffer_capacity,
+    sh264e_output_consumer_t consumer,
+    void *consumer_user)
+{
+    size_t ignored_size = 0u;
+
+    if (consumer == NULL) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+    return sh264e_encode_jpeg_idr_streaming_impl(encoder, NULL, 0u,
+                                                 source,
                                                  jpeg_arena, jpeg_arena_size, 1,
                                                  work_buffer, work_buffer_capacity,
                                                  out_buffer, out_buffer_capacity,
@@ -2478,6 +2623,7 @@ size_t sh264e_jpeg_get_last_slice_work_bytes(void)
 static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *encoder,
                                                              const uint8_t *jpeg_data,
                                                              size_t jpeg_size,
+                                                             const sh264e_jpeg_source_t *jpeg_source,
                                                              uint8_t *jpeg_arena,
                                                              size_t jpeg_arena_size,
                                                              int use_arena,
@@ -2492,7 +2638,8 @@ static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *e
     sh264e_jpeg_stream_context_t ctx;
     sh264e_status_t status;
 
-    if (encoder == NULL || jpeg_data == NULL || out == NULL || out_size == NULL) {
+    if (encoder == NULL || (jpeg_data == NULL && jpeg_source == NULL) ||
+        out == NULL || out_size == NULL) {
         return SH264E_ERR_INVALID_ARGUMENT;
     }
     *out_size = 0u;
@@ -2501,7 +2648,7 @@ static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *e
     if (encoder_idr_active(encoder)) {
         return SH264E_ERR_BAD_STATE;
     }
-    if (jpeg_size == 0u || jpeg_size > (size_t)INT_MAX) {
+    if (jpeg_source == NULL && (jpeg_size == 0u || jpeg_size > (size_t)INT_MAX)) {
         return SH264E_ERR_INVALID_ARGUMENT;
     }
     if (use_arena != 0 && (jpeg_arena == NULL || jpeg_arena_size == 0u)) {
@@ -2524,8 +2671,8 @@ static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *e
         jpeg_allocation_begin_heap();
     }
     njInit();
-    status = map_jpeg_result(njDecodeMcuRows(jpeg_data, (int)jpeg_size,
-                                             streaming_mcu_row_ready, &ctx));
+    status = decode_mcu_rows_from_input(jpeg_data, jpeg_size, jpeg_source,
+                                        streaming_mcu_row_ready, &ctx, NULL);
     if (ctx.status != SH264E_OK) {
         status = ctx.status;
     }
@@ -2563,6 +2710,7 @@ sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype(sh264e_encoder_t *enc
                                                            size_t *out_size)
 {
     return sh264e_encode_jpeg_idr_streaming_impl(encoder, jpeg_data, jpeg_size,
+                                                 NULL,
                                                  NULL, 0u, 0,
                                                  work_buffer, work_buffer_capacity,
                                                  out, out_capacity, out_size,
@@ -2581,6 +2729,7 @@ sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype_with_arena(sh264e_enc
                                                                       size_t *out_size)
 {
     return sh264e_encode_jpeg_idr_streaming_impl(encoder, jpeg_data, jpeg_size,
+                                                 NULL,
                                                  jpeg_arena, jpeg_arena_size, 1,
                                                  work_buffer, work_buffer_capacity,
                                                  out, out_capacity, out_size,

--- a/tests/check_production_profile_symbols.cmake
+++ b/tests/check_production_profile_symbols.cmake
@@ -86,6 +86,9 @@ endif()
 
 foreach(required_symbol
         sh264e_encode_jpeg_idr_with_arena_stream
+        sh264e_encode_jpeg_source_idr_with_arena_stream
+        sh264e_jpeg_source_get_work_size
+        sh264e_jpeg_source_get_slice_work_size
         sh264e_jpeg_get_last_allocation_stats
         sh264e_jpeg_get_last_streaming_cache_bytes
         sh264e_jpeg_get_last_slice_work_bytes

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -41,6 +41,7 @@ H264_OUTPUT_CONSUMER_CHUNKS_MIN = 1 + 90
 H264_OUTPUT_CHUNK_BYTES = 4_096
 H264_TINY_OUTPUT_CHUNK_BYTES = 7
 H264_ONE_SHOT_OUTPUT_BYTES = 11_428_864
+JPEG_SOURCE_CHUNK_SIZES = (1, 2, 7, 64, 1024)
 ENCODER_CONTEXT_BYTES = 72
 ENCODER_BITSTREAM_SCRATCH_BYTES = 126_976
 ENCODER_RECON_LUMA_BYTES = 40_960
@@ -425,6 +426,32 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
             raise RuntimeError(
                 f"JPEG one-shot H.264 output capacity changed: got {output_buffer}, expected {H264_ONE_SHOT_OUTPUT_BYTES}"
             )
+    return result.stdout
+
+
+def encode_jpeg_source_chunks(args, fmt, jpeg_input, bitstream, chunk_size,
+                              expected_cache_bytes=None,
+                              expected_work_bytes=None,
+                              expected_peak_bytes=None,
+                              expected_slice_work_bytes=None,
+                              expected_effective_slice_work_bytes=None):
+    stdout = encode_jpeg(
+        args,
+        fmt,
+        jpeg_input,
+        bitstream,
+        ["--test-jpeg-source-chunk-size", str(chunk_size)],
+        expected_cache_bytes=expected_cache_bytes,
+        expected_work_bytes=expected_work_bytes,
+        expected_peak_bytes=expected_peak_bytes,
+        expected_slice_work_bytes=expected_slice_work_bytes,
+        expected_effective_slice_work_bytes=expected_effective_slice_work_bytes,
+    )
+    reported_chunk_size = parse_jpeg_metric(stdout, "jpeg source chunk bytes:")
+    if reported_chunk_size != chunk_size:
+        raise RuntimeError(
+            f"JPEG source chunk size changed: got {reported_chunk_size}, expected {chunk_size}"
+        )
 
 
 def encode_jpeg_streaming_prototype(args, fmt, jpeg_input, bitstream,
@@ -647,6 +674,25 @@ def main():
                 validate_bitstream(args.ffprobe, args.ffmpeg, tiny_consumer_output)
                 if tiny_consumer_output.read_bytes() != one_shot_output.read_bytes():
                     raise RuntimeError("JPEG tiny-chunk consumer bitstream differs from one-shot output")
+                for source_chunk_size in JPEG_SOURCE_CHUNK_SIZES:
+                    source_output = workdir / (
+                        f"output_jpeg_source_chunk_{source_chunk_size}_yuvj420p_i420.h264"
+                    )
+                    encode_jpeg_source_chunks(
+                        args,
+                        fmt,
+                        jpeg_input,
+                        source_output,
+                        source_chunk_size,
+                        STREAMING_CACHE_BYTES_720P[pix_fmt],
+                        PRODUCTION_MEMORY_720P_420["work"],
+                        PRODUCTION_MEMORY_720P_420["peak"],
+                    )
+                    validate_bitstream(args.ffprobe, args.ffmpeg, source_output)
+                    if source_output.read_bytes() != one_shot_output.read_bytes():
+                        raise RuntimeError(
+                            f"JPEG source chunk {source_chunk_size} bitstream differs from one-shot output"
+                        )
                 run_expect_fail([
                     args.jpeg_encoder,
                     "--test-output-consumer-fail-after",
@@ -720,6 +766,18 @@ def main():
         validate_bitstream(args.ffprobe, args.ffmpeg, restart_jpeg_output)
         compare_decoded_i420(args, restart_jpeg_output, restart_streaming_output,
                              "output_jpeg_yuvj420p_restart_i420_streaming_compare")
+        restart_source_output = workdir / "output_jpeg_source_chunk_7_yuvj420p_restart_i420.h264"
+        encode_jpeg_source_chunks(
+            args,
+            "i420",
+            restart_jpeg_input,
+            restart_source_output,
+            7,
+            STREAMING_CACHE_BYTES_720P["yuvj420p"],
+        )
+        validate_bitstream(args.ffprobe, args.ffmpeg, restart_source_output)
+        if restart_source_output.read_bytes() != restart_jpeg_output.read_bytes():
+            raise RuntimeError("JPEG source restart-marker bitstream differs from memory input")
 
     grayscale_jpeg_input = workdir / "input_gray_720p.jpg"
     run([

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -169,6 +169,7 @@ int main(void)
     sh264e_encoder_t *arena_encoder = NULL;
     sh264e_jpeg_allocation_stats_t jpeg_alloc_stats;
     sh264e_encoder_memory_report_t encoder_memory_report;
+    sh264e_jpeg_source_t bad_jpeg_source;
     int ok = 1;
 
     memset(&config, 0, sizeof(config));
@@ -285,6 +286,26 @@ int main(void)
                         sh264e_jpeg_get_slice_work_size((const uint8_t *)"x", 1u,
                                                         (sh264e_pixfmt_t)99, &jpeg_work_size),
                         SH264E_ERR_UNSUPPORTED_CONFIG);
+    memset(&bad_jpeg_source, 0, sizeof(bad_jpeg_source));
+    ok &= expect_status("null JPEG source work-size input",
+                        sh264e_jpeg_source_get_work_size(NULL, &jpeg_work_size),
+                        SH264E_ERR_INVALID_ARGUMENT);
+    ok &= expect_status("null JPEG source work-size reader",
+                        sh264e_jpeg_source_get_work_size(&bad_jpeg_source, &jpeg_work_size),
+                        SH264E_ERR_INVALID_ARGUMENT);
+    ok &= expect_status("null JPEG source work-size output",
+                        sh264e_jpeg_source_get_work_size(&bad_jpeg_source, NULL),
+                        SH264E_ERR_INVALID_ARGUMENT);
+    ok &= expect_status("null JPEG source slice-work input",
+                        sh264e_jpeg_source_get_slice_work_size(NULL,
+                                                               SH264E_PIXFMT_I420,
+                                                               &jpeg_work_size),
+                        SH264E_ERR_INVALID_ARGUMENT);
+    ok &= expect_status("unsupported JPEG source slice-work format",
+                        sh264e_jpeg_source_get_slice_work_size(&bad_jpeg_source,
+                                                               (sh264e_pixfmt_t)99,
+                                                               &jpeg_work_size),
+                        SH264E_ERR_UNSUPPORTED_CONFIG);
     ok &= expect_status("null JPEG arena encode",
                         sh264e_encode_jpeg_idr_with_arena(NULL, NULL, 0u, NULL, 0u,
                                                           NULL, 0u, NULL, 0u, NULL),
@@ -292,6 +313,13 @@ int main(void)
     ok &= expect_status("null JPEG stream consumer",
                         sh264e_encode_jpeg_idr_with_arena_stream(NULL, NULL, 0u, NULL, 0u,
                                                                  NULL, 0u, NULL, 0u, NULL, NULL),
+                        SH264E_ERR_INVALID_ARGUMENT);
+    ok &= expect_status("null JPEG source stream consumer",
+                        sh264e_encode_jpeg_source_idr_with_arena_stream(NULL, NULL,
+                                                                        NULL, 0u,
+                                                                        NULL, 0u,
+                                                                        NULL, 0u,
+                                                                        NULL, NULL),
                         SH264E_ERR_INVALID_ARGUMENT);
     jpeg_alloc_stats.current_bytes = 123u;
     jpeg_alloc_stats.peak_bytes = 456u;

--- a/tools/sh264e_encode_jpeg.c
+++ b/tools/sh264e_encode_jpeg.c
@@ -25,6 +25,7 @@ static void usage(const char *argv0)
             "[--test-arena-shrink BYTES] [--test-arena-offset BYTES] "
             "[--test-one-shot-output] [--test-output-consumer] "
             "[--test-output-consumer-fail-after CHUNKS] [--test-output-chunk-size BYTES] "
+            "[--test-jpeg-source-chunk-size BYTES] "
             "--format i420|nv12 input.jpg output.h264\n",
             argv0);
 }
@@ -106,6 +107,49 @@ static int write_exact(FILE *fp, const uint8_t *buf, size_t size)
     return fwrite(buf, 1u, size, fp) == size;
 }
 
+typedef struct jpeg_memory_source_state_t {
+    const uint8_t *data;
+    size_t size;
+    size_t offset;
+    size_t chunk_size;
+} jpeg_memory_source_state_t;
+
+static sh264e_status_t read_jpeg_source_chunk(void *user,
+                                              uint8_t *dst,
+                                              size_t requested,
+                                              size_t *out_read)
+{
+    jpeg_memory_source_state_t *state = (jpeg_memory_source_state_t *)user;
+    size_t remaining;
+    size_t to_read;
+
+    if (state == NULL || dst == NULL || out_read == NULL || requested == 0u) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+    if (state->offset > state->size) {
+        return SH264E_ERR_INTERNAL;
+    }
+    remaining = state->size - state->offset;
+    to_read = requested;
+    if (to_read > state->chunk_size) {
+        to_read = state->chunk_size;
+    }
+    if (to_read > remaining) {
+        to_read = remaining;
+    }
+    if (to_read != 0u) {
+        memcpy(dst, state->data + state->offset, to_read);
+        state->offset += to_read;
+    }
+    *out_read = to_read;
+    return SH264E_OK;
+}
+
+static void reset_jpeg_source(jpeg_memory_source_state_t *state)
+{
+    state->offset = 0u;
+}
+
 typedef struct output_consumer_state_t {
     FILE *fp;
     uint8_t *data;
@@ -165,6 +209,7 @@ int main(int argc, char **argv)
     size_t output_capacity = 0;
     size_t output_chunk_capacity = 0;
     size_t output_chunk_override = 0;
+    size_t jpeg_source_chunk_size = 0;
     size_t output_size = 0;
     size_t allocation_limit = (size_t)-1;
     size_t arena_shrink = 0;
@@ -173,6 +218,8 @@ int main(int argc, char **argv)
     int one_shot_output_test = 0;
     int output_consumer_test = 0;
     int output_consumer_fail_after = -1;
+    jpeg_memory_source_state_t jpeg_source_state;
+    sh264e_jpeg_source_t jpeg_source;
     int argi = 1;
     int rc = 1;
 
@@ -207,6 +254,13 @@ int main(int argc, char **argv)
         } else if (argi + 1 < argc && strcmp(argv[argi], "--test-output-chunk-size") == 0) {
             if (!parse_size(argv[argi + 1], &output_chunk_override) ||
                 output_chunk_override == 0u) {
+                usage(argv[0]);
+                return 2;
+            }
+            argi += 2;
+        } else if (argi + 1 < argc && strcmp(argv[argi], "--test-jpeg-source-chunk-size") == 0) {
+            if (!parse_size(argv[argi + 1], &jpeg_source_chunk_size) ||
+                jpeg_source_chunk_size == 0u) {
                 usage(argv[0]);
                 return 2;
             }
@@ -248,6 +302,12 @@ int main(int argc, char **argv)
         fprintf(stderr, "--test-output-consumer cannot be combined with streaming prototype or allocation-limit modes\n");
         goto done;
     }
+    if (jpeg_source_chunk_size != 0u &&
+        (streaming_prototype || allocation_limit != (size_t)-1 ||
+         one_shot_output_test || output_consumer_test)) {
+        fprintf(stderr, "--test-jpeg-source-chunk-size cannot be combined with other JPEG input/output test modes\n");
+        goto done;
+    }
     if (one_shot_output_test && (streaming_prototype || output_consumer_test ||
                                  allocation_limit != (size_t)-1)) {
         fprintf(stderr, "--test-one-shot-output cannot be combined with other output test modes\n");
@@ -258,8 +318,22 @@ int main(int argc, char **argv)
         fprintf(stderr, "--test-output-chunk-size requires streaming output mode\n");
         goto done;
     }
+    memset(&jpeg_source_state, 0, sizeof(jpeg_source_state));
+    memset(&jpeg_source, 0, sizeof(jpeg_source));
+    if (jpeg_source_chunk_size != 0u) {
+        jpeg_source_state.data = jpeg_data;
+        jpeg_source_state.size = jpeg_size;
+        jpeg_source_state.chunk_size = jpeg_source_chunk_size;
+        jpeg_source.read = read_jpeg_source_chunk;
+        jpeg_source.user = &jpeg_source_state;
+    }
     if (allocation_limit == (size_t)-1) {
-        status = sh264e_jpeg_get_work_size(jpeg_data, jpeg_size, &jpeg_work_size);
+        if (jpeg_source_chunk_size != 0u) {
+            reset_jpeg_source(&jpeg_source_state);
+            status = sh264e_jpeg_source_get_work_size(&jpeg_source, &jpeg_work_size);
+        } else {
+            status = sh264e_jpeg_get_work_size(jpeg_data, jpeg_size, &jpeg_work_size);
+        }
         if (status != SH264E_OK) {
             fprintf(stderr, "JPEG work-size query failed: %s\n", sh264e_status_string(status));
             goto done;
@@ -291,7 +365,12 @@ int main(int argc, char **argv)
         fprintf(stderr, "sh264e_encoder_get_work_size failed: %s\n", sh264e_status_string(status));
         goto done;
     }
-    status = sh264e_jpeg_get_slice_work_size(jpeg_data, jpeg_size, pixfmt, &work_size);
+    if (jpeg_source_chunk_size != 0u) {
+        reset_jpeg_source(&jpeg_source_state);
+        status = sh264e_jpeg_source_get_slice_work_size(&jpeg_source, pixfmt, &work_size);
+    } else {
+        status = sh264e_jpeg_get_slice_work_size(jpeg_data, jpeg_size, pixfmt, &work_size);
+    }
     if (status != SH264E_OK) {
         fprintf(stderr, "sh264e_jpeg_get_slice_work_size failed: %s\n", sh264e_status_string(status));
         goto done;
@@ -391,6 +470,35 @@ int main(int argc, char **argv)
             status = SH264E_ERR_INTERNAL;
         }
         if (status == SH264E_OK) {
+            printf("jpeg output consumer chunks: %u\n", consumer_state.chunks);
+            printf("jpeg output chunk buffer bytes: %zu\n", output_chunk_capacity);
+        }
+    } else if (jpeg_source_chunk_size != 0u) {
+        output_consumer_state_t consumer_state;
+
+        output = fopen(output_path, "wb");
+        if (output == NULL) {
+            fprintf(stderr, "failed to open output: %s\n", output_path);
+            goto done;
+        }
+        memset(&consumer_state, 0, sizeof(consumer_state));
+        consumer_state.fp = output;
+        consumer_state.fail_after_chunks = output_consumer_fail_after;
+        reset_jpeg_source(&jpeg_source_state);
+        status = sh264e_encode_jpeg_source_idr_with_arena_stream(
+            encoder, &jpeg_source,
+            jpeg_arena, jpeg_arena_size,
+            work, work_size,
+            output_chunk_buf, output_chunk_capacity,
+            collect_output_chunk, &consumer_state);
+        output_size = consumer_state.size;
+        if (status == SH264E_OK && consumer_state.chunks < 1u + SH264E_V1_SLICE_COUNT) {
+            fprintf(stderr, "output consumer saw %u chunks, expected at least %u\n",
+                    consumer_state.chunks, 1u + SH264E_V1_SLICE_COUNT);
+            status = SH264E_ERR_INTERNAL;
+        }
+        if (status == SH264E_OK) {
+            printf("jpeg source chunk bytes: %zu\n", jpeg_source_chunk_size);
             printf("jpeg output consumer chunks: %u\n", consumer_state.chunks);
             printf("jpeg output chunk buffer bytes: %zu\n", output_chunk_capacity);
         }


### PR DESCRIPTION
Refs #52

## Summary

- Add a public sequential `sh264e_jpeg_source_t` input API for compressed JPEG data.
- Teach NanoJPEG MCU-row decode to use a bounded 512-byte compressed-input window for source-backed parser and entropy reads.
- Keep existing `jpeg_data/jpeg_size` APIs source-compatible and route them through the same MCU-row streaming path.
- Add chunk-boundary integration coverage and update public API/memory documentation.

## Validation

- `cmake -S . -B build/issue52`
- `cmake --build build/issue52`
- `ctest --test-dir build/issue52 --output-on-failure`
- `python3 -m py_compile tests/run_ffmpeg_integration.py`
- `git diff --check`
