### PR TITLE
h264: rewrite bit writer accumulator

### DIFF
--- a/docs/CORTEX_M_OPTIMIZATION_PLAN.md
+++ b/docs/CORTEX_M_OPTIMIZATION_PLAN.md
@@ -103,3 +103,11 @@ The raw resize API includes exact fixed-ratio fast paths for
 `1280x720 -> 2560x1440` and `5120x2880 -> 2560x1440`. These paths bypass the
 general axis mapper but keep the same half-pixel bilinear samples and rounding,
 so I420 and NV12 slices remain byte-exact with the reference scaler.
+
+## H.264 Bit-Writer Status
+
+The H.264 RBSP writer uses a byte-oriented pending-byte accumulator. Aligned
+8-bit writes bypass the old per-bit loop, while unaligned Exp-Golomb, CAVLC,
+and RBSP trailing-bit writes still preserve the same MSB-first bit order and
+byte output. The change keeps the one-macroblock RBSP scratch size unchanged so
+downstream Annex B batching can focus on output streaming overhead.

--- a/docs/ENCODER_MEMORY_REPORT.md
+++ b/docs/ENCODER_MEMORY_REPORT.md
@@ -67,6 +67,9 @@ Future Cortex-M optimization issues are tracked in
 size, bitstream scratch size, or reported sub-block composition must update this
 report, the public diagnostic output, and the regression tests in the same
 change. Cortex-M fast paths should not add persistent encoder SRAM by default.
+The byte-oriented bit-writer accumulator is internal writer state and does not
+change the `256` byte RBSP scratch block, encoder arena size, or reported
+`296` byte total.
 
 The JPEG tool prints the same report:
 

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -41,7 +41,8 @@ typedef struct sh264e_bit_writer_t {
     uint8_t *data;
     size_t capacity;
     size_t byte_pos;
-    unsigned bit_pos;
+    uint8_t pending_byte;
+    unsigned pending_bits;
     int error;
 } sh264e_bit_writer_t;
 
@@ -1543,43 +1544,77 @@ static void bw_init(sh264e_bit_writer_t *bw, uint8_t *data, size_t capacity)
     bw->data = data;
     bw->capacity = capacity;
     bw->byte_pos = 0;
-    bw->bit_pos = 0;
+    bw->pending_byte = 0;
+    bw->pending_bits = 0;
     bw->error = 0;
 }
 
 static size_t bw_size(const sh264e_bit_writer_t *bw)
 {
-    return bw->byte_pos + (bw->bit_pos != 0u ? 1u : 0u);
+    return bw->byte_pos + (bw->pending_bits != 0u ? 1u : 0u);
 }
 
-static void bw_write_bit(sh264e_bit_writer_t *bw, unsigned bit)
+static void bw_store_pending(sh264e_bit_writer_t *bw)
 {
-    if (bw->error != 0) {
-        return;
-    }
     if (bw->byte_pos >= bw->capacity) {
         bw->error = 1;
         return;
     }
-    if (bw->bit_pos == 0u) {
-        bw->data[bw->byte_pos] = 0;
+    bw->data[bw->byte_pos] = bw->pending_byte;
+}
+
+static void bw_commit_pending_byte(sh264e_bit_writer_t *bw)
+{
+    bw_store_pending(bw);
+    if (bw->error != 0) {
+        return;
     }
-    if ((bit & 1u) != 0u) {
-        bw->data[bw->byte_pos] |= (uint8_t)(1u << (7u - bw->bit_pos));
+    bw->byte_pos++;
+    bw->pending_byte = 0;
+    bw->pending_bits = 0;
+}
+
+static void bw_write_aligned_byte(sh264e_bit_writer_t *bw, uint8_t value)
+{
+    if (bw->byte_pos >= bw->capacity) {
+        bw->error = 1;
+        return;
     }
-    bw->bit_pos++;
-    if (bw->bit_pos == 8u) {
-        bw->bit_pos = 0;
-        bw->byte_pos++;
-    }
+    bw->data[bw->byte_pos++] = value;
+}
+
+static void bw_write_bits(sh264e_bit_writer_t *bw, uint32_t bits, unsigned count);
+
+static void bw_write_bit(sh264e_bit_writer_t *bw, unsigned bit)
+{
+    bw_write_bits(bw, bit & 1u, 1u);
 }
 
 static void bw_write_bits(sh264e_bit_writer_t *bw, uint32_t bits, unsigned count)
 {
-    unsigned i;
-    for (i = 0; i < count; i++) {
-        const unsigned shift = count - 1u - i;
-        bw_write_bit(bw, (bits >> shift) & 1u);
+    while (count > 0u && bw->error == 0) {
+        if (bw->pending_bits == 0u && count >= 8u) {
+            const unsigned shift = count - 8u;
+            bw_write_aligned_byte(bw, (uint8_t)((bits >> shift) & 0xffu));
+            count -= 8u;
+        } else {
+            const unsigned free_bits = 8u - bw->pending_bits;
+            const unsigned take = count < free_bits ? count : free_bits;
+            const unsigned shift = count - take;
+            const uint32_t mask = (1u << take) - 1u;
+            const uint8_t chunk = (uint8_t)((bits >> shift) & mask);
+
+            bw->pending_byte |= (uint8_t)(chunk << (free_bits - take));
+            bw->pending_bits += take;
+            bw_store_pending(bw);
+            if (bw->error != 0) {
+                return;
+            }
+            count -= take;
+            if (bw->pending_bits == 8u) {
+                bw_commit_pending_byte(bw);
+            }
+        }
     }
 }
 
@@ -1619,7 +1654,7 @@ static void bw_write_se(sh264e_bit_writer_t *bw, int32_t value)
 static void bw_rbsp_trailing_bits(sh264e_bit_writer_t *bw)
 {
     bw_write_bit(bw, 1);
-    while (bw->bit_pos != 0u) {
+    while (bw->pending_bits != 0u) {
         bw_write_bit(bw, 0);
     }
 }


### PR DESCRIPTION
## Summary

- Replace the RBSP bit writer's per-bit byte updates with a byte-oriented pending-byte accumulator.
- Let aligned 8-bit writes bypass the bit loop while preserving MSB-first ordering for Exp-Golomb, CAVLC, and RBSP trailing bits.
- Keep public APIs, output semantics, RBSP scratch size, and encoder arena sizing unchanged.
- Update Cortex-M optimization and encoder memory docs for the new bit-writer status.

Refs #76

## Validation

- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- Byte-identity comparison against `origin/main` for progressive I420 and NV12 outputs generated from the same integration inputs.
- `ffmpeg -v error -xerror -i build/integration/output_i420_progressive.h264 -f null -`
- `cmake -S . -B build-qemu -DSH264E_BUILD_QEMU_TESTS=ON`
- `cmake --build build-qemu`
- `ctest --test-dir build-qemu -R 'qemu.*encoder' --output-on-failure`
- `git diff --check`

## Notes

The local ARM GCC installation is incomplete: CMake reports `Skipping QEMU firmware tests: arm-none-eabi-gcc cannot compile <stdlib.h>`, so no QEMU firmware tests are generated in this environment. The QEMU build path skips cleanly as designed.
