### PR TITLE
cortex-m: add encoder DWT benchmark firmware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,5 +332,31 @@ if(SH264E_BUILD_TESTS)
             mps2-an500
             SH264E_DISABLE_ARM_DSP
         )
+        sh264e_add_qemu_firmware(
+            sh264e_qemu_encoder_bench_m4
+            tests/qemu_encoder_bench.c
+            cortex-m4
+            mps2-an386
+        )
+        sh264e_add_qemu_firmware(
+            sh264e_qemu_encoder_bench_m4_portable
+            tests/qemu_encoder_bench.c
+            cortex-m4
+            mps2-an386
+            SH264E_DISABLE_ARM_DSP
+        )
+        sh264e_add_qemu_firmware(
+            sh264e_qemu_encoder_bench_m7
+            tests/qemu_encoder_bench.c
+            cortex-m7
+            mps2-an500
+        )
+        sh264e_add_qemu_firmware(
+            sh264e_qemu_encoder_bench_m7_portable
+            tests/qemu_encoder_bench.c
+            cortex-m7
+            mps2-an500
+            SH264E_DISABLE_ARM_DSP
+        )
     endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The test suite covers:
 * ffmpeg/ffprobe integration when those tools are available
 * Cortex-M QEMU scaler smoke tests when `arm-none-eabi-gcc` and `qemu-system-arm` are available and usable
 * Cortex-M QEMU scaler benchmark firmware correctness for default DSP-capable and portable C variants when those tools are available and usable
+* Cortex-M QEMU encoder benchmark firmware correctness for default DSP-capable and portable C variants when those tools are available and usable
 * production-profile symbol audit when `nm` or `llvm-nm` is available
 
 ## CLI Example
@@ -197,6 +198,10 @@ The QEMU benchmark preflight targets are:
 | `sh264e_qemu_scaler_bench_m4_portable` | `cortex-m4` / `mps2-an386` | `SH264E_DISABLE_ARM_DSP` | portable C comparison preflight |
 | `sh264e_qemu_scaler_bench_m7` | `cortex-m7` / `mps2-an500` | default DSP-capable build | M7 benchmark preflight |
 | `sh264e_qemu_scaler_bench_m7_portable` | `cortex-m7` / `mps2-an500` | `SH264E_DISABLE_ARM_DSP` | M7 portable C comparison preflight |
+| `sh264e_qemu_encoder_bench_m4` | `cortex-m4` / `mps2-an386` | default DSP-capable build | progressive H.264 encoder benchmark preflight |
+| `sh264e_qemu_encoder_bench_m4_portable` | `cortex-m4` / `mps2-an386` | `SH264E_DISABLE_ARM_DSP` | encoder portable C comparison preflight |
+| `sh264e_qemu_encoder_bench_m7` | `cortex-m7` / `mps2-an500` | default DSP-capable build | M7 encoder benchmark preflight |
+| `sh264e_qemu_encoder_bench_m7_portable` | `cortex-m7` / `mps2-an500` | `SH264E_DISABLE_ARM_DSP` | M7 encoder portable C comparison preflight |
 
 QEMU validates firmware build/run behavior and stable nonzero `sh264e_bench_checksum`. Treat `sh264e_bench_cycles` from QEMU as a preflight signal only; final tuning-quality cycle counts still need real Cortex-M hardware with documented CPU, clock, compiler flags, cache state, and memory placement.
 Use `docs/CORTEX_M_SCALER_BENCHMARKS.md` as the capture checklist and result table for real-board portable C versus DSP measurements.

--- a/docs/CORTEX_M_OPTIMIZATION_PLAN.md
+++ b/docs/CORTEX_M_OPTIMIZATION_PLAN.md
@@ -88,9 +88,11 @@ deterministic I420 input rows, caller-provided encoder arena placement, and the
 independent-MB progressive path. It exports the same globals as the scaler
 benchmark:
 
-* `sh264e_bench_checksum` - nonzero correctness guard over the generated Annex B bytes.
+* `sh264e_bench_checksum` - correctness guard over the generated Annex B bytes.
 * `sh264e_bench_cycles` - DWT cycle count around `sh264e_begin_idr` plus eight input-row encode calls.
 
-QEMU rows are correctness/preflight only. Real-board captures must compare the
-default DSP-capable and `SH264E_DISABLE_ARM_DSP` portable variants before using
-cycle data for optimization decisions.
+The encoder QEMU firmware currently expects checksum `0x5926e2e5` for both
+default DSP-capable and portable builds. QEMU rows are correctness/preflight
+only. Real-board captures must compare the default DSP-capable and
+`SH264E_DISABLE_ARM_DSP` portable variants before using cycle data for
+optimization decisions.

--- a/docs/CORTEX_M_OPTIMIZATION_PLAN.md
+++ b/docs/CORTEX_M_OPTIMIZATION_PLAN.md
@@ -79,3 +79,18 @@ ctest --test-dir build-qemu -R 'qemu|sh264e_qemu' --output-on-failure
 Performance claims must include real-board DWT cycle data with board, core,
 clock, compiler, flags, cache state, memory placement, checksum, total cycles,
 and cycles per encoded or resized slice.
+
+## Current Benchmark Firmware
+
+The QEMU preflight set now includes scaler smoke/benchmark firmware and H.264
+progressive encoder benchmark firmware. The encoder benchmark uses eight
+deterministic I420 input rows, caller-provided encoder arena placement, and the
+independent-MB progressive path. It exports the same globals as the scaler
+benchmark:
+
+* `sh264e_bench_checksum` - nonzero correctness guard over the generated Annex B bytes.
+* `sh264e_bench_cycles` - DWT cycle count around `sh264e_begin_idr` plus eight input-row encode calls.
+
+QEMU rows are correctness/preflight only. Real-board captures must compare the
+default DSP-capable and `SH264E_DISABLE_ARM_DSP` portable variants before using
+cycle data for optimization decisions.

--- a/docs/CORTEX_M_SCALER_BENCHMARKS.md
+++ b/docs/CORTEX_M_SCALER_BENCHMARKS.md
@@ -23,11 +23,12 @@ The benchmark firmware in `tests/qemu_encoder_bench.c` exercises the
 independent-MB progressive H.264 encoder path on eight deterministic raw I420
 input rows. Each run writes:
 
-* `sh264e_bench_checksum` - nonzero correctness guard over the generated Annex B bytes.
+* `sh264e_bench_checksum` - correctness guard over the generated Annex B bytes.
 * `sh264e_bench_cycles` - DWT cycle count around `sh264e_begin_idr` plus eight `sh264e_encode_idr_slice` calls.
 
 Portable and DSP-capable builds must produce the same checksum for the same
-target fixture. Treat a checksum mismatch as a correctness failure before
+target fixture. The QEMU firmware checks the current expected checksum
+`0x5926e2e5`; treat any checksum mismatch as a correctness failure before
 comparing cycles.
 
 ## QEMU Preflight

--- a/docs/CORTEX_M_SCALER_BENCHMARKS.md
+++ b/docs/CORTEX_M_SCALER_BENCHMARKS.md
@@ -1,10 +1,10 @@
-# Cortex-M Scaler Benchmark Capture
+# Cortex-M Benchmark Capture
 
-This document is the handoff artifact for Cortex-M scaler benchmarking. It
-keeps QEMU preflight results separate from real-board timing so cycle counts
-are not confused with emulator behavior.
+This document is the handoff artifact for Cortex-M scaler and encoder
+benchmarking. It keeps QEMU preflight results separate from real-board timing
+so cycle counts are not confused with emulator behavior.
 
-## Scope
+## Scaler Scope
 
 The benchmark firmware in `tests/qemu_scaler_bench.c` exercises
 `sh264e_resize_make_slice` on a deterministic 1280x720 NV12 source. Each run
@@ -17,10 +17,18 @@ Portable and DSP builds must produce the same checksum for the same target
 fixture. Treat a checksum mismatch as a correctness failure before comparing
 cycles.
 
-Future H.264 encoder benchmark firmware must use the same QEMU preflight and
-real-board DWT capture policy. Encoder benchmarks should export checksum and
-cycle globals for the independent-MB progressive encode path, and should compare
-portable C and DSP-capable builds only after checksum parity is established.
+## Encoder Scope
+
+The benchmark firmware in `tests/qemu_encoder_bench.c` exercises the
+independent-MB progressive H.264 encoder path on eight deterministic raw I420
+input rows. Each run writes:
+
+* `sh264e_bench_checksum` - nonzero correctness guard over the generated Annex B bytes.
+* `sh264e_bench_cycles` - DWT cycle count around `sh264e_begin_idr` plus eight `sh264e_encode_idr_slice` calls.
+
+Portable and DSP-capable builds must produce the same checksum for the same
+target fixture. Treat a checksum mismatch as a correctness failure before
+comparing cycles.
 
 ## QEMU Preflight
 
@@ -34,8 +42,12 @@ cmake --build build-qemu --target \
   sh264e_qemu_scaler_bench_m4 \
   sh264e_qemu_scaler_bench_m4_portable \
   sh264e_qemu_scaler_bench_m7 \
-  sh264e_qemu_scaler_bench_m7_portable
-ctest --test-dir build-qemu -R 'sh264e_qemu_scaler_(smoke|bench)_(m4|m7)' --output-on-failure
+  sh264e_qemu_scaler_bench_m7_portable \
+  sh264e_qemu_encoder_bench_m4 \
+  sh264e_qemu_encoder_bench_m4_portable \
+  sh264e_qemu_encoder_bench_m7 \
+  sh264e_qemu_encoder_bench_m7_portable
+ctest --test-dir build-qemu -R 'sh264e_qemu_(scaler|encoder)_(smoke|bench)_(m4|m7)' --output-on-failure
 ```
 
 CMake intentionally skips these firmware targets when `arm-none-eabi-gcc` or
@@ -57,8 +69,10 @@ p/u sh264e_bench_cycles
 p/u sh264e_bench_cycles / 8
 ```
 
-The final expression reports cycles per resized encoder slice because
-`BENCH_ITERS` is currently `8`.
+The final expression reports cycles per resized scaler slice for
+`tests/qemu_scaler_bench.c` or cycles per encoded input row for
+`tests/qemu_encoder_bench.c`; both currently use an eight-iteration benchmark
+window.
 
 Record these metadata fields with every result:
 
@@ -86,6 +100,10 @@ preflight-only if they are included for traceability.
 | TBD | QEMU preflight | `mps2-an386` | Cortex-M4 | N/A | N/A | emulator default | `arm-none-eabi-gcc -O2 -mcpu=cortex-m4 -mthumb -DSH264E_DISABLE_ARM_DSP` | portable C | TBD | preflight only | preflight only | checksum must match DSP-capable row |
 | TBD | QEMU preflight | `mps2-an500` | Cortex-M7 | N/A | N/A | emulator default | `arm-none-eabi-gcc -O2 -mcpu=cortex-m7 -mthumb` | DSP-capable | TBD | preflight only | preflight only | firmware boot/checksum only |
 | TBD | QEMU preflight | `mps2-an500` | Cortex-M7 | N/A | N/A | emulator default | `arm-none-eabi-gcc -O2 -mcpu=cortex-m7 -mthumb -DSH264E_DISABLE_ARM_DSP` | portable C | TBD | preflight only | preflight only | checksum must match DSP-capable row |
+| TBD | QEMU preflight | `mps2-an386` | Cortex-M4 | N/A | N/A | emulator default | `arm-none-eabi-gcc -O2 -mcpu=cortex-m4 -mthumb` | encoder DSP-capable | TBD | preflight only | preflight only | firmware boot/checksum only |
+| TBD | QEMU preflight | `mps2-an386` | Cortex-M4 | N/A | N/A | emulator default | `arm-none-eabi-gcc -O2 -mcpu=cortex-m4 -mthumb -DSH264E_DISABLE_ARM_DSP` | encoder portable C | TBD | preflight only | preflight only | checksum must match DSP-capable row |
+| TBD | QEMU preflight | `mps2-an500` | Cortex-M7 | N/A | N/A | emulator default | `arm-none-eabi-gcc -O2 -mcpu=cortex-m7 -mthumb` | encoder DSP-capable | TBD | preflight only | preflight only | firmware boot/checksum only |
+| TBD | QEMU preflight | `mps2-an500` | Cortex-M7 | N/A | N/A | emulator default | `arm-none-eabi-gcc -O2 -mcpu=cortex-m7 -mthumb -DSH264E_DISABLE_ARM_DSP` | encoder portable C | TBD | preflight only | preflight only | checksum must match DSP-capable row |
 
 ## Tuning Decision
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -721,6 +721,7 @@ Validate:
 * Invalid resize dimensions fail
 * Cortex-M3/M4/M7 QEMU scaler smoke tests pass when the ARM bare-metal toolchain and QEMU are available
 * Cortex-M4 QEMU scaler benchmark firmware passes correctness checks
+* Cortex-M4/M7 QEMU encoder benchmark firmware passes correctness checks for default DSP-capable and portable C builds
 
 ---
 

--- a/tests/qemu_encoder_bench.c
+++ b/tests/qemu_encoder_bench.c
@@ -1,0 +1,222 @@
+#include "sh264e.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define BENCH_ROWS 8u
+#define ENCODER_ARENA_CAPACITY 512u
+#define HEADER_OUTPUT_CAPACITY 1024u
+#define ROW_OUTPUT_CAPACITY 62080u
+#define SLICE_Y_BYTES ((size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_LUMA_HEIGHT)
+#define SLICE_C_BYTES ((size_t)(SH264E_V1_WIDTH / 2u) * SH264E_V1_SLICE_CHROMA_HEIGHT)
+
+#define DEMCR (*(volatile uint32_t *)0xE000EDFCu)
+#define DWT_CTRL (*(volatile uint32_t *)0xE0001000u)
+#define DWT_CYCCNT (*(volatile uint32_t *)0xE0001004u)
+#define DEMCR_TRCENA (1u << 24)
+#define DWT_CTRL_CYCCNTENA 1u
+
+extern unsigned long _estack;
+extern unsigned long __bss_start__;
+extern unsigned long __bss_end__;
+
+static uint8_t encoder_arena[ENCODER_ARENA_CAPACITY];
+static uint8_t input_y[(size_t)BENCH_ROWS * SLICE_Y_BYTES];
+static uint8_t input_u[(size_t)BENCH_ROWS * SLICE_C_BYTES];
+static uint8_t input_v[(size_t)BENCH_ROWS * SLICE_C_BYTES];
+static uint8_t header_output[HEADER_OUTPUT_CAPACITY];
+static uint8_t row_output[(size_t)BENCH_ROWS * ROW_OUTPUT_CAPACITY];
+static size_t row_output_size[BENCH_ROWS];
+volatile uint32_t sh264e_bench_cycles;
+volatile uint32_t sh264e_bench_checksum;
+
+void *memset(void *dst, int value, size_t size)
+{
+    uint8_t *p = (uint8_t *)dst;
+    while (size > 0u) {
+        *p++ = (uint8_t)value;
+        size--;
+    }
+    return dst;
+}
+
+static void fill_input_rows(void)
+{
+    uint32_t row;
+    uint32_t y;
+    uint32_t x;
+
+    for (row = 0; row < BENCH_ROWS; row++) {
+        uint8_t *slice_y = input_y + (size_t)row * SLICE_Y_BYTES;
+        uint8_t *slice_u = input_u + (size_t)row * SLICE_C_BYTES;
+        uint8_t *slice_v = input_v + (size_t)row * SLICE_C_BYTES;
+
+        for (y = 0; y < SH264E_V1_SLICE_LUMA_HEIGHT; y++) {
+            uint8_t *dst = slice_y + (size_t)y * SH264E_V1_WIDTH;
+            for (x = 0; x < SH264E_V1_WIDTH; x++) {
+                dst[x] = (uint8_t)((x * 3u + (row * 16u + y) * 5u) & 0xffu);
+            }
+        }
+
+        for (y = 0; y < SH264E_V1_SLICE_CHROMA_HEIGHT; y++) {
+            uint8_t *dst_u = slice_u + (size_t)y * (SH264E_V1_WIDTH / 2u);
+            uint8_t *dst_v = slice_v + (size_t)y * (SH264E_V1_WIDTH / 2u);
+            for (x = 0; x < SH264E_V1_WIDTH / 2u; x++) {
+                dst_u[x] = (uint8_t)(80u + ((x + row + y) & 31u));
+                dst_v[x] = (uint8_t)(160u + ((x * 2u + row + y) & 31u));
+            }
+        }
+    }
+}
+
+static void make_input_slice(uint32_t row, sh264e_slice_t *slice)
+{
+    memset(slice, 0, sizeof(*slice));
+    slice->pixfmt = SH264E_PIXFMT_I420;
+    slice->plane[0] = input_y + (size_t)row * SLICE_Y_BYTES;
+    slice->plane[1] = input_u + (size_t)row * SLICE_C_BYTES;
+    slice->plane[2] = input_v + (size_t)row * SLICE_C_BYTES;
+    slice->stride[0] = SH264E_V1_WIDTH;
+    slice->stride[1] = SH264E_V1_WIDTH / 2u;
+    slice->stride[2] = SH264E_V1_WIDTH / 2u;
+}
+
+static void dwt_start(void)
+{
+    DEMCR |= DEMCR_TRCENA;
+    DWT_CYCCNT = 0u;
+    DWT_CTRL |= DWT_CTRL_CYCCNTENA;
+}
+
+static uint32_t dwt_stop(void)
+{
+    return DWT_CYCCNT;
+}
+
+static uint32_t checksum_bytes(uint32_t checksum, const uint8_t *data, size_t size)
+{
+    size_t i;
+
+    for (i = 0; i < size; i++) {
+        checksum ^= data[i];
+        checksum *= 16777619u;
+    }
+    return checksum;
+}
+
+static int run_benchmark(void)
+{
+    sh264e_config_t config;
+    sh264e_encoder_t *encoder = NULL;
+    sh264e_slice_t slice;
+    size_t encoder_work_size = 0u;
+    size_t max_header_size = 0u;
+    size_t max_row_size = 0u;
+    size_t header_size = 0u;
+    uint32_t row;
+    uint32_t checksum = 2166136261u;
+    sh264e_status_t status;
+
+    memset(&config, 0, sizeof(config));
+    config.width = SH264E_V1_WIDTH;
+    config.height = SH264E_V1_HEIGHT;
+    config.pixfmt = SH264E_PIXFMT_I420;
+    config.qp = SH264E_DEFAULT_QP;
+
+    status = sh264e_encoder_get_work_size(&config, &encoder_work_size);
+    if (status != SH264E_OK) {
+        return 1;
+    }
+    if (encoder_work_size > sizeof(encoder_arena)) {
+        return 2;
+    }
+    status = sh264e_get_max_header_output_size(&config, &max_header_size);
+    if (status != SH264E_OK || max_header_size > sizeof(header_output)) {
+        return 3;
+    }
+    status = sh264e_get_max_slice_output_size(&config, &max_row_size);
+    if (status != SH264E_OK || max_row_size > ROW_OUTPUT_CAPACITY) {
+        return 4;
+    }
+    status = sh264e_encoder_create_with_arena(&config, encoder_arena,
+                                              sizeof(encoder_arena), &encoder);
+    if (status != SH264E_OK || encoder == NULL) {
+        return 5;
+    }
+
+    dwt_start();
+    status = sh264e_begin_idr(encoder, header_output, sizeof(header_output), &header_size);
+    if (status != SH264E_OK) {
+        return 6;
+    }
+
+    for (row = 0; row < BENCH_ROWS; row++) {
+        make_input_slice(row, &slice);
+        status = sh264e_encode_idr_slice(encoder, &slice,
+                                         row_output + (size_t)row * ROW_OUTPUT_CAPACITY,
+                                         ROW_OUTPUT_CAPACITY,
+                                         &row_output_size[row]);
+        if (status != SH264E_OK) {
+            return 7;
+        }
+        if (row_output_size[row] == 0u || row_output_size[row] > ROW_OUTPUT_CAPACITY) {
+            return 8;
+        }
+    }
+    sh264e_bench_cycles = dwt_stop();
+
+    checksum = checksum_bytes(checksum, header_output, header_size);
+    for (row = 0; row < BENCH_ROWS; row++) {
+        checksum ^= (uint32_t)row_output_size[row];
+        checksum *= 16777619u;
+        checksum = checksum_bytes(checksum,
+                                  row_output + (size_t)row * ROW_OUTPUT_CAPACITY,
+                                  row_output_size[row]);
+    }
+    sh264e_bench_checksum = checksum;
+
+    if (checksum == 0u || sh264e_bench_cycles == 0u) {
+        return 9;
+    }
+    return 0;
+}
+
+static void semihost_exit(int code)
+{
+    uint32_t args[2];
+    register uint32_t r0 __asm("r0") = 0x20u;
+    register uint32_t r1 __asm("r1");
+
+    args[0] = 0x20026u;
+    args[1] = (uint32_t)code;
+    r1 = (uint32_t)args;
+    __asm volatile("bkpt 0xab" : : "r"(r0), "r"(r1) : "memory");
+    for (;;) {
+    }
+}
+
+void Reset_Handler(void)
+{
+    unsigned long *p;
+    int rc;
+
+    for (p = &__bss_start__; p < &__bss_end__; p++) {
+        *p = 0u;
+    }
+
+    fill_input_rows();
+    rc = run_benchmark();
+    semihost_exit(rc);
+}
+
+void Default_Handler(void)
+{
+    semihost_exit(99);
+}
+
+__attribute__((section(".isr_vector"), used))
+void (*const g_vector_table[])(void) = {
+    (void (*)(void))(&_estack),
+    Reset_Handler,
+    Default_Handler
+};

--- a/tests/qemu_encoder_bench.c
+++ b/tests/qemu_encoder_bench.c
@@ -9,6 +9,7 @@
 #define ROW_OUTPUT_CAPACITY 62080u
 #define SLICE_Y_BYTES ((size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_LUMA_HEIGHT)
 #define SLICE_C_BYTES ((size_t)(SH264E_V1_WIDTH / 2u) * SH264E_V1_SLICE_CHROMA_HEIGHT)
+#define EXPECTED_CHECKSUM 0x5926e2e5u
 
 #define DEMCR (*(volatile uint32_t *)0xE000EDFCu)
 #define DWT_CTRL (*(volatile uint32_t *)0xE0001000u)
@@ -175,7 +176,7 @@ static int run_benchmark(void)
     }
     sh264e_bench_checksum = checksum;
 
-    if (checksum == 0u || sh264e_bench_cycles == 0u) {
+    if (checksum != EXPECTED_CHECKSUM || sh264e_bench_cycles == 0u) {
         return 9;
     }
     return 0;


### PR DESCRIPTION
## Summary

- Add Cortex-M4/M7 H.264 encoder DWT benchmark firmware for the independent-MB progressive path.
- Wire default DSP-capable and `SH264E_DISABLE_ARM_DSP` portable QEMU targets for M4 and M7.
- Document encoder benchmark targets, checksum/cycle globals, QEMU preflight scope, and real-board DWT capture guidance.

Refs #74

## Validation

- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `cmake -S . -B build-qemu -DSH264E_BUILD_QEMU_TESTS=ON`
- `cmake --build build-qemu`
- `ctest --test-dir build-qemu -R 'qemu.*encoder|qemu.*scaler' --output-on-failure`
- `clang --target=arm-none-eabi -mcpu=cortex-m4 -mthumb -O2 -ffreestanding -fno-builtin -fsyntax-only -Iinclude tests/qemu_encoder_bench.c`
- `git diff --check`

## Notes

The local ARM GCC installation is incomplete: CMake reports `Skipping QEMU firmware tests: arm-none-eabi-gcc cannot compile <stdlib.h>`, so no QEMU firmware tests are generated in this environment. The build path skips cleanly as designed; the new firmware source was syntax-checked with Clang's ARM target.
