### PR TITLE
scaler: add exact fixed-ratio fast paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ The resize tool accepts even source dimensions in the bilinear-friendly range:
 
 It reads a full source frame for file-based validation, then calls the library scaler to generate one 2560x16 luma / 8-row chroma output slice at a time and immediately feeds that slice to the progressive encoder.
 The library scaler uses fixed-point bilinear interpolation. When the source is already 2560x1440, `sh264e_resize_make_slice` bypasses scaling and points the output slice directly into the source frame.
+The common `1280x720 -> 2560x1440` and `5120x2880 -> 2560x1440`
+ratios use exact fixed-ratio fast paths that preserve the same half-pixel
+bilinear output as the general mapper for I420 and NV12.
 On ARM builds with DSP extension support, the scaler uses an `smlad` guarded path unless `SH264E_DISABLE_ARM_DSP` is defined.
 
 Encode a baseline JPEG memory-input path through the library wrapper:

--- a/docs/CORTEX_M_OPTIMIZATION_PLAN.md
+++ b/docs/CORTEX_M_OPTIMIZATION_PLAN.md
@@ -35,7 +35,7 @@ follow-up work.
 4. Batch Annex B streaming output runs that do not need emulation-prevention
    insertion.
 5. Add exact scaler fast paths for `1280x720 -> 2560x1440` and
-   `5120x2880 -> 2560x1440`.
+   `5120x2880 -> 2560x1440` for I420 and NV12.
 6. Reduce the `2560x1440` JPEG 4:2:0 1:1 NV12 slice-work staging requirement.
 7. Evaluate exact DSP vertical blend optimization for the bilinear scaler.
 
@@ -79,3 +79,10 @@ ctest --test-dir build-qemu -R 'qemu|sh264e_qemu' --output-on-failure
 Performance claims must include real-board DWT cycle data with board, core,
 clock, compiler, flags, cache state, memory placement, checksum, total cycles,
 and cycles per encoded or resized slice.
+
+## Scaler Fast-Path Status
+
+The raw resize API includes exact fixed-ratio fast paths for
+`1280x720 -> 2560x1440` and `5120x2880 -> 2560x1440`. These paths bypass the
+general axis mapper but keep the same half-pixel bilinear samples and rounding,
+so I420 and NV12 slices remain byte-exact with the reference scaler.

--- a/docs/CORTEX_M_SCALER_BENCHMARKS.md
+++ b/docs/CORTEX_M_SCALER_BENCHMARKS.md
@@ -7,8 +7,9 @@ are not confused with emulator behavior.
 ## Scope
 
 The benchmark firmware in `tests/qemu_scaler_bench.c` exercises
-`sh264e_resize_make_slice` on a deterministic 1280x720 NV12 source. Each run
-generates `BENCH_ITERS` encoder slices and writes:
+`sh264e_resize_make_slice` on a deterministic 1280x720 NV12 source. That
+geometry uses the exact 2x scaler fast path. Each run generates `BENCH_ITERS`
+encoder slices and writes:
 
 * `sh264e_bench_checksum` - nonzero correctness guard for the generated slices.
 * `sh264e_bench_cycles` - DWT cycle count around the resize loop.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -299,6 +299,10 @@ Source sample indices are clamped at image boundaries.
 
 The library scaler implementation must use fixed-point integer arithmetic for coordinate mapping and bilinear interpolation. The inner pixel loops should avoid division so the path remains suitable for ARM Cortex-M class CPUs.
 
+Exact `2x` and `0.5x` source-to-target ratios may use specialized coordinate
+paths that avoid the general mapper. These paths must remain byte-exact with
+the half-pixel bilinear formula above for both I420 and NV12 output.
+
 When compiled for ARM cores with the DSP extension, the bilinear horizontal blend may use `smlad`/DSP intrinsics or inline assembly behind a compile-time guard. Defining `SH264E_DISABLE_ARM_DSP` must force the portable C path.
 
 ### Cortex-M Optimization Policy
@@ -718,6 +722,7 @@ Validate:
 
 * 1:1 resize reports zero work-buffer bytes and bypasses copy
 * Scaled resize reports non-zero work-buffer bytes and emits encoder-sized slices
+* Exact 2x and 0.5x resize paths match the general half-pixel bilinear reference for I420 and NV12
 * Invalid resize dimensions fail
 * Cortex-M3/M4/M7 QEMU scaler smoke tests pass when the ARM bare-metal toolchain and QEMU are available
 * Cortex-M4 QEMU scaler benchmark firmware passes correctness checks

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -684,6 +684,51 @@ static uint8_t bilinear_sample_nv12_chroma_mapped(const uint8_t *src,
                              sy.fraction);
 }
 
+static int exact_scale_ratio_mode(uint32_t src_width,
+                                  uint32_t src_height,
+                                  uint32_t dst_width,
+                                  uint32_t dst_height)
+{
+    if (src_width * 2u == dst_width && src_height * 2u == dst_height) {
+        return 1;
+    }
+    if (src_width == dst_width * 2u && src_height == dst_height * 2u) {
+        return 2;
+    }
+    return 0;
+}
+
+static sh264e_scale_coord_t exact_scale_coord(int mode,
+                                              uint32_t dst_pos,
+                                              uint32_t dst_size,
+                                              uint32_t src_size)
+{
+    sh264e_scale_coord_t coord;
+
+    if (mode == 1) {
+        uint32_t raw_quarters;
+
+        if (dst_pos == 0u) {
+            coord.index = 0u;
+            coord.fraction = 0u;
+            return coord;
+        }
+        if (dst_pos + 1u >= dst_size) {
+            coord.index = src_size - 1u;
+            coord.fraction = 0u;
+            return coord;
+        }
+        raw_quarters = dst_pos * 2u - 1u;
+        coord.index = raw_quarters >> 2u;
+        coord.fraction = (raw_quarters & 3u) * (SH264E_SCALE_FP_ONE / 4u);
+        return coord;
+    }
+
+    coord.index = dst_pos * 2u;
+    coord.fraction = SH264E_SCALE_FP_HALF;
+    return coord;
+}
+
 static void jpeg_fill_i420_neutral_chroma(uint8_t *dst_u, uint8_t *dst_v)
 {
     memset(dst_u, 128, (size_t)SH264E_CHROMA_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT);
@@ -1327,21 +1372,31 @@ static void resize_scale_plane_slice(const uint8_t *src,
                                      uint32_t dst_rows,
                                      ptrdiff_t dst_stride)
 {
+    const int exact_mode = exact_scale_ratio_mode(src_width, src_height, dst_width, dst_height);
     sh264e_axis_mapper_t y_mapper = scale_axis_mapper_init(src_height, dst_height, dst_y_start);
     uint32_t y;
 
     for (y = 0; y < dst_rows; y++) {
         uint8_t *dst_row = dst + (size_t)y * (size_t)dst_stride;
-        const sh264e_scale_coord_t sy = scale_coord_from_raw(y_mapper.pos, src_height);
+        const uint32_t dst_y = dst_y_start + y;
+        const sh264e_scale_coord_t sy = exact_mode != 0 ?
+                                        exact_scale_coord(exact_mode, dst_y, dst_height, src_height) :
+                                        scale_coord_from_raw(y_mapper.pos, src_height);
         sh264e_axis_mapper_t x_mapper = scale_axis_mapper_init(src_width, dst_width, 0u);
         uint32_t x;
 
         for (x = 0; x < dst_width; x++) {
-            const sh264e_scale_coord_t sx = scale_coord_from_raw(x_mapper.pos, src_width);
+            const sh264e_scale_coord_t sx = exact_mode != 0 ?
+                                            exact_scale_coord(exact_mode, x, dst_width, src_width) :
+                                            scale_coord_from_raw(x_mapper.pos, src_width);
             dst_row[x] = bilinear_sample_plane_mapped(src, src_width, src_height, src_stride, sx, sy);
-            scale_axis_mapper_advance(&x_mapper);
+            if (exact_mode == 0) {
+                scale_axis_mapper_advance(&x_mapper);
+            }
         }
-        scale_axis_mapper_advance(&y_mapper);
+        if (exact_mode == 0) {
+            scale_axis_mapper_advance(&y_mapper);
+        }
     }
 }
 
@@ -1352,6 +1407,10 @@ static void resize_scale_nv12_chroma_slice(const uint8_t *src_uv,
                                            uint8_t *dst_uv,
                                            uint32_t dst_y_start)
 {
+    const int exact_mode = exact_scale_ratio_mode(src_chroma_width,
+                                                 src_chroma_height,
+                                                 SH264E_CHROMA_WIDTH,
+                                                 SH264E_V1_HEIGHT / 2u);
     sh264e_axis_mapper_t y_mapper = scale_axis_mapper_init(src_chroma_height,
                                                            SH264E_V1_HEIGHT / 2u,
                                                            dst_y_start);
@@ -1359,12 +1418,23 @@ static void resize_scale_nv12_chroma_slice(const uint8_t *src_uv,
 
     for (y = 0; y < SH264E_V1_SLICE_CHROMA_HEIGHT; y++) {
         uint8_t *dst_row = dst_uv + (size_t)y * SH264E_V1_WIDTH;
-        const sh264e_scale_coord_t sy = scale_coord_from_raw(y_mapper.pos, src_chroma_height);
+        const uint32_t dst_y = dst_y_start + y;
+        const sh264e_scale_coord_t sy = exact_mode != 0 ?
+                                        exact_scale_coord(exact_mode,
+                                                          dst_y,
+                                                          SH264E_V1_HEIGHT / 2u,
+                                                          src_chroma_height) :
+                                        scale_coord_from_raw(y_mapper.pos, src_chroma_height);
         sh264e_axis_mapper_t x_mapper = scale_axis_mapper_init(src_chroma_width, SH264E_CHROMA_WIDTH, 0u);
         uint32_t x;
 
         for (x = 0; x < SH264E_CHROMA_WIDTH; x++) {
-            const sh264e_scale_coord_t sx = scale_coord_from_raw(x_mapper.pos, src_chroma_width);
+            const sh264e_scale_coord_t sx = exact_mode != 0 ?
+                                            exact_scale_coord(exact_mode,
+                                                              x,
+                                                              SH264E_CHROMA_WIDTH,
+                                                              src_chroma_width) :
+                                            scale_coord_from_raw(x_mapper.pos, src_chroma_width);
             dst_row[(size_t)x * 2u] = bilinear_sample_nv12_chroma_mapped(src_uv,
                                                                          src_chroma_width,
                                                                          src_chroma_height,
@@ -1379,9 +1449,13 @@ static void resize_scale_nv12_chroma_slice(const uint8_t *src_uv,
                                                                               1u,
                                                                               sx,
                                                                               sy);
-            scale_axis_mapper_advance(&x_mapper);
+            if (exact_mode == 0) {
+                scale_axis_mapper_advance(&x_mapper);
+            }
         }
-        scale_axis_mapper_advance(&y_mapper);
+        if (exact_mode == 0) {
+            scale_axis_mapper_advance(&y_mapper);
+        }
     }
 }
 

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -4,6 +4,16 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define TEST_SCALE_FP_BITS 16u
+#define TEST_SCALE_FP_ONE (1u << TEST_SCALE_FP_BITS)
+#define TEST_SCALE_FP_HALF (TEST_SCALE_FP_ONE >> 1u)
+#define TEST_SCALE_FP_BLEND_ROUND ((uint64_t)1u << ((TEST_SCALE_FP_BITS * 2u) - 1u))
+
+typedef struct test_scale_coord_t {
+    uint32_t index;
+    uint32_t fraction;
+} test_scale_coord_t;
+
 static int expect_status(const char *name, sh264e_status_t got, sh264e_status_t expected)
 {
     if (got != expected) {
@@ -229,6 +239,266 @@ static void fill_i420_sized(uint8_t *buf, uint32_t width, uint32_t height)
     }
     memset(buf + y_size, 96, c_size);
     memset(buf + y_size + c_size, 176, c_size);
+}
+
+static void fill_nv12_sized(uint8_t *buf, uint32_t width, uint32_t height)
+{
+    const size_t y_size = (size_t)width * height;
+    uint32_t y;
+    uint32_t x;
+
+    for (y = 0; y < height; y++) {
+        uint8_t *row = buf + (size_t)y * width;
+        for (x = 0; x < width; x++) {
+            row[x] = (uint8_t)((x * 7u + y * 11u) & 0xffu);
+        }
+    }
+    for (y = 0; y < height / 2u; y++) {
+        uint8_t *row = buf + y_size + (size_t)y * width;
+        for (x = 0; x < width / 2u; x++) {
+            row[(size_t)x * 2u] = (uint8_t)(64u + ((x * 5u + y * 3u) & 63u));
+            row[(size_t)x * 2u + 1u] = (uint8_t)(144u + ((x * 9u + y * 7u) & 63u));
+        }
+    }
+}
+
+static test_scale_coord_t test_scale_coord(uint32_t src_size, uint32_t dst_size, uint32_t dst_pos)
+{
+    const uint64_t denom = (uint64_t)dst_size * 2u;
+    const uint64_t pos_num = (uint64_t)(2u * dst_pos + 1u) *
+                             (uint64_t)src_size *
+                             (uint64_t)TEST_SCALE_FP_ONE;
+    const int64_t raw_pos = (int64_t)(pos_num / denom) - (int64_t)TEST_SCALE_FP_HALF;
+    const uint64_t max_pos = (uint64_t)(src_size - 1u) * (uint64_t)TEST_SCALE_FP_ONE;
+    test_scale_coord_t coord;
+
+    if (raw_pos <= 0) {
+        coord.index = 0u;
+        coord.fraction = 0u;
+        return coord;
+    }
+    if ((uint64_t)raw_pos >= max_pos) {
+        coord.index = src_size - 1u;
+        coord.fraction = 0u;
+        return coord;
+    }
+    coord.index = (uint32_t)((uint64_t)raw_pos >> TEST_SCALE_FP_BITS);
+    coord.fraction = (uint32_t)((uint64_t)raw_pos & (uint64_t)(TEST_SCALE_FP_ONE - 1u));
+    return coord;
+}
+
+static uint8_t test_bilinear_blend_u8(uint8_t p00,
+                                      uint8_t p01,
+                                      uint8_t p10,
+                                      uint8_t p11,
+                                      uint32_t wx,
+                                      uint32_t wy)
+{
+    const uint32_t inv_wx = TEST_SCALE_FP_ONE - wx;
+    const uint32_t inv_wy = TEST_SCALE_FP_ONE - wy;
+    const uint64_t top = (uint64_t)p00 * inv_wx + (uint64_t)p01 * wx;
+    const uint64_t bottom = (uint64_t)p10 * inv_wx + (uint64_t)p11 * wx;
+    const uint64_t blended = top * inv_wy + bottom * wy;
+
+    return (uint8_t)((blended + TEST_SCALE_FP_BLEND_ROUND) >> (TEST_SCALE_FP_BITS * 2u));
+}
+
+static void reference_scale_plane_slice(const uint8_t *src,
+                                        uint32_t src_width,
+                                        uint32_t src_height,
+                                        ptrdiff_t src_stride,
+                                        uint8_t *dst,
+                                        uint32_t dst_width,
+                                        uint32_t dst_height,
+                                        uint32_t dst_y_start,
+                                        uint32_t dst_rows,
+                                        ptrdiff_t dst_stride)
+{
+    uint32_t y;
+
+    for (y = 0; y < dst_rows; y++) {
+        const test_scale_coord_t sy = test_scale_coord(src_height, dst_height, dst_y_start + y);
+        const uint32_t y0 = sy.index;
+        const uint32_t y1 = y0 + 1u < src_height ? y0 + 1u : y0;
+        const uint8_t *row0 = src + (size_t)y0 * (size_t)src_stride;
+        const uint8_t *row1 = src + (size_t)y1 * (size_t)src_stride;
+        uint8_t *dst_row = dst + (size_t)y * (size_t)dst_stride;
+        uint32_t x;
+
+        for (x = 0; x < dst_width; x++) {
+            const test_scale_coord_t sx = test_scale_coord(src_width, dst_width, x);
+            const uint32_t x0 = sx.index;
+            const uint32_t x1 = x0 + 1u < src_width ? x0 + 1u : x0;
+
+            dst_row[x] = test_bilinear_blend_u8(row0[x0], row0[x1],
+                                                row1[x0], row1[x1],
+                                                sx.fraction, sy.fraction);
+        }
+    }
+}
+
+static void reference_scale_nv12_chroma_slice(const uint8_t *src_uv,
+                                              uint32_t src_chroma_width,
+                                              uint32_t src_chroma_height,
+                                              ptrdiff_t src_stride,
+                                              uint8_t *dst_uv,
+                                              uint32_t dst_y_start)
+{
+    uint32_t y;
+
+    for (y = 0; y < SH264E_V1_SLICE_CHROMA_HEIGHT; y++) {
+        const test_scale_coord_t sy = test_scale_coord(src_chroma_height,
+                                                       SH264E_V1_HEIGHT / 2u,
+                                                       dst_y_start + y);
+        const uint32_t y0 = sy.index;
+        const uint32_t y1 = y0 + 1u < src_chroma_height ? y0 + 1u : y0;
+        const uint8_t *row0 = src_uv + (size_t)y0 * (size_t)src_stride;
+        const uint8_t *row1 = src_uv + (size_t)y1 * (size_t)src_stride;
+        uint8_t *dst_row = dst_uv + (size_t)y * SH264E_V1_WIDTH;
+        uint32_t x;
+
+        for (x = 0; x < SH264E_V1_WIDTH / 2u; x++) {
+            const test_scale_coord_t sx = test_scale_coord(src_chroma_width,
+                                                           SH264E_V1_WIDTH / 2u,
+                                                           x);
+            const uint32_t x0 = sx.index;
+            const uint32_t x1 = x0 + 1u < src_chroma_width ? x0 + 1u : x0;
+
+            dst_row[(size_t)x * 2u] =
+                test_bilinear_blend_u8(row0[(size_t)x0 * 2u],
+                                       row0[(size_t)x1 * 2u],
+                                       row1[(size_t)x0 * 2u],
+                                       row1[(size_t)x1 * 2u],
+                                       sx.fraction,
+                                       sy.fraction);
+            dst_row[(size_t)x * 2u + 1u] =
+                test_bilinear_blend_u8(row0[(size_t)x0 * 2u + 1u],
+                                       row0[(size_t)x1 * 2u + 1u],
+                                       row1[(size_t)x0 * 2u + 1u],
+                                       row1[(size_t)x1 * 2u + 1u],
+                                       sx.fraction,
+                                       sy.fraction);
+        }
+    }
+}
+
+static int expect_resize_reference_slice(const char *name,
+                                         uint32_t width,
+                                         uint32_t height,
+                                         sh264e_pixfmt_t pixfmt,
+                                         unsigned slice_index)
+{
+    const size_t src_size = (size_t)width * height * 3u / 2u;
+    const size_t dst_y_size = (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_LUMA_HEIGHT;
+    const size_t dst_c_size = (size_t)(SH264E_V1_WIDTH / 2u) * SH264E_V1_SLICE_CHROMA_HEIGHT;
+    const size_t dst_uv_size = (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT;
+    uint8_t *src = (uint8_t *)malloc(src_size);
+    uint8_t *work = NULL;
+    uint8_t *expected = NULL;
+    sh264e_frame_t frame;
+    sh264e_slice_t slice;
+    size_t work_size = 0u;
+    int ok = 1;
+
+    if (src == NULL) {
+        fprintf(stderr, "%s: source allocation failed\n", name);
+        return 0;
+    }
+    if (pixfmt == SH264E_PIXFMT_I420) {
+        fill_i420_sized(src, width, height);
+    } else {
+        fill_nv12_sized(src, width, height);
+    }
+
+    memset(&frame, 0, sizeof(frame));
+    frame.width = width;
+    frame.height = height;
+    frame.pixfmt = pixfmt;
+    frame.plane[0] = src;
+    frame.stride[0] = width;
+    if (pixfmt == SH264E_PIXFMT_I420) {
+        const size_t y_size = (size_t)width * height;
+        const size_t c_size = (size_t)(width / 2u) * (height / 2u);
+
+        frame.plane[1] = src + y_size;
+        frame.plane[2] = src + y_size + c_size;
+        frame.stride[1] = width / 2u;
+        frame.stride[2] = width / 2u;
+    } else {
+        frame.plane[1] = src + (size_t)width * height;
+        frame.stride[1] = width;
+    }
+
+    if (!expect_status(name, sh264e_resize_get_slice_buffer_size(&frame, &work_size), SH264E_OK)) {
+        free(src);
+        return 0;
+    }
+    work = (uint8_t *)malloc(work_size);
+    expected = (uint8_t *)malloc(work_size);
+    if (work == NULL || expected == NULL) {
+        fprintf(stderr, "%s: work allocation failed\n", name);
+        free(src);
+        free(work);
+        free(expected);
+        return 0;
+    }
+    memset(work, 0xa5, work_size);
+    memset(expected, 0x5a, work_size);
+
+    if (!expect_status(name,
+                       sh264e_resize_make_slice(&frame, slice_index, work, work_size, &slice),
+                       SH264E_OK)) {
+        ok = 0;
+    }
+    if (ok && slice.plane[0] != work) {
+        fprintf(stderr, "%s: scaled output did not use work buffer\n", name);
+        ok = 0;
+    }
+
+    if (ok) {
+        reference_scale_plane_slice(frame.plane[0], width, height, frame.stride[0],
+                                    expected, SH264E_V1_WIDTH, SH264E_V1_HEIGHT,
+                                    slice_index * SH264E_V1_SLICE_LUMA_HEIGHT,
+                                    SH264E_V1_SLICE_LUMA_HEIGHT, SH264E_V1_WIDTH);
+        if (memcmp(slice.plane[0], expected, dst_y_size) != 0) {
+            fprintf(stderr, "%s: luma output differs from reference scaler\n", name);
+            ok = 0;
+        }
+    }
+
+    if (ok && pixfmt == SH264E_PIXFMT_I420) {
+        uint8_t *expected_u = expected + dst_y_size;
+        uint8_t *expected_v = expected_u + dst_c_size;
+
+        reference_scale_plane_slice(frame.plane[1], width / 2u, height / 2u, frame.stride[1],
+                                    expected_u, SH264E_V1_WIDTH / 2u, SH264E_V1_HEIGHT / 2u,
+                                    slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                    SH264E_V1_SLICE_CHROMA_HEIGHT, SH264E_V1_WIDTH / 2u);
+        reference_scale_plane_slice(frame.plane[2], width / 2u, height / 2u, frame.stride[2],
+                                    expected_v, SH264E_V1_WIDTH / 2u, SH264E_V1_HEIGHT / 2u,
+                                    slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT,
+                                    SH264E_V1_SLICE_CHROMA_HEIGHT, SH264E_V1_WIDTH / 2u);
+        if (memcmp(slice.plane[1], expected_u, dst_c_size) != 0 ||
+            memcmp(slice.plane[2], expected_v, dst_c_size) != 0) {
+            fprintf(stderr, "%s: I420 chroma output differs from reference scaler\n", name);
+            ok = 0;
+        }
+    } else if (ok) {
+        uint8_t *expected_uv = expected + dst_y_size;
+
+        reference_scale_nv12_chroma_slice(frame.plane[1], width / 2u, height / 2u,
+                                          frame.stride[1], expected_uv,
+                                          slice_index * SH264E_V1_SLICE_CHROMA_HEIGHT);
+        if (memcmp(slice.plane[1], expected_uv, dst_uv_size) != 0) {
+            fprintf(stderr, "%s: NV12 chroma output differs from reference scaler\n", name);
+            ok = 0;
+        }
+    }
+
+    free(src);
+    free(work);
+    free(expected);
+    return ok;
 }
 
 static void make_i420_slice(const uint8_t *input, unsigned slice_index, sh264e_slice_t *slice)
@@ -536,6 +806,17 @@ int main(void)
                                 SH264E_ERR_UNSUPPORTED_CONFIG);
         }
     }
+
+    ok &= expect_resize_reference_slice("2x I420 resize reference",
+                                        1280u, 720u, SH264E_PIXFMT_I420, 0u);
+    ok &= expect_resize_reference_slice("2x NV12 resize reference",
+                                        1280u, 720u, SH264E_PIXFMT_NV12,
+                                        SH264E_V1_SLICE_COUNT - 1u);
+    ok &= expect_resize_reference_slice("0.5x I420 resize reference",
+                                        5120u, 2880u, SH264E_PIXFMT_I420, 37u);
+    ok &= expect_resize_reference_slice("0.5x NV12 resize reference",
+                                        5120u, 2880u, SH264E_PIXFMT_NV12,
+                                        SH264E_V1_SLICE_COUNT - 1u);
 
     memset(&frame, 0, sizeof(frame));
     frame.width = SH264E_V1_WIDTH;


### PR DESCRIPTION
## Summary

- Add exact fixed-ratio scaler coordinate paths for `1280x720 -> 2560x1440` and `5120x2880 -> 2560x1440`.
- Cover both I420 and NV12 through the raw resize API while preserving existing 1:1 bypass behavior and work-buffer sizing.
- Add API regression checks that compare 2x and 0.5x output slices against an independent half-pixel bilinear reference.
- Update README/SPEC/Cortex-M docs to describe the exact fast paths and benchmark scope.

Refs #78

## Validation

- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- `cmake -S . -B build-qemu -DSH264E_BUILD_QEMU_TESTS=ON`
- `cmake --build build-qemu`
- `ctest --test-dir build-qemu -R 'sh264e_qemu_scaler' --output-on-failure`
- `git diff --check`

## Notes

The local ARM GCC installation is incomplete: CMake reports `Skipping QEMU firmware tests: arm-none-eabi-gcc cannot compile <stdlib.h>`, so no QEMU firmware tests are generated in this environment. The QEMU build path skips cleanly as designed.
