### PR TITLE
docs: close out independent MB status

### DIFF
--- a/INDEPENDENT_MB_MODE_PLAN.md
+++ b/INDEPENDENT_MB_MODE_PLAN.md
@@ -1,9 +1,9 @@
-# Independent Macroblock Slice Mode Plan
+# Independent Macroblock Slice Mode Status
 
-## Goal
+## Implemented Behavior
 
-Change the H.264 encoder direction from row-slice intra prediction to
-independent macroblock slices:
+The H.264 encoder uses independent macroblock slices instead of row-slice
+reconstructed-neighbor intra prediction:
 
 * IDR-only
 * fixed 16x16 macroblocks
@@ -15,14 +15,15 @@ independent macroblock slices:
 This is a deliberate Cortex-M tradeoff. The encoder is intended to be simple,
 deterministic, and low-memory rather than compression efficient.
 
-Issues #63 and #64 implement the bitstream shape and memory removal in this
-plan. The implementation uses fixed unavailable-neighbor residual prediction and
-fixed CAVLC `nC = 0`; it retains no row-level or per-macroblock reconstructed
-neighbor state.
+Issues #63, #64, #65, #66, and #67 implemented and validated this mode. The
+implementation uses fixed unavailable-neighbor residual prediction and fixed
+CAVLC `nC = 0`; it retains no row-level or per-macroblock reconstructed neighbor
+state.
 
-## Current Baseline
+## Former Row-Slice Baseline
 
-The current progressive input API consumes one macroblock row per call:
+The progressive input API consumed one macroblock row per call before this
+change, and that public call shape remains unchanged:
 
 ```text
 sh264e_begin_idr
@@ -30,7 +31,7 @@ sh264e_begin_idr
 sh264e_end_idr
 ```
 
-Current bitstream shape:
+Former bitstream shape:
 
 ```text
 SPS
@@ -38,23 +39,23 @@ PPS
 90 IDR slice NALUs
 ```
 
-Each current IDR slice contains one horizontal macroblock row, or 160
+Each former IDR slice contained one horizontal macroblock row, or 160
 macroblocks. That model uses reconstructed left/top samples inside a slice for
 DC prediction and CAVLC neighbor context.
 
-Current encoder-owned memory includes:
+Former encoder-owned memory included:
 
 | Block | Bytes |
 | --- | ---: |
 | Reconstructed luma slice | 40,960 |
 | Reconstructed chroma slices | 20,480 |
 | Neighbor/nonzero state | 2,560 |
-| Total removable target | 64,000 |
+| Removed subtotal | 64,000 |
 
-## Target Bitstream Shape
+## Current Bitstream Shape
 
-Keep the progressive input API row-oriented, but change the H.264 slice output
-inside each row:
+The progressive input API remains row-oriented, while the H.264 slice output
+inside each row is now macroblock-oriented:
 
 ```text
 SPS
@@ -86,7 +87,7 @@ reconstructed-neighbor prediction is used.
 
 ## API Behavior
 
-Avoid large public API churn for the first implementation:
+The implementation preserves the public progressive API shape:
 
 * `sh264e_begin_idr` still emits SPS/PPS.
 * `sh264e_encode_idr_slice` still consumes one horizontal input macroblock row.
@@ -104,7 +105,7 @@ slice NALU. The clearer terminology is:
 
 ## Prediction and Residual
 
-Target encoder behavior:
+Implemented encoder behavior:
 
 * no luma reconstructed-neighbor prediction
 * no chroma reconstructed-neighbor prediction
@@ -125,38 +126,37 @@ write CAVLC residual with nC = 0
 
 Chroma may continue to use one simplified DC-like residual per 8x8 block.
 
-## Memory Target
+## Memory Result
 
-The first implementation should remove these encoder-owned blocks:
+The implementation removes these encoder-owned blocks:
 
-| Block | Current bytes | Target |
+| Block | Former bytes | Current bytes |
 | --- | ---: | ---: |
 | Reconstructed luma slice | 40,960 | 0 |
 | Reconstructed chroma slices | 20,480 | 0 |
 | Neighbor/nonzero state | 2,560 | 0 |
-| Removable subtotal | 64,000 | 0 |
+| Removed subtotal | 64,000 | 0 |
 
-The encoder will still need:
+The encoder still needs:
 
 * opaque context/config
 * bitstream/RBSP scratch unless the streaming output writer removes or shrinks
   it further
 * any small temporary per-macroblock local variables
 
-If #48 streaming H.264 output is active, this independent-MB mode should also
-help reduce the worst-case bitstream scratch requirement because the encoder no
-longer needs a full macroblock-row slice RBSP.
+Independent-MB mode also reduced the worst-case bitstream scratch requirement
+because the encoder no longer needs a full macroblock-row slice RBSP.
 
-## CPU and SRAM Bandwidth Target
+## CPU and SRAM Bandwidth Result
 
-The implementation should eliminate:
+The implementation eliminates:
 
 * per-slice `memset` of reconstructed luma/chroma buffers
 * per-block reads from reconstructed left/top samples
 * per-block reconstructed pixel writes
 * nonzero-neighbor state updates and reads
 
-Expected result:
+Result:
 
 * lower CPU cycles per macroblock
 * lower SRAM read/write bandwidth
@@ -176,24 +176,24 @@ The cost is intentional:
 This tradeoff is acceptable for the target use case if CPU/SRAM is more
 important than bitstream size.
 
-## Implementation Steps
+## Implemented Steps
 
-1. Update documentation and tests to distinguish input rows from H.264 slices.
-2. Refactor the IDR writer so one helper emits exactly one macroblock as one
+1. Documentation and tests distinguish input rows from H.264 slices.
+2. The IDR writer has one helper that emits exactly one macroblock as one
    IDR slice NALU.
-3. In `sh264e_encode_idr_slice`, loop over 160 macroblocks and emit 160 IDR
+3. `sh264e_encode_idr_slice` loops over 160 macroblocks and emits 160 IDR
    slice NALUs for the submitted input row.
-4. Set `first_mb_in_slice = row_index * 160 + mb_x`.
-5. Replace reconstructed-neighbor prediction with fixed boundary prediction.
-6. Remove reconstructed luma/chroma buffers from encoder state.
-7. Remove neighbor/nonzero state from encoder state.
-8. Fix CAVLC `nC` to 0.
-9. Update max output sizing and streaming output buffer assumptions.
-10. Update memory reports and regression tests.
+4. `first_mb_in_slice = row_index * 160 + mb_x`.
+5. Reconstructed-neighbor prediction is replaced with fixed boundary prediction.
+6. Reconstructed luma/chroma buffers are removed from encoder state.
+7. Neighbor/nonzero state is removed from encoder state.
+8. CAVLC `nC` is fixed to 0.
+9. Max output sizing and streaming output buffer assumptions are updated.
+10. Memory reports and regression tests are updated.
 
 ## Validation
 
-Required validation:
+Validation used for the final status:
 
 ```sh
 cmake -S . -B build

--- a/MEMORY_OPTIMIZATION_PLAN.md
+++ b/MEMORY_OPTIMIZATION_PLAN.md
@@ -33,9 +33,9 @@ storage and `.rodata`:
 The old full decoded JPEG component-frame allocation was 5,529,600 bytes for
 `2560x1440` 4:2:0 and is no longer allowed for public JPEG APIs.
 
-Independent-MB result:
+Independent-MB memory result:
 
-| Block | Current bytes | Independent-MB target |
+| Block | Former bytes | Current bytes |
 | --- | ---: | ---: |
 | Reconstructed luma slice | 40,960 | 0 |
 | Reconstructed chroma slices | 20,480 | 0 |

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ This project is intentionally small and narrow in scope:
 * Core memory-input and source-input baseline JPEG decode path via NanoJPEG
 
 The encoder is designed for validation and offline experiments, not compression efficiency.
+The current independent-MB bitstream intentionally trades compression ratio for
+low SRAM use: it emits 14,400 IDR slice NALUs per frame instead of the former 90
+row-slice NALUs, which increases slice-header overhead while eliminating
+encoder-owned reconstructed-neighbor row state.
 
 ## Layout
 

--- a/docs/ENCODER_MEMORY_REPORT.md
+++ b/docs/ENCODER_MEMORY_REPORT.md
@@ -29,14 +29,14 @@ workspace now only needs to hold one macroblock slice.
 
 The independent macroblock slice mode eliminates these blocks:
 
-| Block | Current bytes | Target |
+| Block | Former bytes | Current bytes |
 | --- | ---: | ---: |
 | Reconstructed luma slice | 40,960 | 0 |
 | Reconstructed chroma slices | 20,480 | 0 |
 | Neighbor/nonzero state | 2,560 | 0 |
 | Removable subtotal | 64,000 | 0 |
 
-The target bitstream emits one H.264 slice per macroblock so the decoder treats
+The current bitstream emits one H.264 slice per macroblock so the decoder treats
 left/top macroblocks as unavailable. Encoder-side row reconstructed-neighbor
 prediction and row CAVLC neighbor context are therefore removed.
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -135,7 +135,7 @@ Progressive slice mode is the preferred v1 library interface. Frame mode (`sh264
 * Bitstream format:
 
   * Annex B (start code: `0x000001`)
-* Target independent-MB output structure:
+* Independent-MB output structure:
 
   ```
   SPS
@@ -190,8 +190,8 @@ IDR Slice[MB 14399]
 
 `sh264e_begin_idr` emits SPS/PPS. `sh264e_end_idr` emits no bitstream in v1; it validates that exactly 90 input rows were submitted and resets the progressive frame state.
 
-The target independent-MB mode keeps the public progressive input call sequence
-but changes H.264 slice granularity:
+Independent-MB mode keeps the public progressive input call sequence but changes
+H.264 slice granularity:
 
 * `sh264e_encode_idr_slice` still consumes one horizontal macroblock input row.
 * Each input-row call emits **160** complete IDR slice NALUs.
@@ -207,7 +207,7 @@ The encoder owns the progressive slice index.
 
 * Caller must submit slices in top-to-bottom raster order
 * Caller does not pass a slice index
-* Target independent-MB mode: `first_mb_in_slice = row_index * 160 + mb_x`
+* Independent-MB mode: `first_mb_in_slice = row_index * 160 + mb_x`
 * A 91st slice call must fail
 * Calling slice encode before `sh264e_begin_idr` must fail
 * Calling `sh264e_end_idr` before all 90 slices are encoded must fail
@@ -531,7 +531,7 @@ NALU Packaging
 
 #### Rules:
 
-* Target mode emits one H.264 slice per macroblock.
+* Independent-MB mode emits one H.264 slice per macroblock.
 * Left and top macroblocks are outside the current H.264 slice, so they are
   unavailable to the decoder.
 * Encoder must not read or write row-level reconstructed-neighbor samples.
@@ -585,7 +585,7 @@ NALU Packaging
 * PPS (nal_unit_type = 8)
 * IDR Slice (nal_unit_type = 5)
 
-Target independent-MB mode emits one IDR slice NALU per macroblock.
+Independent-MB mode emits one IDR slice NALU per macroblock.
 
 #### Constraints:
 


### PR DESCRIPTION
Refs #68

## Summary
- update the independent-MB plan into an implemented status document
- replace current-behavior target/future wording in the spec and memory docs
- document the final 90 input-row / 14,400 IDR-slice behavior, 2,088-byte encoder report, 2,095-byte arena, and bitstream-size tradeoff

## Validation
- rg -n "target independent|Target independent|planned|future|Current bitstream|Current Baseline|Target Bitstream|Memory Target|should remove|should eliminate|first implementation|Target mode|Current bytes \| Target" INDEPENDENT_MB_MODE_PLAN.md docs/SPEC.md docs/ENCODER_MEMORY_REPORT.md MEMORY_OPTIMIZATION_PLAN.md README.md
- git diff --check