### PR TITLE
Cortex-M: allow zero QEMU encoder DWT cycles

### DIFF
--- a/tests/qemu_encoder_bench.c
+++ b/tests/qemu_encoder_bench.c
@@ -176,7 +176,7 @@ static int run_benchmark(void)
     }
     sh264e_bench_checksum = checksum;
 
-    if (checksum != EXPECTED_CHECKSUM || sh264e_bench_cycles == 0u) {
+    if (checksum != EXPECTED_CHECKSUM) {
         return 9;
     }
     return 0;


### PR DESCRIPTION
Refs #88

## Summary
- Keep exporting `sh264e_bench_cycles = dwt_stop()` from the encoder benchmark firmware.
- Stop treating `sh264e_bench_cycles == 0` as a QEMU benchmark failure.
- Preserve deterministic failure on checksum mismatch via the existing expected checksum guard.

## Validation
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build -R 'sh264e_qemu_encoder_bench' --output-on-failure` returned no tests because this local configure skipped QEMU firmware: `arm-none-eabi-gcc` cannot compile `<stdlib.h>`.
- `ctest --test-dir build --output-on-failure`
- `cmake -S . -B build-qemu -DSH264E_BUILD_QEMU_TESTS=ON` also skipped QEMU firmware for the same local ARM toolchain issue.
- `cmake --build build-qemu`
- `ctest --test-dir build-qemu -R 'qemu|sh264e_qemu' --output-on-failure` returned no tests after the documented skip.
- `git diff --check`
