### PR TITLE
CI: add macOS host validation

### DIFF
--- a/.github/workflows/macos-validation.yml
+++ b/.github/workflows/macos-validation.yml
@@ -1,0 +1,39 @@
+name: macOS validation
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  macos:
+    name: macOS host validation
+    runs-on: macos-15
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v4
+
+      - name: Log toolchain versions
+        run: |
+          xcodebuild -version
+          clang --version
+          cmake --version
+
+      - name: Configure macOS host build
+        run: |
+          cmake -S . -B build-macos \
+            -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build macOS host targets
+        run: cmake --build build-macos --parallel
+
+      - name: Run macOS host tests
+        run: ctest --test-dir build-macos --output-on-failure


### PR DESCRIPTION
Refs #108

## Summary

- Add a `macos-15` GitHub Actions workflow for macOS host validation.
- Log Xcode, Clang, and CMake versions before building.
- Configure, build, and run the host CTest suite with AppleClang.
- Keep iOS, signing, simulator, device, and Xcode project work out of scope.

## Validation

- `xcodebuild -version`
- `clang --version`
- `cmake --version`
- `cmake -S . -B build-macos-issue108 -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build-macos-issue108 --parallel`
- `ctest --test-dir build-macos-issue108 --output-on-failure`
