### PR TITLE
[codex] h264: optimize Exp-Golomb bit writes

### DIFF
--- a/docs/CORTEX_M_OPTIMIZATION_PLAN.md
+++ b/docs/CORTEX_M_OPTIMIZATION_PLAN.md
@@ -128,7 +128,9 @@ real-board DWT timing is still required before making cycle-speed claims.
 ## H.264 Bit-Writer Status
 
 The H.264 RBSP writer uses a byte-oriented pending-byte accumulator. Aligned
-8-bit writes bypass the old per-bit loop, while unaligned Exp-Golomb, CAVLC,
-and RBSP trailing-bit writes still preserve the same MSB-first bit order and
-byte output. The change keeps the one-macroblock RBSP scratch size unchanged so
-downstream Annex B batching can focus on output streaming overhead.
+8-bit writes bypass the old per-bit loop, and Exp-Golomb writes use CLZ-backed
+length calculation with a portable fallback plus batched zero-run writes.
+Unaligned CAVLC and RBSP trailing-bit writes still preserve the same MSB-first
+bit order and byte output. The change keeps the one-macroblock RBSP scratch
+size unchanged so downstream Annex B batching can focus on output streaming
+overhead.

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -38,6 +38,23 @@
 #define SH264E_USE_ARM_DSP 1
 #endif
 
+static unsigned sh264e_u32_floor_log2(uint32_t value)
+{
+    if (value == 0u) {
+        return 0u;
+    }
+#if (defined(__GNUC__) || defined(__clang__)) && UINT_MAX == 0xffffffffu
+    return 31u - (unsigned)__builtin_clz(value);
+#else
+    unsigned bits = 0u;
+    while (value > 1u) {
+        value >>= 1u;
+        bits++;
+    }
+    return bits;
+#endif
+}
+
 typedef struct sh264e_bit_writer_t {
     uint8_t *data;
     size_t capacity;
@@ -1709,25 +1726,20 @@ static void bw_write_bits(sh264e_bit_writer_t *bw, uint32_t bits, unsigned count
     }
 }
 
+static void bw_write_zero_bits(sh264e_bit_writer_t *bw, unsigned count)
+{
+    while (count > 0u && bw->error == 0) {
+        const unsigned take = count > 32u ? 32u : count;
+        bw_write_bits(bw, 0u, take);
+        count -= take;
+    }
+}
+
 static void bw_write_ue(sh264e_bit_writer_t *bw, uint32_t value)
 {
-    uint32_t code_num = value + 1u;
-    unsigned leading_zero_bits = 0;
-    uint32_t tmp = code_num;
-    while (tmp > 1u) {
-        tmp >>= 1u;
-        leading_zero_bits++;
-    }
-    while (leading_zero_bits > 0u) {
-        bw_write_bit(bw, 0);
-        leading_zero_bits--;
-    }
-    tmp = code_num;
-    leading_zero_bits = 0;
-    while (tmp > 1u) {
-        tmp >>= 1u;
-        leading_zero_bits++;
-    }
+    const uint32_t code_num = value + 1u;
+    const unsigned leading_zero_bits = sh264e_u32_floor_log2(code_num);
+    bw_write_zero_bits(bw, leading_zero_bits);
     bw_write_bits(bw, code_num, leading_zero_bits + 1u);
 }
 
@@ -1745,8 +1757,8 @@ static void bw_write_se(sh264e_bit_writer_t *bw, int32_t value)
 static void bw_rbsp_trailing_bits(sh264e_bit_writer_t *bw)
 {
     bw_write_bit(bw, 1);
-    while (bw->pending_bits != 0u) {
-        bw_write_bit(bw, 0);
+    if (bw->pending_bits != 0u) {
+        bw_write_zero_bits(bw, 8u - bw->pending_bits);
     }
 }
 
@@ -2278,7 +2290,6 @@ static int write_cavlc_level(sh264e_bit_writer_t *bw, int level)
     unsigned prefix;
     unsigned suffix_size = 0u;
     uint32_t suffix = 0u;
-    unsigned i;
 
     if (target < 14u) {
         prefix = (unsigned)target;
@@ -2294,9 +2305,7 @@ static int write_cavlc_level(sh264e_bit_writer_t *bw, int level)
         return 0;
     }
 
-    for (i = 0; i < prefix; i++) {
-        bw_write_bit(bw, 0);
-    }
+    bw_write_zero_bits(bw, prefix);
     bw_write_bit(bw, 1);
     if (suffix_size > 0u) {
         bw_write_bits(bw, suffix, suffix_size);


### PR DESCRIPTION
Refs #94

## Summary
- Replaced duplicated Exp-Golomb leading-zero loops with a CLZ-backed `uint32_t` floor-log2 helper and portable fallback.
- Added a bit-writer zero-run helper and reused it for Exp-Golomb prefixes, RBSP trailing padding, and CAVLC level prefixes.
- Updated the Cortex-M optimization status note to reflect the CLZ/zero-run bit-writer path.
- Kept public APIs and persistent encoder state unchanged.

## Validation
- `cmake -S . -B build-issue94 -DCMAKE_BUILD_TYPE=Debug && cmake --build build-issue94 && ctest --test-dir build-issue94 --output-on-failure`
- Byte-identical output check against `origin/main` for a deterministic 2560x1440 I420 encode: both outputs were 1,171,371 bytes with SHA-256 `fdad6af5263ed18c9b53de924a8f26a825be2ecb4baceb12d6cb2c9cfeb3dc93`.
- `C_INCLUDE_PATH=/tmp/sh264e_arm_min_headers cmake -S . -B build-qemu-issue94 -DSH264E_BUILD_QEMU_TESTS=ON`
- `C_INCLUDE_PATH=/tmp/sh264e_arm_min_headers cmake --build build-qemu-issue94 --target sh264e_qemu_encoder_bench_m4 sh264e_qemu_encoder_bench_m4_portable sh264e_qemu_encoder_bench_m7 sh264e_qemu_encoder_bench_m7_portable`
- `ctest --test-dir build-qemu-issue94 -R 'sh264e_qemu_encoder_bench_(m4|m7)' --output-on-failure`
- `python3 tests/run_qemu_proxy_timing.py --build-dir build-qemu-issue94 --repeat 3 --target sh264e_qemu_encoder_bench_m4 --target sh264e_qemu_encoder_bench_m4_portable --target sh264e_qemu_encoder_bench_m7 --target sh264e_qemu_encoder_bench_m7_portable`
- `git diff --check`

## QEMU Proxy Timing Sample
Values are host/QEMU wall time only, not Cortex-M cycles.

| Target firmware | Variant | Repeats | Median wall time | Min wall time | Max wall time | Status |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| `sh264e_qemu_encoder_bench_m4` | DSP-capable | 3 | 0.041112s | 0.040978s | 0.041271s | pass |
| `sh264e_qemu_encoder_bench_m4_portable` | portable C | 3 | 0.046185s | 0.040739s | 0.046360s | pass |
| `sh264e_qemu_encoder_bench_m7` | DSP-capable | 3 | 0.042489s | 0.040737s | 0.050220s | pass |
| `sh264e_qemu_encoder_bench_m7_portable` | portable C | 3 | 0.042253s | 0.039361s | 0.042368s | pass |

## Notes
- The local Homebrew `arm-none-eabi-gcc` still lacks bundled C library headers, so QEMU firmware validation used the same temporary minimal declaration header path used for #92 while preserving the repo's freestanding `-nostdlib` firmware link.
