### PR TITLE
build: fix production nm lookup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,7 @@ if(SH264E_BUILD_TESTS)
             -DSH264E_PROJECT_DIR=${CMAKE_CURRENT_SOURCE_DIR}
             -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/check_jpeg_diagnostics_boundary.cmake
     )
-    find_program(SH264E_NM nm llvm-nm)
+    find_program(SH264E_NM NAMES nm llvm-nm)
     if(SH264E_NM)
         add_test(
             NAME sh264e_production_profile_symbols


### PR DESCRIPTION
Refs #54

## Summary

- Fix the production-profile symbol-audit tool lookup to use CMake's multi-name `find_program` form.
- Ensures environments with `llvm-nm` but no `nm` run `sh264e_production_profile_symbols` instead of silently skipping the audit.

## Validation

- `cmake -S . -B build/issue54-nm-fix`
- `cmake --build build/issue54-nm-fix`
- `ctest --test-dir build/issue54-nm-fix --output-on-failure -R sh264e_production_profile_symbols`
- `ctest --test-dir build/issue54-nm-fix --output-on-failure -R 'sh264e_jpeg_diagnostics_boundary|sh264e_production_profile_symbols|sh264e_api'`
- `ctest --test-dir build/issue54-nm-fix --output-on-failure`
- `git diff --check`

## Notes

CMake still skips QEMU firmware tests in this environment because `arm-none-eabi-gcc` cannot compile `<stdlib.h>`.
