### PR TITLE
[codex] jpeg: use exact streaming resize paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,10 @@ callers that have not parsed their JPEG yet.
 used by the last JPEG encode. For `2560x1440` 4:2:0 source JPEGs, the 1:1 fast
 path reduces retained row cache to 61,440 bytes and requires 0 bytes of
 caller slice work for both I420 and NV12.
+For `1280x720` and `5120x2880` 4:2:0 source JPEGs, the streaming JPEG scaler
+uses the same exact 2x and 0.5x quarter-step paths as the raw resize API while
+still retaining only the rolling MCU-row cache plus one encoder slice work
+buffer.
 `sh264e_encoder_get_memory_report` reports the fixed-v1 encoder heap breakdown
 without creating an encoder; `docs/ENCODER_MEMORY_REPORT.md` records the current
 296-byte total and sub-block composition.

--- a/docs/CORTEX_M_OPTIMIZATION_PLAN.md
+++ b/docs/CORTEX_M_OPTIMIZATION_PLAN.md
@@ -119,6 +119,9 @@ The raw resize API includes exact fixed-ratio fast paths for
 `1280x720 -> 2560x1440` and `5120x2880 -> 2560x1440`. These paths bypass the
 general axis mapper but keep the same half-pixel bilinear samples and rounding,
 so I420 and NV12 slices remain byte-exact with the reference scaler.
+The JPEG MCU-row streaming path now uses the same exact-ratio quarter-step
+sampler for matching 2x and 0.5x source JPEGs while preserving the 1:1
+zero-slice-work path and rolling row-cache behavior.
 The exact-ratio blend now uses quarter-step integer weights. DSP-capable ARM
 builds use `smlad` for both horizontal pair sums and the final vertical pair sum
 in that exact path, while portable builds use the same 32-bit arithmetic.

--- a/docs/CORTEX_M_SCALER_BENCHMARKS.md
+++ b/docs/CORTEX_M_SCALER_BENCHMARKS.md
@@ -11,6 +11,10 @@ The benchmark firmware in `tests/qemu_scaler_bench.c` exercises
 geometry uses the exact 2x scaler fast path. Each run generates `BENCH_ITERS`
 encoder slices and writes:
 
+The JPEG MCU-row streaming path uses the same exact quarter-step sampler for
+matching 2x and 0.5x JPEG resize cases, but QEMU scaler firmware remains scoped
+to the raw resize API fixture so proxy timing rows stay comparable.
+
 * `sh264e_bench_checksum` - nonzero correctness guard for the generated slices.
 * `sh264e_bench_cycles` - DWT cycle count around the resize loop.
 

--- a/docs/JPEG_STREAMING_MEMORY_REPORT.md
+++ b/docs/JPEG_STREAMING_MEMORY_REPORT.md
@@ -12,9 +12,10 @@ from the earlier allocation report. The production measurements below are from
 
 | Source JPEG | Previous full component planes | Production arena work | Production peak allocation | Streaming row cache | Slice work buffer |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| 1280x720 4:2:0 | 1,382,400 | 92,304 | 92,160 | 61,440 | 61,440 |
+| 1280x720 4:2:0, exact 2x path | 1,382,400 | 92,304 | 92,160 | 61,440 | 61,440 |
 | 2560x1440 4:2:0, 1:1 fast path, I420 | 5,529,600 | 123,024 | 122,880 | 61,440 | 0 |
 | 2560x1440 4:2:0, 1:1 fast path, NV12 | 5,529,600 | 123,024 | 122,880 | 61,440 | 0 |
+| 5120x2880 4:2:0, exact 0.5x path | 22,118,400 | 491,664 | 491,520 | 368,640 | 61,440 |
 
 `Production peak allocation` now excludes the previous dynamic NanoJPEG VLC
 lookup block. NanoJPEG decodes DHT tables into compact canonical Huffman
@@ -40,7 +41,10 @@ For the `2560x1440` 4:2:0 1:1 row, the measured peak breaks down as:
 Issue #31 reduced production peak allocation below the 270 KiB target without
 regressing to full component-plane decode. Issue #49 then added the 1:1
 `2560x1440` 4:2:0 fast path, reducing that row cache to one MCU/slice row.
-Custom DHT baseline JPEGs remain supported.
+Issue #96 routes JPEG streaming scale work through the same exact fixed-ratio
+quarter-step sampler as the raw resize API for `1280x720 -> 2560x1440` and
+`5120x2880 -> 2560x1440`, while preserving the 1:1 zero-slice-work path. Custom
+DHT baseline JPEGs remain supported.
 
 For callers that do not yet know JPEG geometry, `sh264e_jpeg_get_slice_buffer_size`
 still returns the conservative 61,440-byte worst-case slice work capacity.
@@ -115,11 +119,12 @@ and arena alignment padding.
 
 `tests/run_ffmpeg_integration.py` asserts the exact production arena work,
 peak-allocation, row-cache, effective slice work, reusable output chunk, encoder
-memory report, path-specific slice work, source-input chunking, and one-shot
-output capacity values for representative JPEG fixtures. It also keeps broader
-color-subsampling coverage that fails if the production arena path regresses to
-full component-plane allocation or if the default JPEG tool path regresses to
-allocating `sh264e_get_max_output_size()` for H.264 output.
+memory report, path-specific slice work, source-input chunking, exact
+2x/0.5x JPEG scaler dispatch, and one-shot output capacity values for
+representative JPEG fixtures. It also keeps broader color-subsampling coverage
+that fails if the production arena path regresses to full component-plane
+allocation or if the default JPEG tool path regresses to allocating
+`sh264e_get_max_output_size()` for H.264 output.
 
 The source-input stress cases feed generated JPEGs through chunk limits of 1, 2,
 7, 64, and 1024 bytes. Those cases force marker parsing and entropy decode
@@ -161,13 +166,17 @@ build/sh264e_encode_jpeg --format i420 \
 build/sh264e_encode_jpeg --format i420 \
   build/integration/input_1440p_yuvj420p.jpg \
   build/issue21_default_1440_i420.h264
+
+build/sh264e_encode_jpeg --format i420 \
+  build/integration/input_2880p_yuvj420p.jpg \
+  build/issue96_default_2880_i420.h264
 ```
 
 Expected metric lines:
 
 ```text
 1280x720:
-jpeg output consumer chunks: 92
+jpeg output consumer chunks: 14402
 jpeg output chunk buffer bytes: 4096
 jpeg work arena bytes: 92304
 jpeg slice work bytes: 61440
@@ -177,13 +186,23 @@ jpeg streaming cache bytes: 61440
 jpeg output buffer bytes: 4096
 
 2560x1440:
-jpeg output consumer chunks: 92
+jpeg output consumer chunks: 14402
 jpeg output chunk buffer bytes: 4096
 jpeg work arena bytes: 123024
 jpeg slice work bytes: 0
 jpeg effective slice work bytes: 0
 jpeg peak allocation bytes: 122880
 jpeg streaming cache bytes: 61440
+jpeg output buffer bytes: 4096
+
+5120x2880:
+jpeg output consumer chunks: 14402
+jpeg output chunk buffer bytes: 4096
+jpeg work arena bytes: 491664
+jpeg slice work bytes: 61440
+jpeg effective slice work bytes: 61440
+jpeg peak allocation bytes: 491520
+jpeg streaming cache bytes: 368640
 jpeg output buffer bytes: 4096
 ```
 
@@ -214,5 +233,5 @@ build/sh264e_encode_jpeg --test-one-shot-output --format i420 \
 Expected one-shot output metric:
 
 ```text
-jpeg output buffer bytes: 11428864
+jpeg output buffer bytes: 5588224
 ```

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -302,6 +302,9 @@ The library scaler implementation must use fixed-point integer arithmetic for co
 Exact `2x` and `0.5x` source-to-target ratios may use specialized coordinate
 paths that avoid the general mapper. These paths must remain byte-exact with
 the half-pixel bilinear formula above for both I420 and NV12 output.
+The JPEG MCU-row streaming scaler must use the same exact-ratio coordinate and
+quarter-step blend path for matching `1280x720 -> 2560x1440` and
+`5120x2880 -> 2560x1440` inputs without decoding a full component frame.
 
 When compiled for ARM cores with the DSP extension, the bilinear horizontal
 blend may use `smlad`/DSP intrinsics or inline assembly behind a compile-time
@@ -485,6 +488,10 @@ For `2560x1440` 4:2:0 source JPEGs encoded to the fixed target, the JPEG path
 uses a 1:1 fast path. It skips bilinear scaling, keeps one MCU row per
 component, and feeds slices directly from the retained rows without a
 caller-provided slice-work buffer.
+For `1280x720` and `5120x2880` 4:2:0 source JPEGs encoded to the fixed target,
+the JPEG path uses exact 2x and 0.5x scaler paths from the retained MCU-row
+cache. It still emits one encoder-sized slice at a time and must not allocate a
+full decoded component frame.
 
 * I420 JPEG path: Y, U, and V retained rows
 * NV12 JPEG path: Y, Cb, and Cr retained rows through the internal streaming
@@ -728,6 +735,7 @@ Validate:
 * 1:1 resize reports zero work-buffer bytes and bypasses copy
 * Scaled resize reports non-zero work-buffer bytes and emits encoder-sized slices
 * Exact 2x and 0.5x resize paths match the general half-pixel bilinear reference for I420 and NV12
+* JPEG streaming 1280x720 and 5120x2880 4:2:0 inputs dispatch through the exact scaler paths for I420 and NV12 output
 * Invalid resize dimensions fail
 * Cortex-M3/M4/M7 QEMU scaler smoke tests pass when the ARM bare-metal toolchain and QEMU are available
 * Cortex-M4 QEMU scaler benchmark firmware passes correctness checks

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -33,6 +33,8 @@
 #define SH264E_ENCODER_FLAG_OWNS_MEMORY 2u
 #define SH264E_ENCODER_ARENA_ALIGNMENT ((size_t)sizeof(void *))
 #define SH264E_DC_PRED 128
+#define SH264E_JPEG_EXACT_RESIZE_2X_MASK 1u
+#define SH264E_JPEG_EXACT_RESIZE_HALF_MASK 2u
 
 #if !defined(SH264E_DISABLE_ARM_DSP) && defined(__ARM_FEATURE_DSP) && defined(__GNUC__)
 #define SH264E_USE_ARM_DSP 1
@@ -158,6 +160,9 @@ static uint8_t *sh264e_jpeg_alloc_arena;
 static size_t sh264e_jpeg_alloc_arena_capacity;
 static size_t sh264e_jpeg_streaming_last_cache_bytes;
 static size_t sh264e_jpeg_streaming_last_slice_work_bytes;
+#if SH264E_ENABLE_JPEG_TEST_HOOKS
+static unsigned sh264e_jpeg_streaming_last_exact_resize_mask;
+#endif
 
 static void reset_progressive_state(sh264e_encoder_t *encoder);
 static sh264e_status_t sh264e_begin_idr_to_consumer(sh264e_encoder_t *encoder,
@@ -826,6 +831,19 @@ static sh264e_scale_coord_t exact_scale_coord(int mode,
     return coord;
 }
 
+static void streaming_note_exact_scale_mode(int mode)
+{
+#if SH264E_ENABLE_JPEG_TEST_HOOKS
+    if (mode == 1) {
+        sh264e_jpeg_streaming_last_exact_resize_mask |= SH264E_JPEG_EXACT_RESIZE_2X_MASK;
+    } else if (mode == 2) {
+        sh264e_jpeg_streaming_last_exact_resize_mask |= SH264E_JPEG_EXACT_RESIZE_HALF_MASK;
+    }
+#else
+    (void)mode;
+#endif
+}
+
 static void jpeg_fill_i420_neutral_chroma(uint8_t *dst_u, uint8_t *dst_v)
 {
     memset(dst_u, 128, (size_t)SH264E_CHROMA_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT);
@@ -877,6 +895,40 @@ static uint8_t streaming_bilinear_sample_plane(const sh264e_jpeg_stream_componen
     return bilinear_blend_u8(row0[x0], row0[x1], row1[x0], row1[x1], sx.fraction, sy.fraction);
 }
 
+static uint8_t streaming_bilinear_sample_plane_quarter(const sh264e_jpeg_stream_component_t *src,
+                                                       sh264e_scale_coord_t sx,
+                                                       sh264e_scale_coord_t sy)
+{
+    uint32_t y0 = sy.index;
+    uint32_t y1 = y0 + 1u < src->height ? y0 + 1u : y0;
+    const uint32_t x0 = sx.index;
+    const uint32_t x1 = x0 + 1u < src->width ? x0 + 1u : x0;
+    const uint8_t *row0;
+    const uint8_t *row1;
+    const unsigned wx_quarters = sx.fraction >> (SH264E_SCALE_FP_BITS - 2u);
+    const unsigned wy_quarters = sy.fraction >> (SH264E_SCALE_FP_BITS - 2u);
+
+    if (y0 < src->row0) {
+        y0 = src->row0;
+    }
+    if (y1 < src->row0) {
+        y1 = src->row0;
+    }
+    y0 -= src->row0;
+    y1 -= src->row0;
+    if (y0 >= src->rows) {
+        y0 = src->rows - 1u;
+    }
+    if (y1 >= src->rows) {
+        y1 = src->rows - 1u;
+    }
+
+    row0 = src->pixels + (size_t)y0 * (size_t)src->stride;
+    row1 = src->pixels + (size_t)y1 * (size_t)src->stride;
+    return bilinear_blend_quarter_u8(row0[x0], row0[x1], row1[x0], row1[x1],
+                                     wx_quarters, wy_quarters);
+}
+
 static void streaming_scale_component_slice(const sh264e_jpeg_stream_component_t *src,
                                             uint8_t *dst,
                                             uint32_t dst_width,
@@ -885,21 +937,34 @@ static void streaming_scale_component_slice(const sh264e_jpeg_stream_component_t
                                             uint32_t dst_rows,
                                             ptrdiff_t dst_stride)
 {
+    const int exact_mode = exact_scale_ratio_mode(src->width, src->height, dst_width, dst_height);
     sh264e_axis_mapper_t y_mapper = scale_axis_mapper_init(src->height, dst_height, dst_y_start);
     uint32_t y;
 
+    streaming_note_exact_scale_mode(exact_mode);
     for (y = 0; y < dst_rows; y++) {
         uint8_t *dst_row = dst + (size_t)y * (size_t)dst_stride;
-        const sh264e_scale_coord_t sy = scale_coord_from_raw(y_mapper.pos, src->height);
+        const uint32_t dst_y = dst_y_start + y;
+        const sh264e_scale_coord_t sy = exact_mode != 0 ?
+                                        exact_scale_coord(exact_mode, dst_y, dst_height, src->height) :
+                                        scale_coord_from_raw(y_mapper.pos, src->height);
         sh264e_axis_mapper_t x_mapper = scale_axis_mapper_init(src->width, dst_width, 0u);
         uint32_t x;
 
         for (x = 0; x < dst_width; x++) {
-            const sh264e_scale_coord_t sx = scale_coord_from_raw(x_mapper.pos, src->width);
-            dst_row[x] = streaming_bilinear_sample_plane(src, sx, sy);
-            scale_axis_mapper_advance(&x_mapper);
+            const sh264e_scale_coord_t sx = exact_mode != 0 ?
+                                            exact_scale_coord(exact_mode, x, dst_width, src->width) :
+                                            scale_coord_from_raw(x_mapper.pos, src->width);
+            dst_row[x] = exact_mode != 0
+                             ? streaming_bilinear_sample_plane_quarter(src, sx, sy)
+                             : streaming_bilinear_sample_plane(src, sx, sy);
+            if (exact_mode == 0) {
+                scale_axis_mapper_advance(&x_mapper);
+            }
         }
-        scale_axis_mapper_advance(&y_mapper);
+        if (exact_mode == 0) {
+            scale_axis_mapper_advance(&y_mapper);
+        }
     }
 }
 
@@ -908,24 +973,48 @@ static void streaming_scale_nv12_component_chroma_slice(const sh264e_jpeg_stream
                                                         uint8_t *dst_uv,
                                                         uint32_t dst_y_start)
 {
+    const int exact_mode = exact_scale_ratio_mode(cb->width,
+                                                 cb->height,
+                                                 SH264E_CHROMA_WIDTH,
+                                                 SH264E_V1_HEIGHT / 2u);
     sh264e_axis_mapper_t y_mapper = scale_axis_mapper_init(cb->height,
                                                            SH264E_V1_HEIGHT / 2u,
                                                            dst_y_start);
     uint32_t y;
 
+    streaming_note_exact_scale_mode(exact_mode);
     for (y = 0; y < SH264E_V1_SLICE_CHROMA_HEIGHT; y++) {
         uint8_t *row = dst_uv + (size_t)y * SH264E_V1_WIDTH;
-        const sh264e_scale_coord_t sy = scale_coord_from_raw(y_mapper.pos, cb->height);
+        const uint32_t dst_y = dst_y_start + y;
+        const sh264e_scale_coord_t sy = exact_mode != 0 ?
+                                        exact_scale_coord(exact_mode,
+                                                          dst_y,
+                                                          SH264E_V1_HEIGHT / 2u,
+                                                          cb->height) :
+                                        scale_coord_from_raw(y_mapper.pos, cb->height);
         sh264e_axis_mapper_t x_mapper = scale_axis_mapper_init(cb->width, SH264E_CHROMA_WIDTH, 0u);
         uint32_t x;
 
         for (x = 0; x < SH264E_CHROMA_WIDTH; x++) {
-            const sh264e_scale_coord_t sx = scale_coord_from_raw(x_mapper.pos, cb->width);
-            row[(size_t)x * 2u] = streaming_bilinear_sample_plane(cb, sx, sy);
-            row[(size_t)x * 2u + 1u] = streaming_bilinear_sample_plane(cr, sx, sy);
-            scale_axis_mapper_advance(&x_mapper);
+            const sh264e_scale_coord_t sx = exact_mode != 0 ?
+                                            exact_scale_coord(exact_mode,
+                                                              x,
+                                                              SH264E_CHROMA_WIDTH,
+                                                              cb->width) :
+                                            scale_coord_from_raw(x_mapper.pos, cb->width);
+            row[(size_t)x * 2u] = exact_mode != 0
+                                      ? streaming_bilinear_sample_plane_quarter(cb, sx, sy)
+                                      : streaming_bilinear_sample_plane(cb, sx, sy);
+            row[(size_t)x * 2u + 1u] = exact_mode != 0
+                                           ? streaming_bilinear_sample_plane_quarter(cr, sx, sy)
+                                           : streaming_bilinear_sample_plane(cr, sx, sy);
+            if (exact_mode == 0) {
+                scale_axis_mapper_advance(&x_mapper);
+            }
         }
-        scale_axis_mapper_advance(&y_mapper);
+        if (exact_mode == 0) {
+            scale_axis_mapper_advance(&y_mapper);
+        }
     }
 }
 
@@ -2612,6 +2701,9 @@ static sh264e_status_t jpeg_measure_streaming_requirements(const uint8_t *jpeg_d
     }
     sh264e_jpeg_streaming_last_cache_bytes = 0u;
     sh264e_jpeg_streaming_last_slice_work_bytes = 0u;
+#if SH264E_ENABLE_JPEG_TEST_HOOKS
+    sh264e_jpeg_streaming_last_exact_resize_mask = 0u;
+#endif
     if (jpeg_source == NULL && (jpeg_size == 0u || jpeg_size > (size_t)INT_MAX)) {
         return SH264E_ERR_INVALID_ARGUMENT;
     }
@@ -2696,6 +2788,11 @@ sh264e_status_t sh264e_jpeg_source_get_slice_work_size(const sh264e_jpeg_source_
 void sh264e_jpeg_set_test_allocation_limit(size_t max_bytes)
 {
     sh264e_jpeg_alloc_limit = max_bytes;
+}
+
+unsigned sh264e_jpeg_get_test_last_exact_resize_mask(void)
+{
+    return sh264e_jpeg_streaming_last_exact_resize_mask;
 }
 
 #endif
@@ -2824,6 +2921,9 @@ static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *e
     *out_size = 0u;
     sh264e_jpeg_streaming_last_cache_bytes = 0u;
     sh264e_jpeg_streaming_last_slice_work_bytes = 0u;
+#if SH264E_ENABLE_JPEG_TEST_HOOKS
+    sh264e_jpeg_streaming_last_exact_resize_mask = 0u;
+#endif
     if (encoder_idr_active(encoder)) {
         return SH264E_ERR_BAD_STATE;
     }

--- a/tests/check_jpeg_diagnostics_boundary.cmake
+++ b/tests/check_jpeg_diagnostics_boundary.cmake
@@ -27,8 +27,16 @@ if(NOT test_hooks MATCHES "sh264e_jpeg_set_test_allocation_limit[ \t\r\n]*\\(")
     message(FATAL_ERROR "Allocation-limit hook must be test-only")
 endif()
 
+if(NOT test_hooks MATCHES "sh264e_jpeg_get_test_last_exact_resize_mask[ \t\r\n]*\\(")
+    message(FATAL_ERROR "JPEG exact-resize diagnostic hook must be test-only")
+endif()
+
 if(NOT sh264e_source MATCHES "#if SH264E_ENABLE_JPEG_TEST_HOOKS[ \t\r\n]+void[ \t\r\n]+sh264e_jpeg_set_test_allocation_limit")
     message(FATAL_ERROR "Allocation-limit implementation must be test-hook gated")
+endif()
+
+if(NOT sh264e_source MATCHES "#if SH264E_ENABLE_JPEG_TEST_HOOKS[ \t\r\n]+static[ \t\r\n]+unsigned[ \t\r\n]+sh264e_jpeg_streaming_last_exact_resize_mask")
+    message(FATAL_ERROR "JPEG exact-resize diagnostic state must be test-hook gated")
 endif()
 
 if(NOT sh264e_source MATCHES "#if SH264E_ENABLE_JPEG_TEST_HOOKS[ \t\r\n]+sh264e_status_t[ \t\r\n]+sh264e_encode_jpeg_idr_streaming_prototype")

--- a/tests/check_production_profile_symbols.cmake
+++ b/tests/check_production_profile_symbols.cmake
@@ -100,6 +100,7 @@ endforeach()
 
 foreach(forbidden_symbol
         sh264e_jpeg_set_test_allocation_limit
+        sh264e_jpeg_get_test_last_exact_resize_mask
         sh264e_encode_jpeg_idr_streaming_prototype
         sh264e_encode_jpeg_idr_streaming_prototype_with_arena
         njDecodeComponents

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -14,23 +14,29 @@ SMALL_WIDTH = 1280
 SMALL_HEIGHT = 720
 LARGE_WIDTH = 2560
 LARGE_HEIGHT = 1440
+DOWNSCALE_WIDTH = 5120
+DOWNSCALE_HEIGHT = 2880
 JPEG_SLICE_WORK_BYTES = WIDTH * 16 + (WIDTH // 2) * 8 * 2
 JPEG_DIRECT_I420_SLICE_WORK_BYTES = 0
 JPEG_DIRECT_NV12_SLICE_WORK_BYTES = 0
 JPEG_DIRECT_I420_EFFECTIVE_SLICE_WORK_BYTES = 0
 JPEG_DIRECT_NV12_EFFECTIVE_SLICE_WORK_BYTES = 0
+JPEG_EXACT_RESIZE_2X_MASK = 1
+JPEG_EXACT_RESIZE_HALF_MASK = 2
 STREAMING_CACHE_BYTES_720P = {
     "yuvj420p": 61_440,
     "yuvj422p": 81_920,
     "yuvj444p": 122_880,
 }
 STREAMING_CACHE_BYTES_1440P_420 = 61_440
+STREAMING_CACHE_BYTES_2880P_420 = 368_640
 FULL_COMPONENT_BYTES_720P = {
     "yuvj420p": 1_382_400,
     "yuvj422p": 1_843_200,
     "yuvj444p": 2_764_800,
 }
 FULL_COMPONENT_BYTES_1440P_420 = 5_529_600
+FULL_COMPONENT_BYTES_2880P_420 = 22_118_400
 PRODUCTION_MEMORY_720P_420 = {
     "work": 92_304,
     "peak": 92_160,
@@ -40,6 +46,11 @@ PRODUCTION_MEMORY_1440P_420 = {
     "work": 123_024,
     "peak": 122_880,
     "cache": STREAMING_CACHE_BYTES_1440P_420,
+}
+PRODUCTION_MEMORY_2880P_420 = {
+    "work": 491_664,
+    "peak": 491_520,
+    "cache": STREAMING_CACHE_BYTES_2880P_420,
 }
 H264_OUTPUT_CONSUMER_CHUNKS_MIN = 2 + (WIDTH // 16) * (HEIGHT // 16)
 H264_OUTPUT_CHUNK_BYTES = 4_096
@@ -434,7 +445,8 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
                 expected_cache_bytes=None, max_peak_bytes=None,
                 expected_work_bytes=None, expected_peak_bytes=None,
                 expected_slice_work_bytes=None,
-                expected_effective_slice_work_bytes=None):
+                expected_effective_slice_work_bytes=None,
+                expected_exact_resize_mask=None):
     command = [args.jpeg_encoder]
     if extra_args:
         command.extend(extra_args)
@@ -482,6 +494,13 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
         raise RuntimeError(
             f"JPEG encoder default row cache changed for {jpeg_input}: got {cache}, expected {expected_cache_bytes}"
         )
+    if expected_exact_resize_mask is not None:
+        exact_resize_mask = parse_jpeg_metric(result.stdout, "jpeg exact resize mask:")
+        if exact_resize_mask != expected_exact_resize_mask:
+            raise RuntimeError(
+                "JPEG encoder exact resize path changed: "
+                f"got mask {exact_resize_mask}, expected {expected_exact_resize_mask}"
+            )
     if max_peak_bytes is not None and peak >= max_peak_bytes:
         raise RuntimeError(
             f"JPEG encoder default path used full component-plane memory: got peak {peak}, limit {max_peak_bytes}"
@@ -520,7 +539,8 @@ def encode_jpeg_source_chunks(args, fmt, jpeg_input, bitstream, chunk_size,
                               expected_work_bytes=None,
                               expected_peak_bytes=None,
                               expected_slice_work_bytes=None,
-                              expected_effective_slice_work_bytes=None):
+                              expected_effective_slice_work_bytes=None,
+                              expected_exact_resize_mask=None):
     stdout = encode_jpeg(
         args,
         fmt,
@@ -532,6 +552,7 @@ def encode_jpeg_source_chunks(args, fmt, jpeg_input, bitstream, chunk_size,
         expected_peak_bytes=expected_peak_bytes,
         expected_slice_work_bytes=expected_slice_work_bytes,
         expected_effective_slice_work_bytes=expected_effective_slice_work_bytes,
+        expected_exact_resize_mask=expected_exact_resize_mask,
     )
     reported_chunk_size = parse_jpeg_metric(stdout, "jpeg source chunk bytes:")
     if reported_chunk_size != chunk_size:
@@ -542,7 +563,8 @@ def encode_jpeg_source_chunks(args, fmt, jpeg_input, bitstream, chunk_size,
 
 def encode_jpeg_streaming_prototype(args, fmt, jpeg_input, bitstream,
                                     expected_cache_bytes=None,
-                                    expected_slice_work_bytes=None):
+                                    expected_slice_work_bytes=None,
+                                    expected_exact_resize_mask=None):
     result = run_capture([
         args.jpeg_encoder,
         "--streaming-prototype",
@@ -573,6 +595,13 @@ def encode_jpeg_streaming_prototype(args, fmt, jpeg_input, bitstream,
         raise RuntimeError(
             f"streaming JPEG row cache changed for {jpeg_input}: got {cache}, expected {expected_cache_bytes}"
         )
+    if expected_exact_resize_mask is not None:
+        exact_resize_mask = parse_jpeg_metric(result.stdout, "jpeg exact resize mask:")
+        if exact_resize_mask != expected_exact_resize_mask:
+            raise RuntimeError(
+                "streaming JPEG exact resize path changed: "
+                f"got mask {exact_resize_mask}, expected {expected_exact_resize_mask}"
+            )
 
 
 def encode_jpeg_output_consumer(args, fmt, jpeg_input, bitstream, extra_args=None,
@@ -731,7 +760,8 @@ def main():
                         expected_cache_bytes=STREAMING_CACHE_BYTES_720P[pix_fmt],
                         max_peak_bytes=FULL_COMPONENT_BYTES_720P[pix_fmt],
                         expected_work_bytes=expected_work,
-                        expected_peak_bytes=expected_peak)
+                        expected_peak_bytes=expected_peak,
+                        expected_exact_resize_mask=JPEG_EXACT_RESIZE_2X_MASK)
             if pix_fmt == "yuvj420p" and fmt == "i420":
                 one_shot_output = workdir / "output_jpeg_one_shot_yuvj420p_i420.h264"
                 encode_jpeg(args, fmt, jpeg_input, one_shot_output,
@@ -739,7 +769,8 @@ def main():
                             STREAMING_CACHE_BYTES_720P[pix_fmt],
                             FULL_COMPONENT_BYTES_720P[pix_fmt],
                             PRODUCTION_MEMORY_720P_420["work"],
-                            PRODUCTION_MEMORY_720P_420["peak"])
+                            PRODUCTION_MEMORY_720P_420["peak"],
+                            expected_exact_resize_mask=JPEG_EXACT_RESIZE_2X_MASK)
                 validate_bitstream(args.ffprobe, args.ffmpeg, one_shot_output)
                 if jpeg_output.read_bytes() != one_shot_output.read_bytes():
                     raise RuntimeError("JPEG default output consumer bitstream differs from one-shot output")
@@ -773,6 +804,7 @@ def main():
                         STREAMING_CACHE_BYTES_720P[pix_fmt],
                         PRODUCTION_MEMORY_720P_420["work"],
                         PRODUCTION_MEMORY_720P_420["peak"],
+                        expected_exact_resize_mask=JPEG_EXACT_RESIZE_2X_MASK,
                     )
                     validate_bitstream(args.ffprobe, args.ffmpeg, source_output)
                     if source_output.read_bytes() != one_shot_output.read_bytes():
@@ -789,7 +821,8 @@ def main():
                     str(workdir / "output_jpeg_consumer_fail.h264"),
                 ], stderr_contains="internal error")
             encode_jpeg_streaming_prototype(args, fmt, jpeg_input, streaming_output,
-                                            STREAMING_CACHE_BYTES_720P[pix_fmt])
+                                            STREAMING_CACHE_BYTES_720P[pix_fmt],
+                                            expected_exact_resize_mask=JPEG_EXACT_RESIZE_2X_MASK)
             validate_bitstream(args.ffprobe, args.ffmpeg, jpeg_output)
             validate_bitstream(args.ffprobe, args.ffmpeg, streaming_output)
             compare_decoded_i420(args, jpeg_output, streaming_output,
@@ -805,7 +838,8 @@ def main():
                 expected_work_bytes=PRODUCTION_MEMORY_1440P_420["work"],
                 expected_peak_bytes=PRODUCTION_MEMORY_1440P_420["peak"],
                 expected_slice_work_bytes=JPEG_DIRECT_I420_SLICE_WORK_BYTES,
-                expected_effective_slice_work_bytes=JPEG_DIRECT_I420_EFFECTIVE_SLICE_WORK_BYTES)
+                expected_effective_slice_work_bytes=JPEG_DIRECT_I420_EFFECTIVE_SLICE_WORK_BYTES,
+                expected_exact_resize_mask=0)
     large_jpeg_output_nv12 = workdir / "output_jpeg_1440p_yuvj420p_nv12.h264"
     encode_jpeg(args, "nv12", large_jpeg_input, large_jpeg_output_nv12,
                 expected_cache_bytes=STREAMING_CACHE_BYTES_1440P_420,
@@ -813,7 +847,8 @@ def main():
                 expected_work_bytes=PRODUCTION_MEMORY_1440P_420["work"],
                 expected_peak_bytes=PRODUCTION_MEMORY_1440P_420["peak"],
                 expected_slice_work_bytes=JPEG_DIRECT_NV12_SLICE_WORK_BYTES,
-                expected_effective_slice_work_bytes=JPEG_DIRECT_NV12_EFFECTIVE_SLICE_WORK_BYTES)
+                expected_effective_slice_work_bytes=JPEG_DIRECT_NV12_EFFECTIVE_SLICE_WORK_BYTES,
+                expected_exact_resize_mask=0)
     validate_bitstream(args.ffprobe, args.ffmpeg, large_jpeg_output_nv12)
     large_heap_wrapper_output = workdir / "output_jpeg_heap_wrapper_1440p_yuvj420p_i420.h264"
     encode_jpeg(args, "i420", large_jpeg_input, large_heap_wrapper_output,
@@ -822,7 +857,8 @@ def main():
                 max_peak_bytes=FULL_COMPONENT_BYTES_1440P_420,
                 expected_peak_bytes=PRODUCTION_MEMORY_1440P_420["peak"],
                 expected_slice_work_bytes=JPEG_DIRECT_I420_SLICE_WORK_BYTES,
-                expected_effective_slice_work_bytes=JPEG_DIRECT_I420_EFFECTIVE_SLICE_WORK_BYTES)
+                expected_effective_slice_work_bytes=JPEG_DIRECT_I420_EFFECTIVE_SLICE_WORK_BYTES,
+                expected_exact_resize_mask=0)
     validate_bitstream(args.ffprobe, args.ffmpeg, large_heap_wrapper_output)
     if large_heap_wrapper_output.read_bytes() != large_jpeg_output.read_bytes():
         raise RuntimeError("JPEG heap wrapper bitstream differs from arena streaming output")
@@ -833,10 +869,23 @@ def main():
         )
     encode_jpeg_streaming_prototype(args, "i420", large_jpeg_input, large_streaming_output,
                                     STREAMING_CACHE_BYTES_1440P_420,
-                                    JPEG_DIRECT_I420_SLICE_WORK_BYTES)
+                                    JPEG_DIRECT_I420_SLICE_WORK_BYTES,
+                                    expected_exact_resize_mask=0)
     validate_bitstream(args.ffprobe, args.ffmpeg, large_streaming_output)
     compare_decoded_i420(args, large_jpeg_output, large_streaming_output,
                          "output_jpeg_1440p_yuvj420p_i420_streaming_compare")
+
+    downscale_jpeg_input = workdir / "input_2880p_yuvj420p.jpg"
+    make_color_jpeg_sized(args, downscale_jpeg_input, "yuvj420p", DOWNSCALE_WIDTH, DOWNSCALE_HEIGHT)
+    for fmt in ("i420", "nv12"):
+        downscale_output = workdir / f"output_jpeg_2880p_yuvj420p_{fmt}.h264"
+        encode_jpeg(args, fmt, downscale_jpeg_input, downscale_output,
+                    expected_cache_bytes=STREAMING_CACHE_BYTES_2880P_420,
+                    max_peak_bytes=FULL_COMPONENT_BYTES_2880P_420,
+                    expected_work_bytes=PRODUCTION_MEMORY_2880P_420["work"],
+                    expected_peak_bytes=PRODUCTION_MEMORY_2880P_420["peak"],
+                    expected_exact_resize_mask=JPEG_EXACT_RESIZE_HALF_MASK)
+        validate_bitstream(args.ffprobe, args.ffmpeg, downscale_output)
 
     if args.cjpeg:
         restart_jpeg_input = workdir / "input_720p_yuvj420p_restart.jpg"
@@ -844,11 +893,13 @@ def main():
         restart_streaming_output = workdir / "output_jpeg_streaming_yuvj420p_restart_i420.h264"
         restart_jpeg_output = workdir / "output_jpeg_yuvj420p_restart_i420.h264"
         encode_jpeg_streaming_prototype(args, "i420", restart_jpeg_input, restart_streaming_output,
-                                        STREAMING_CACHE_BYTES_720P["yuvj420p"])
+                                        STREAMING_CACHE_BYTES_720P["yuvj420p"],
+                                        expected_exact_resize_mask=JPEG_EXACT_RESIZE_2X_MASK)
         validate_bitstream(args.ffprobe, args.ffmpeg, restart_streaming_output)
         encode_jpeg(args, "i420", restart_jpeg_input, restart_jpeg_output,
                     expected_cache_bytes=STREAMING_CACHE_BYTES_720P["yuvj420p"],
-                    max_peak_bytes=FULL_COMPONENT_BYTES_720P["yuvj420p"])
+                    max_peak_bytes=FULL_COMPONENT_BYTES_720P["yuvj420p"],
+                    expected_exact_resize_mask=JPEG_EXACT_RESIZE_2X_MASK)
         validate_bitstream(args.ffprobe, args.ffmpeg, restart_jpeg_output)
         compare_decoded_i420(args, restart_jpeg_output, restart_streaming_output,
                              "output_jpeg_yuvj420p_restart_i420_streaming_compare")
@@ -860,6 +911,7 @@ def main():
             restart_source_output,
             7,
             STREAMING_CACHE_BYTES_720P["yuvj420p"],
+            expected_exact_resize_mask=JPEG_EXACT_RESIZE_2X_MASK,
         )
         validate_bitstream(args.ffprobe, args.ffmpeg, restart_source_output)
         if restart_source_output.read_bytes() != restart_jpeg_output.read_bytes():
@@ -888,8 +940,10 @@ def main():
     for fmt in ("i420", "nv12"):
         grayscale_jpeg_output = workdir / f"output_jpeg_gray_{fmt}.h264"
         grayscale_streaming_output = workdir / f"output_jpeg_streaming_gray_{fmt}.h264"
-        encode_jpeg(args, fmt, grayscale_jpeg_input, grayscale_jpeg_output)
-        encode_jpeg_streaming_prototype(args, fmt, grayscale_jpeg_input, grayscale_streaming_output)
+        encode_jpeg(args, fmt, grayscale_jpeg_input, grayscale_jpeg_output,
+                    expected_exact_resize_mask=JPEG_EXACT_RESIZE_2X_MASK)
+        encode_jpeg_streaming_prototype(args, fmt, grayscale_jpeg_input, grayscale_streaming_output,
+                                        expected_exact_resize_mask=JPEG_EXACT_RESIZE_2X_MASK)
         validate_bitstream(args.ffprobe, args.ffmpeg, grayscale_jpeg_output)
         validate_bitstream(args.ffprobe, args.ffmpeg, grayscale_streaming_output)
         compare_decoded_i420(args, grayscale_jpeg_output, grayscale_streaming_output,

--- a/tests/sh264e_jpeg_test_hooks.h
+++ b/tests/sh264e_jpeg_test_hooks.h
@@ -13,6 +13,8 @@
 
 void sh264e_jpeg_set_test_allocation_limit(size_t max_bytes);
 
+unsigned sh264e_jpeg_get_test_last_exact_resize_mask(void);
+
 sh264e_status_t sh264e_encode_jpeg_idr_streaming_prototype(
     sh264e_encoder_t *encoder,
     const uint8_t *jpeg_data,

--- a/tools/sh264e_encode_jpeg.c
+++ b/tools/sh264e_encode_jpeg.c
@@ -573,6 +573,9 @@ int main(int argc, char **argv)
         if (streaming_prototype || sh264e_jpeg_get_last_streaming_cache_bytes() != 0u) {
             printf("jpeg streaming cache bytes: %zu\n", sh264e_jpeg_get_last_streaming_cache_bytes());
         }
+#if SH264E_ENABLE_JPEG_TEST_HOOKS
+        printf("jpeg exact resize mask: %u\n", sh264e_jpeg_get_test_last_exact_resize_mask());
+#endif
         if ((one_shot_output_test || allocation_limit != (size_t)-1) && output_capacity != 0u) {
             printf("jpeg output buffer bytes: %zu\n", output_capacity);
         } else if (!streaming_prototype && allocation_limit == (size_t)-1 &&


### PR DESCRIPTION
Refs #96

## Summary
- Route JPEG MCU-row streaming resize through the exact 2x and 0.5x quarter-step scaler sampler when source/destination geometry matches the fixed-ratio paths.
- Preserve the 2560x1440 4:2:0 1:1 bypass path with zero effective slice work for I420 and NV12.
- Add a test-only exact-resize diagnostic mask so integration coverage asserts that 720p JPEGs use the exact 2x path and 2880p JPEGs use the exact 0.5x path.
- Extend ffmpeg integration coverage to strict-decode 5120x2880 -> 2560x1440 JPEG I420/NV12 outputs and update JPEG memory docs with measured 2880p arena/peak/cache values.

## Validation
- `python3 -m py_compile tests/run_ffmpeg_integration.py tests/run_qemu_proxy_timing.py`
- `cmake -S . -B build-issue96 -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build-issue96`
- `ctest --test-dir build-issue96 --output-on-failure`
- `C_INCLUDE_PATH=/tmp/sh264e_arm_min_headers cmake -S . -B build-qemu-issue96 -DSH264E_BUILD_QEMU_TESTS=ON`
- `C_INCLUDE_PATH=/tmp/sh264e_arm_min_headers cmake --build build-qemu-issue96`
- `ctest --test-dir build-qemu-issue96 -R 'qemu.*scaler|proxy' --output-on-failure`
- `python3 tests/run_qemu_proxy_timing.py --build-dir build-qemu-issue96 --repeat 3 --target sh264e_qemu_scaler_bench_m4 --target sh264e_qemu_scaler_bench_m4_portable --target sh264e_qemu_scaler_bench_m7 --target sh264e_qemu_scaler_bench_m7_portable`
- `git diff --check`

## Notes
- The local Homebrew `arm-none-eabi-gcc` still lacks bundled C library headers. QEMU firmware validation used the existing temporary minimal declaration headers at `/tmp/sh264e_arm_min_headers` while preserving the repo's freestanding `-nostdlib` firmware link.
