### PR TITLE
[codex] h264: specialize independent MB slice constants

### DIFF
--- a/docs/CORTEX_M_OPTIMIZATION_PLAN.md
+++ b/docs/CORTEX_M_OPTIMIZATION_PLAN.md
@@ -133,7 +133,10 @@ real-board DWT timing is still required before making cycle-speed claims.
 The H.264 RBSP writer uses a byte-oriented pending-byte accumulator. Aligned
 8-bit writes bypass the old per-bit loop, and Exp-Golomb writes use CLZ-backed
 length calculation with a portable fallback plus batched zero-run writes.
-Unaligned CAVLC and RBSP trailing-bit writes still preserve the same MSB-first
-bit order and byte output. The change keeps the one-macroblock RBSP scratch
-size unchanged so downstream Annex B batching can focus on output streaming
-overhead.
+The independent-MB slice writer also packs the fixed IDR slice-header tail and
+fixed I_NxN macroblock prefix into constant bit writes while leaving
+`first_mb_in_slice`, coded block pattern, and residual syntax on their variable
+paths. Unaligned CAVLC and RBSP trailing-bit writes still preserve the same
+MSB-first bit order and byte output. These changes keep the one-macroblock RBSP
+scratch size unchanged so downstream Annex B batching can focus on output
+streaming overhead.

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -2413,6 +2413,31 @@ static void write_chroma_dc_residual(sh264e_bit_writer_t *bw, int level)
     bw_write_bit(bw, 1);                 /* total_zeros = 0 for TotalCoeff=1 */
 }
 
+enum {
+    SH264E_IDR_MB_SLICE_FIXED_HEADER_BITS = 23,
+    SH264E_I_NXN_FIXED_PREFIX_BITS = 18
+};
+
+static void write_idr_mb_slice_header(sh264e_bit_writer_t *bw, unsigned first_mb_in_slice)
+{
+    bw_write_ue(bw, first_mb_in_slice);
+    /*
+     * Fixed tail after first_mb_in_slice:
+     * slice_type=I(7), pps=0, frame_num=0, idr_pic_id=0, poc_lsb=0,
+     * ref flags=0, slice_qp_delta=0, disable_deblocking_filter_idc=1.
+     */
+    bw_write_bits(bw, 0x8840au, SH264E_IDR_MB_SLICE_FIXED_HEADER_BITS);
+}
+
+static void write_i_nxn_fixed_prefix(sh264e_bit_writer_t *bw)
+{
+    /*
+     * mb_type=I_NxN (ue(0)), sixteen prev_intra4x4_pred_mode_flag bits set,
+     * and intra_chroma_pred_mode=DC (ue(0)).
+     */
+    bw_write_bits(bw, 0x3ffffu, SH264E_I_NXN_FIXED_PREFIX_BITS);
+}
+
 static sh264e_status_t write_idr_mb_slice_rbsp(sh264e_encoder_t *encoder,
                                                const sh264e_slice_t *slice,
                                                unsigned row_index,
@@ -2429,16 +2454,7 @@ static sh264e_status_t write_idr_mb_slice_rbsp(sh264e_encoder_t *encoder,
 
     bw_init(&bw, encoder->rbsp, encoder->rbsp_capacity);
 
-    bw_write_ue(&bw, row_index * SH264E_MBS_X + mb_x);
-    bw_write_ue(&bw, 7);                 /* slice_type: all I slices */
-    bw_write_ue(&bw, 0);                 /* pic_parameter_set_id */
-    bw_write_bits(&bw, 0, 4);            /* frame_num */
-    bw_write_ue(&bw, 0);                 /* idr_pic_id */
-    bw_write_bits(&bw, 0, 4);            /* pic_order_cnt_lsb */
-    bw_write_bit(&bw, 0);                /* no_output_of_prior_pics_flag */
-    bw_write_bit(&bw, 0);                /* long_term_reference_flag */
-    bw_write_se(&bw, 0);                 /* slice_qp_delta */
-    bw_write_ue(&bw, 1);                 /* disable_deblocking_filter_idc */
+    write_idr_mb_slice_header(&bw, row_index * SH264E_MBS_X + mb_x);
 
     for (b = 0; b < 16u; b++) {
         const unsigned x = k_luma4x4_x[b];
@@ -2455,15 +2471,11 @@ static sh264e_status_t write_idr_mb_slice_rbsp(sh264e_encoder_t *encoder,
     cbp_chroma = (chroma_dc[0] != 0 || chroma_dc[1] != 0) ? 1u : 0u;
     cbp = cbp_luma + cbp_chroma * 16u;
 
-    bw_write_ue(&bw, 0);                         /* mb_type: I_NxN */
-    for (b = 0; b < 16u; b++) {
-        bw_write_bit(&bw, 1);                    /* prev_intra4x4_pred_mode_flag */
-    }
-    bw_write_ue(&bw, 0);                         /* intra_chroma_pred_mode: DC */
+    write_i_nxn_fixed_prefix(&bw);
     bw_write_ue(&bw, k_cbp_intra_code_num[cbp]);
 
     if (cbp != 0u) {
-        bw_write_se(&bw, 0);                     /* mb_qp_delta */
+        bw_write_bit(&bw, 1);                    /* mb_qp_delta: se(0) */
         for (b = 0; b < 16u; b++) {
             if ((cbp_luma & (1u << (b / 4u))) != 0u) {
                 write_luma_residual_dc_only(&bw, levels[b], 0u);


### PR DESCRIPTION
Refs #95

## Summary
- Pack the fixed IDR macroblock-slice header tail into one constant bit write after the variable `first_mb_in_slice` Exp-Golomb field.
- Pack the fixed I_NxN macroblock prefix into one constant bit write while leaving coded block pattern and residual syntax unchanged.
- Replace the fixed `mb_qp_delta = se(0)` generic write with its direct one-bit code.
- Update the Cortex-M optimization status note for the constant-syntax specialization.

## Validation
- `cmake -S . -B build-issue95 -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build-issue95`
- `ctest --test-dir build-issue95 --output-on-failure`
- Byte-identical output check against `origin/main` for deterministic progressive I420 and NV12 encodes:
  - I420: both outputs were 1,192,716 bytes with SHA-256 `dbd453bac68606603100d8db9c3b92917bea54871d7f290502eb6179bd210a79`.
  - NV12: both outputs were 1,182,661 bytes with SHA-256 `e3b6a27665de9c9dc7266ec6d82402b0c404c52bd14fdab883c39d7285f409ac`.
- `C_INCLUDE_PATH=/tmp/sh264e_arm_min_headers cmake -S . -B build-qemu-issue95 -DSH264E_BUILD_QEMU_TESTS=ON`
- `C_INCLUDE_PATH=/tmp/sh264e_arm_min_headers cmake --build build-qemu-issue95 --target sh264e_qemu_encoder_bench_m4 sh264e_qemu_encoder_bench_m4_portable sh264e_qemu_encoder_bench_m7 sh264e_qemu_encoder_bench_m7_portable`
- `ctest --test-dir build-qemu-issue95 -R 'sh264e_qemu_encoder_bench_(m4|m7)' --output-on-failure`
- `python3 tests/run_qemu_proxy_timing.py --build-dir build-qemu-issue95 --repeat 3 --target sh264e_qemu_encoder_bench_m4 --target sh264e_qemu_encoder_bench_m4_portable --target sh264e_qemu_encoder_bench_m7 --target sh264e_qemu_encoder_bench_m7_portable`
- `git diff --check`
- `python3 -m py_compile tests/run_qemu_proxy_timing.py tests/run_ffmpeg_integration.py`

## QEMU Proxy Timing Sample
Values are host/QEMU wall time only, not Cortex-M cycles.

| Target firmware | Variant | Repeats | Median wall time | Min wall time | Max wall time | Status |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| `sh264e_qemu_encoder_bench_m4` | DSP-capable | 3 | 0.045550s | 0.040655s | 0.045652s | pass |
| `sh264e_qemu_encoder_bench_m4_portable` | portable C | 3 | 0.044044s | 0.040083s | 0.044601s | pass |
| `sh264e_qemu_encoder_bench_m7` | DSP-capable | 3 | 0.041232s | 0.040523s | 0.068971s | pass |
| `sh264e_qemu_encoder_bench_m7_portable` | portable C | 3 | 0.040252s | 0.040143s | 0.042698s | pass |

## Notes
- The local Homebrew `arm-none-eabi-gcc` still lacks bundled C library headers. QEMU firmware validation used the existing temporary minimal declaration headers at `/tmp/sh264e_arm_min_headers` while preserving the repo's freestanding firmware link.
- A full all-target `cmake --build build-qemu-issue95` with that `C_INCLUDE_PATH` is not representative here because the stub headers leak into host tool compilation; focused encoder firmware targets were built and tested instead.
