### PR TITLE
[codex] h264: stream IDR Annex B directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ Cr component frame. One-shot JPEG APIs may still require a caller-provided
 complete H.264 output buffer; that output model is separate from JPEG decoded
 image memory.
 The JPEG tool uses the streaming H.264 output consumer API for its production arena path, so it flushes the Annex B byte stream as it is produced instead of allocating `sh264e_get_max_output_size()` bytes for the complete frame. For the current 2560x1440 encoder geometry this replaces the 5,588,224-byte one-shot output capacity with a reusable 4,096-byte output chunk buffer. Embedded callers can use the same API to forward chunks to flash, storage, DMA, or a ring buffer without a full-frame or full-slice output buffer.
+IDR macroblock-slice NALUs on this path are written directly from the bit writer into the Annex B chunk writer as bytes become complete, including emulation-prevention insertion. The caller-buffer APIs still produce byte-identical Annex B output through their existing RBSP scratch path.
 
 For Cortex-M validation, CMake builds QEMU smoke firmware for M3/M4/M7 when the ARM bare-metal toolchain and QEMU are available. CMake first probes whether `arm-none-eabi-gcc` can compile the library's standard-header usage; if the toolchain is only partially installed, QEMU firmware tests are skipped instead of breaking the host build.
 

--- a/docs/CORTEX_M_OPTIMIZATION_PLAN.md
+++ b/docs/CORTEX_M_OPTIMIZATION_PLAN.md
@@ -137,6 +137,12 @@ The independent-MB slice writer also packs the fixed IDR slice-header tail and
 fixed I_NxN macroblock prefix into constant bit writes while leaving
 `first_mb_in_slice`, coded block pattern, and residual syntax on their variable
 paths. Unaligned CAVLC and RBSP trailing-bit writes still preserve the same
-MSB-first bit order and byte output. These changes keep the one-macroblock RBSP
-scratch size unchanged so downstream Annex B batching can focus on output
-streaming overhead.
+MSB-first bit order and byte output.
+
+The JPEG/output-consumer streaming path now writes each completed IDR
+macroblock-slice RBSP byte directly through the Annex B emulation-prevention
+streamer instead of staging the macroblock in `encoder->rbsp` and replaying it.
+SPS/PPS and caller-buffer progressive APIs still use the 256-byte
+one-macroblock RBSP scratch, so the public encoder memory report and arena size
+stay unchanged. The direct path preserves byte-identical Annex B output and
+consumer failure propagation.

--- a/docs/ENCODER_MEMORY_REPORT.md
+++ b/docs/ENCODER_MEMORY_REPORT.md
@@ -72,6 +72,11 @@ not change any encoder-owned memory block or the reported `296` byte total.
 The byte-oriented bit-writer accumulator is internal writer state and does not
 change the `256` byte RBSP scratch block, encoder arena size, or reported
 `296` byte total.
+The streaming output-consumer path bypasses the RBSP scratch for IDR
+macroblock-slice NALUs by sending completed RBSP bytes directly through the
+Annex B emulation-prevention chunk writer. The scratch block remains part of
+the encoder report because SPS/PPS and caller-buffer progressive APIs still use
+it, so the reported total and caller-provided arena size are unchanged.
 
 The JPEG tool prints the same report:
 

--- a/docs/JPEG_STREAMING_MEMORY_REPORT.md
+++ b/docs/JPEG_STREAMING_MEMORY_REPORT.md
@@ -93,7 +93,9 @@ and reuses one caller-owned byte-stream flush buffer, currently 4,096 bytes,
 instead of the 5,588,224-byte one-shot maximum output buffer or the
 62,080-byte one-input-row output chunk. The tool writes Annex B chunks through a
 file consumer outside the library; tests also cover tiny chunk boundaries to
-lock emulation-prevention behavior across flushes.
+lock emulation-prevention behavior across flushes. IDR macroblock-slice NALUs
+on this path are generated directly into that Annex B chunk stream, so the path
+does not stage a full NALU in the encoder RBSP scratch before flushing.
 
 For the `2560x1440` 4:2:0 embedded path, excluding compressed JPEG input
 storage and `.rodata`, the current budget is:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -432,6 +432,13 @@ tool uses a 4 KiB buffer by default, and smaller buffers are valid for tests or
 tighter embedded integrations. The library must not call file APIs; tools/tests
 may implement a consumer that writes to a file.
 
+For IDR macroblock-slice NALUs, the streaming-output path writes completed RBSP
+bytes directly into the Annex B chunk writer and inserts emulation-prevention
+bytes before flushing to the consumer. It does not allocate a full-frame,
+full-row, or full-NALU output buffer. Consumer callback failures are returned
+from the active encode call and reset the progressive encoder state in the
+JPEG streaming wrapper.
+
 `sh264e_jpeg_get_last_allocation_stats` reports the current and peak tracked
 JPEG allocations from the last JPEG work-size query or encode call.
 `sh264e_jpeg_get_last_streaming_cache_bytes` reports the decoded row-cache

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -57,23 +57,28 @@ static unsigned sh264e_u32_floor_log2(uint32_t value)
 #endif
 }
 
+typedef struct sh264e_chunk_writer_t sh264e_chunk_writer_t;
+
 typedef struct sh264e_bit_writer_t {
     uint8_t *data;
     size_t capacity;
     size_t byte_pos;
     uint8_t pending_byte;
     unsigned pending_bits;
+    sh264e_chunk_writer_t *annexb_writer;
+    unsigned annexb_zero_count;
+    sh264e_status_t status;
     int error;
 } sh264e_bit_writer_t;
 
-typedef struct sh264e_chunk_writer_t {
+struct sh264e_chunk_writer_t {
     uint8_t *buffer;
     size_t capacity;
     size_t size;
     size_t total;
     sh264e_output_consumer_t consumer;
     void *user;
-} sh264e_chunk_writer_t;
+};
 
 struct sh264e_encoder_t {
     sh264e_config_t config;
@@ -217,6 +222,7 @@ static sh264e_status_t sh264e_encode_jpeg_idr_streaming_impl(sh264e_encoder_t *e
                                                              size_t *out_size,
                                                              sh264e_output_consumer_t consumer,
                                                              void *consumer_user);
+static sh264e_status_t chunk_writer_put_byte(sh264e_chunk_writer_t *writer, uint8_t value);
 
 static const uint8_t k_luma4x4_x[16] = {
     0, 4, 0, 4, 8, 12, 8, 12, 0, 4, 0, 4, 8, 12, 8, 12
@@ -1743,6 +1749,9 @@ static void bw_init(sh264e_bit_writer_t *bw, uint8_t *data, size_t capacity)
     bw->byte_pos = 0;
     bw->pending_byte = 0;
     bw->pending_bits = 0;
+    bw->annexb_writer = NULL;
+    bw->annexb_zero_count = 0u;
+    bw->status = SH264E_OK;
     bw->error = 0;
 }
 
@@ -1753,31 +1762,65 @@ static size_t bw_size(const sh264e_bit_writer_t *bw)
 
 static void bw_store_pending(sh264e_bit_writer_t *bw)
 {
+    if (bw->annexb_writer != NULL) {
+        return;
+    }
     if (bw->byte_pos >= bw->capacity) {
         bw->error = 1;
+        bw->status = SH264E_ERR_INTERNAL;
         return;
     }
     bw->data[bw->byte_pos] = bw->pending_byte;
 }
 
-static void bw_commit_pending_byte(sh264e_bit_writer_t *bw)
+static void bw_write_complete_byte(sh264e_bit_writer_t *bw, uint8_t value)
 {
-    bw_store_pending(bw);
-    if (bw->error != 0) {
+    sh264e_status_t status;
+
+    if (bw->annexb_writer != NULL) {
+        if (bw->annexb_zero_count >= 2u && value <= 0x03u) {
+            status = chunk_writer_put_byte(bw->annexb_writer, 0x03u);
+            if (status != SH264E_OK) {
+                bw->status = status;
+                bw->error = 1;
+                return;
+            }
+            bw->annexb_zero_count = 0u;
+        }
+
+        status = chunk_writer_put_byte(bw->annexb_writer, value);
+        if (status != SH264E_OK) {
+            bw->status = status;
+            bw->error = 1;
+            return;
+        }
+        if (value == 0x00u) {
+            bw->annexb_zero_count++;
+        } else {
+            bw->annexb_zero_count = 0u;
+        }
+        bw->byte_pos++;
         return;
     }
-    bw->byte_pos++;
+
+    if (bw->byte_pos >= bw->capacity) {
+        bw->error = 1;
+        bw->status = SH264E_ERR_INTERNAL;
+        return;
+    }
+    bw->data[bw->byte_pos++] = value;
+}
+
+static void bw_commit_pending_byte(sh264e_bit_writer_t *bw)
+{
+    bw_write_complete_byte(bw, bw->pending_byte);
     bw->pending_byte = 0;
     bw->pending_bits = 0;
 }
 
 static void bw_write_aligned_byte(sh264e_bit_writer_t *bw, uint8_t value)
 {
-    if (bw->byte_pos >= bw->capacity) {
-        bw->error = 1;
-        return;
-    }
-    bw->data[bw->byte_pos++] = value;
+    bw_write_complete_byte(bw, value);
 }
 
 static void bw_write_bits(sh264e_bit_writer_t *bw, uint32_t bits, unsigned count);
@@ -2000,6 +2043,33 @@ static sh264e_status_t stream_annexb_nalu(uint8_t *chunk_buffer,
     }
     *out_size = writer.total;
     return SH264E_OK;
+}
+
+static sh264e_status_t bw_begin_annexb_nalu(sh264e_bit_writer_t *bw,
+                                            sh264e_chunk_writer_t *writer,
+                                            uint8_t nal_header)
+{
+    sh264e_status_t status;
+
+    if (bw == NULL || writer == NULL) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+
+    bw_init(bw, NULL, 0u);
+    bw->annexb_writer = writer;
+    status = chunk_writer_put_byte(writer, 0x00u);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    status = chunk_writer_put_byte(writer, 0x00u);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    status = chunk_writer_put_byte(writer, 0x01u);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    return chunk_writer_put_byte(writer, nal_header);
 }
 
 static sh264e_status_t append_annexb_nalu(uint8_t *out,
@@ -2438,13 +2508,12 @@ static void write_i_nxn_fixed_prefix(sh264e_bit_writer_t *bw)
     bw_write_bits(bw, 0x3ffffu, SH264E_I_NXN_FIXED_PREFIX_BITS);
 }
 
-static sh264e_status_t write_idr_mb_slice_rbsp(sh264e_encoder_t *encoder,
-                                               const sh264e_slice_t *slice,
-                                               unsigned row_index,
-                                               unsigned mb_x,
-                                               size_t *out_rbsp_size)
+static sh264e_status_t write_idr_mb_slice_payload(sh264e_encoder_t *encoder,
+                                                  const sh264e_slice_t *slice,
+                                                  unsigned row_index,
+                                                  unsigned mb_x,
+                                                  sh264e_bit_writer_t *bw)
 {
-    sh264e_bit_writer_t bw;
     int levels[16];
     int chroma_dc[2];
     unsigned b;
@@ -2452,9 +2521,7 @@ static sh264e_status_t write_idr_mb_slice_rbsp(sh264e_encoder_t *encoder,
     unsigned cbp_chroma;
     unsigned cbp;
 
-    bw_init(&bw, encoder->rbsp, encoder->rbsp_capacity);
-
-    write_idr_mb_slice_header(&bw, row_index * SH264E_MBS_X + mb_x);
+    write_idr_mb_slice_header(bw, row_index * SH264E_MBS_X + mb_x);
 
     for (b = 0; b < 16u; b++) {
         const unsigned x = k_luma4x4_x[b];
@@ -2471,29 +2538,47 @@ static sh264e_status_t write_idr_mb_slice_rbsp(sh264e_encoder_t *encoder,
     cbp_chroma = (chroma_dc[0] != 0 || chroma_dc[1] != 0) ? 1u : 0u;
     cbp = cbp_luma + cbp_chroma * 16u;
 
-    write_i_nxn_fixed_prefix(&bw);
-    bw_write_ue(&bw, k_cbp_intra_code_num[cbp]);
+    write_i_nxn_fixed_prefix(bw);
+    bw_write_ue(bw, k_cbp_intra_code_num[cbp]);
 
     if (cbp != 0u) {
-        bw_write_bit(&bw, 1);                    /* mb_qp_delta: se(0) */
+        bw_write_bit(bw, 1);                     /* mb_qp_delta: se(0) */
         for (b = 0; b < 16u; b++) {
             if ((cbp_luma & (1u << (b / 4u))) != 0u) {
-                write_luma_residual_dc_only(&bw, levels[b], 0u);
+                write_luma_residual_dc_only(bw, levels[b], 0u);
             }
         }
         if (cbp_chroma != 0u) {
-            write_chroma_dc_residual(&bw, chroma_dc[0]);
-            write_chroma_dc_residual(&bw, chroma_dc[1]);
+            write_chroma_dc_residual(bw, chroma_dc[0]);
+            write_chroma_dc_residual(bw, chroma_dc[1]);
         }
     }
 
-    if (bw.error != 0) {
-        return SH264E_ERR_INTERNAL;
+    if (bw->error != 0) {
+        return bw->status != SH264E_OK ? bw->status : SH264E_ERR_INTERNAL;
     }
 
-    bw_rbsp_trailing_bits(&bw);
-    if (bw.error != 0) {
-        return SH264E_ERR_INTERNAL;
+    bw_rbsp_trailing_bits(bw);
+    if (bw->error != 0) {
+        return bw->status != SH264E_OK ? bw->status : SH264E_ERR_INTERNAL;
+    }
+    return SH264E_OK;
+}
+
+static sh264e_status_t write_idr_mb_slice_rbsp(sh264e_encoder_t *encoder,
+                                               const sh264e_slice_t *slice,
+                                               unsigned row_index,
+                                               unsigned mb_x,
+                                               size_t *out_rbsp_size)
+{
+    sh264e_bit_writer_t bw;
+    sh264e_status_t status;
+
+    bw_init(&bw, encoder->rbsp, encoder->rbsp_capacity);
+
+    status = write_idr_mb_slice_payload(encoder, slice, row_index, mb_x, &bw);
+    if (status != SH264E_OK) {
+        return status;
     }
     *out_rbsp_size = bw_size(&bw);
     return SH264E_OK;
@@ -2515,6 +2600,47 @@ static sh264e_status_t make_idr_slice(sh264e_encoder_t *encoder,
         return status;
     }
     return append_annexb_nalu(out, capacity, offset, 0x65u, encoder->rbsp, rbsp_size);
+}
+
+static sh264e_status_t stream_idr_slice_nalu_direct(sh264e_encoder_t *encoder,
+                                                    const sh264e_slice_t *slice,
+                                                    unsigned row_index,
+                                                    unsigned mb_x,
+                                                    uint8_t *chunk_buffer,
+                                                    size_t chunk_capacity,
+                                                    size_t *out_size,
+                                                    sh264e_output_consumer_t consumer,
+                                                    void *consumer_user)
+{
+    sh264e_chunk_writer_t writer;
+    sh264e_bit_writer_t bw;
+    sh264e_status_t status;
+
+    if (chunk_buffer == NULL || out_size == NULL || consumer == NULL ||
+        chunk_capacity == 0u) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+
+    memset(&writer, 0, sizeof(writer));
+    writer.buffer = chunk_buffer;
+    writer.capacity = chunk_capacity;
+    writer.consumer = consumer;
+    writer.user = consumer_user;
+
+    status = bw_begin_annexb_nalu(&bw, &writer, 0x65u);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    status = write_idr_mb_slice_payload(encoder, slice, row_index, mb_x, &bw);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    status = chunk_writer_flush(&writer);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    *out_size = writer.total;
+    return SH264E_OK;
 }
 
 static sh264e_status_t map_jpeg_result(int result)
@@ -3508,16 +3634,10 @@ static sh264e_status_t sh264e_encode_idr_slice_to_consumer_internal(
     {
         unsigned mb_x;
         for (mb_x = 0; mb_x < SH264E_MBS_X; mb_x++) {
-            size_t rbsp_size = 0u;
             size_t nalu_size = 0u;
-            status = write_idr_mb_slice_rbsp(encoder, slice, encoder->slices_encoded,
-                                             mb_x, &rbsp_size);
-            if (status != SH264E_OK) {
-                return status;
-            }
-            status = stream_annexb_nalu(chunk_buffer, chunk_capacity, &nalu_size,
-                                        consumer, consumer_user, 0x65u,
-                                        encoder->rbsp, rbsp_size);
+            status = stream_idr_slice_nalu_direct(encoder, slice, encoder->slices_encoded,
+                                                  mb_x, chunk_buffer, chunk_capacity,
+                                                  &nalu_size, consumer, consumer_user);
             if (status != SH264E_OK) {
                 return status;
             }


### PR DESCRIPTION
Refs #97

## Summary

- Added an Annex B streaming mode to the internal bit writer so completed IDR macroblock-slice RBSP bytes can flow directly through emulation-prevention insertion into the output consumer.
- Kept caller-buffer SPS/PPS and progressive slice APIs on the existing RBSP scratch path, preserving public API behavior and encoder memory report values.
- Reused the same independent-MB syntax writer for scratch-backed and direct-streaming paths so output remains byte-identical.
- Updated README and memory/spec/Cortex-M docs for the direct streaming-output path and unchanged scratch/arena reporting.

## Validation

- `cmake -S . -B build-issue97 -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build-issue97`
- `ctest --test-dir build-issue97 --output-on-failure`
- `git diff --check`
- `python3 -m py_compile tests/run_ffmpeg_integration.py tests/run_qemu_proxy_timing.py`
- `C_INCLUDE_PATH=/tmp/sh264e_arm_min_headers cmake -S . -B build-qemu-issue97 -DSH264E_BUILD_QEMU_TESTS=ON`
- `C_INCLUDE_PATH=/tmp/sh264e_arm_min_headers cmake --build build-qemu-issue97 --target sh264e_qemu_encoder_bench_m4 sh264e_qemu_encoder_bench_m4_portable sh264e_qemu_encoder_bench_m7 sh264e_qemu_encoder_bench_m7_portable`
- `ctest --test-dir build-qemu-issue97 -R 'sh264e_qemu_encoder_bench_(m4|m7)' --output-on-failure`
- `python3 tests/run_qemu_proxy_timing.py --build-dir build-qemu-issue97 --repeat 3 --target sh264e_qemu_encoder_bench_m4 --target sh264e_qemu_encoder_bench_m4_portable --target sh264e_qemu_encoder_bench_m7 --target sh264e_qemu_encoder_bench_m7_portable`

## QEMU Proxy Timing Sample

Values are host/QEMU wall time only, not Cortex-M cycles.

| Target firmware | Variant | Repeats | Median wall time | Min wall time | Max wall time | Status |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| `sh264e_qemu_encoder_bench_m4` | DSP-capable | 3 | 0.039514s | 0.037483s | 0.039835s | pass |
| `sh264e_qemu_encoder_bench_m4_portable` | portable C | 3 | 0.039524s | 0.037238s | 0.039982s | pass |
| `sh264e_qemu_encoder_bench_m7` | DSP-capable | 3 | 0.039314s | 0.039199s | 0.039441s | pass |
| `sh264e_qemu_encoder_bench_m7_portable` | portable C | 3 | 0.039923s | 0.038720s | 0.040020s | pass |

## Notes

- The local Homebrew `arm-none-eabi-gcc` still lacks bundled C library headers. QEMU firmware validation used the existing temporary minimal declaration headers at `/tmp/sh264e_arm_min_headers` while preserving the repo's freestanding firmware link.
