### PR TITLE
Release: build FreeRTOS Cortex-M7 packages

### DIFF
--- a/.github/workflows/linux-validation.yml
+++ b/.github/workflows/linux-validation.yml
@@ -29,6 +29,7 @@ jobs:
             ninja-build \
             ffmpeg \
             libjpeg-turbo-progs \
+            binutils-arm-none-eabi \
             gcc-arm-none-eabi \
             libnewlib-arm-none-eabi \
             qemu-system-arm
@@ -75,3 +76,12 @@ jobs:
 
       - name: Build production profile
         run: cmake --build build-prod --parallel
+
+      - name: Build FreeRTOS Cortex-M7 developer packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(sed -nE 's/^[[:space:]]*project\([[:space:]]*simple_h264_enc_i[[:space:]]+VERSION[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+).*$/\1/p' CMakeLists.txt)"
+          scripts/build_freertos_cortex_m7_packages.sh \
+            --version "${version}" \
+            --output-dir build/freertos-cortex-m7-packages

--- a/.github/workflows/source-release.yml
+++ b/.github/workflows/source-release.yml
@@ -26,6 +26,7 @@ jobs:
             ninja-build \
             ffmpeg \
             libjpeg-turbo-progs \
+            binutils-arm-none-eabi \
             gcc-arm-none-eabi \
             libnewlib-arm-none-eabi \
             qemu-system-arm
@@ -100,16 +101,24 @@ jobs:
         run: ctest --test-dir build-macos --output-on-failure
 
   release:
-    name: Publish source release
+    name: Publish source and FreeRTOS release
     runs-on: ubuntu-24.04
     needs:
       - linux-validation
       - macos-validation
-    timeout-minutes: 10
+    timeout-minutes: 20
 
     steps:
       - name: Check out sources
         uses: actions/checkout@v6
+
+      - name: Install release package dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            binutils-arm-none-eabi \
+            gcc-arm-none-eabi \
+            libnewlib-arm-none-eabi
 
       - name: Verify tag matches CMake project version
         shell: bash
@@ -141,16 +150,29 @@ jobs:
         run: |
           set -euo pipefail
 
+          mkdir -p release-assets
           archive="simple_h264_enc_i-${VERSION}.tar.gz"
-          git archive --format=tar --prefix="simple_h264_enc_i-${VERSION}/" HEAD | gzip -n > "${archive}"
-          sha256sum "${archive}" > "${archive}.sha256"
+          git archive --format=tar --prefix="simple_h264_enc_i-${VERSION}/" HEAD | gzip -n > "release-assets/${archive}"
+          (cd release-assets && sha256sum "${archive}" > "${archive}.sha256")
+
+      - name: Build FreeRTOS Cortex-M7 developer packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/build_freertos_cortex_m7_packages.sh \
+            --version "${VERSION}" \
+            --output-dir release-assets
 
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "${GITHUB_REF_NAME}" \
-            "simple_h264_enc_i-${VERSION}.tar.gz" \
-            "simple_h264_enc_i-${VERSION}.tar.gz.sha256" \
+            "release-assets/simple_h264_enc_i-${VERSION}.tar.gz" \
+            "release-assets/simple_h264_enc_i-${VERSION}.tar.gz.sha256" \
+            "release-assets/simple_h264_enc_i-${VERSION}-freertos-cortex-m7-soft.tar.gz" \
+            "release-assets/simple_h264_enc_i-${VERSION}-freertos-cortex-m7-soft.tar.gz.sha256" \
+            "release-assets/simple_h264_enc_i-${VERSION}-freertos-cortex-m7-fpv5-sp-hard.tar.gz" \
+            "release-assets/simple_h264_enc_i-${VERSION}-freertos-cortex-m7-fpv5-sp-hard.tar.gz.sha256" \
             --target "${GITHUB_SHA}" \
             --generate-notes

--- a/README.md
+++ b/README.md
@@ -119,25 +119,53 @@ Pull requests and `main` pushes run the supported CI validation matrix:
 
 | Workflow | Runner | Coverage |
 | --- | --- | --- |
-| `linux-validation.yml` | `ubuntu-24.04` | Debug CMake/Ninja build, ffmpeg integration, Cortex-M4/M7 QEMU scaler and encoder firmware tests, and Release production-profile build |
+| `linux-validation.yml` | `ubuntu-24.04` | Debug CMake/Ninja build, ffmpeg integration, Cortex-M4/M7 QEMU scaler and encoder firmware tests, Release production-profile build, and FreeRTOS Cortex-M7 developer package validation |
 | `macos-validation.yml` | `macos-15` | AppleClang host Debug build and CTest, with Xcode, Clang, and CMake versions logged |
 
 Android and iOS validation are not supported CI targets for this release
-tranche. Cortex-M4/M7 coverage is provided by the Ubuntu QEMU firmware tests,
-not by publishing embedded binaries.
+tranche. Cortex-M4/M7 validation is provided by the Ubuntu QEMU firmware tests,
+and release assets additionally include Cortex-M7 FreeRTOS static-library
+developer packages.
 
 Source releases are created by `source-release.yml` on tags that match
 `v*.*.*`. The release workflow reruns the Linux/QEMU and macOS validation gates,
 verifies the tag `vX.Y.Z` matches
-`project(simple_h264_enc_i VERSION X.Y.Z)` in `CMakeLists.txt`, then publishes
-only:
+`project(simple_h264_enc_i VERSION X.Y.Z)` in `CMakeLists.txt`, then publishes:
 
 * `simple_h264_enc_i-${VERSION}.tar.gz`
 * `simple_h264_enc_i-${VERSION}.tar.gz.sha256`
+* `simple_h264_enc_i-${VERSION}-freertos-cortex-m7-soft.tar.gz`
+* `simple_h264_enc_i-${VERSION}-freertos-cortex-m7-soft.tar.gz.sha256`
+* `simple_h264_enc_i-${VERSION}-freertos-cortex-m7-fpv5-sp-hard.tar.gz`
+* `simple_h264_enc_i-${VERSION}-freertos-cortex-m7-fpv5-sp-hard.tar.gz.sha256`
 * generated GitHub release notes
 
 The source archive is produced with `git archive` and `gzip -n` so repeated
 builds of the same commit and version are deterministic.
+
+FreeRTOS Cortex-M7 developer packages contain:
+
+* `include/sh264e.h`
+* `lib/libsimple_h264_enc_i.a`
+* `docs/README-FREERTOS-CORTEX-M7.md`
+* `docs/API.md`
+* `docs/MEMORY.md`
+* `build-info.txt`
+* `manifest.txt`
+
+Choose `freertos-cortex-m7-soft` for FreeRTOS projects compiled with
+`-mfloat-abi=soft`. Choose `freertos-cortex-m7-fpv5-sp-hard` for Cortex-M7
+single-precision FPU projects compiled with
+`-mfpu=fpv5-sp-d16 -mfloat-abi=hard`. The consuming application must compile
+its objects with compatible `-mcpu=cortex-m7`, `-mthumb`, FPU, and
+`-mfloat-abi` settings; hard-float and soft-float object files are not ABI
+compatible.
+
+The Cortex-M7 packages are built from the production library sources only
+(`src/sh264e.c` and `src/nanojpeg.c`) with tools, tests, JPEG diagnostic hooks,
+and NanoJPEG full-image decode exports disabled. They are developer integration
+packages, not standalone host Linux/macOS binaries. Android and iOS artifacts
+remain out of scope.
 
 Release checklist:
 
@@ -145,7 +173,8 @@ Release checklist:
 2. Merge the release commit to `main`.
 3. Confirm the Linux and macOS CI workflows are green on `main`.
 4. Create and push the matching tag: `git tag vX.Y.Z && git push origin vX.Y.Z`.
-5. Verify the GitHub Release contains the source archive and SHA-256 checksum.
+5. Verify the GitHub Release contains the source archive, both Cortex-M7
+   FreeRTOS packages, and all SHA-256 checksums.
 
 ## CLI Example
 

--- a/docs/freertos-cortex-m7/API.md
+++ b/docs/freertos-cortex-m7/API.md
@@ -1,0 +1,108 @@
+# FreeRTOS Cortex-M7 Public API
+
+The public C API is declared in `include/sh264e.h`. This document summarizes
+the application-facing surface included in the FreeRTOS Cortex-M7 package.
+
+## Fixed Encoder Geometry
+
+The current encoder supports a fixed v1 IDR frame geometry:
+
+```text
+SH264E_V1_WIDTH = 2560
+SH264E_V1_HEIGHT = 1440
+SH264E_V1_SLICE_COUNT = 90
+SH264E_V1_SLICE_LUMA_HEIGHT = 16
+SH264E_V1_SLICE_CHROMA_HEIGHT = 8
+```
+
+Input frames and slices use either `SH264E_PIXFMT_I420` or
+`SH264E_PIXFMT_NV12`.
+
+## Encoder Lifecycle
+
+Use `sh264e_encoder_get_work_size` and
+`sh264e_encoder_create_with_arena` for embedded integrations that provide a
+caller-owned arena. Use `sh264e_encoder_destroy` to end the encoder lifetime;
+it does not free caller-owned arena memory.
+
+Heap-backed `sh264e_encoder_create` remains part of the public API, but
+FreeRTOS integrations should prefer explicit arenas unless their runtime
+allocator policy is already defined.
+
+## Raw Progressive Encoding
+
+For direct raw input, call:
+
+```text
+sh264e_begin_idr
+sh264e_encode_idr_slice
+sh264e_end_idr
+```
+
+The caller provides each 16-luma-row / 8-chroma-row output slice. The encoder
+emits Annex B SPS, PPS, and independent macroblock-slice IDR NAL units.
+
+`sh264e_encode_idr` remains available for callers that already have a complete
+fixed-geometry input frame and a complete output buffer.
+
+## Resize Helpers
+
+Use `sh264e_resize_get_slice_buffer_size` to size the caller-owned resize work
+buffer and `sh264e_resize_make_slice` to produce one fixed-geometry encoder
+slice from an even-dimension I420 or NV12 source frame.
+
+The supported source range is:
+
+```text
+1280 <= src_width  <= 5120
+720  <= src_height <= 2880
+```
+
+The exact `1280x720 -> 2560x1440`, `5120x2880 -> 2560x1440`, and
+`2560x1440 -> 2560x1440` paths use optimized fixed-ratio behavior.
+
+## JPEG Input
+
+Use `sh264e_jpeg_get_work_size` or `sh264e_jpeg_source_get_work_size` to size
+the JPEG decoder arena. Use `sh264e_jpeg_get_slice_work_size` or
+`sh264e_jpeg_source_get_slice_work_size` to size the path-specific slice work
+buffer.
+
+The production streaming entry points are:
+
+```text
+sh264e_encode_jpeg_idr_with_arena_stream
+sh264e_encode_jpeg_source_idr_with_arena_stream
+```
+
+The memory-input variant accepts a contiguous compressed JPEG buffer. The
+source-input variant accepts a pull-only sequential reader callback. Work-size
+queries consume source readers, so reset or recreate the reader before the
+slice-work query and the encode call.
+
+## Output Consumer
+
+The streaming JPEG APIs emit Annex B bytes through:
+
+```text
+typedef sh264e_status_t (*sh264e_output_consumer_t)(
+    void *user,
+    const uint8_t *data,
+    size_t size);
+```
+
+The consumer is called synchronously. Return `SH264E_OK` after accepting the
+chunk or another `sh264e_status_t` value to abort encoding.
+
+## Diagnostics
+
+The package keeps the public memory/stat APIs:
+
+```text
+sh264e_encoder_get_memory_report
+sh264e_jpeg_get_last_allocation_stats
+sh264e_jpeg_get_last_streaming_cache_bytes
+sh264e_jpeg_get_last_slice_work_bytes
+```
+
+Use `sh264e_status_string` for diagnostic text for `sh264e_status_t` values.

--- a/docs/freertos-cortex-m7/MEMORY.md
+++ b/docs/freertos-cortex-m7/MEMORY.md
@@ -1,0 +1,117 @@
+# FreeRTOS Cortex-M7 Memory Notes
+
+The library is designed for caller-owned memory. FreeRTOS applications should
+allocate arenas and output buffers from known memory regions that match the
+board's SRAM, DTCM, cache, DMA, and task-stack policy.
+
+## Encoder Arena
+
+For the supported fixed v1 configuration, `sh264e_encoder_get_work_size`
+currently reports a 303-byte caller arena requirement for
+`sh264e_encoder_create_with_arena`.
+
+`sh264e_encoder_get_memory_report` reports the encoder-owned breakdown:
+
+```text
+context/control bytes: 40
+bitstream scratch bytes: 256
+reconstructed luma bytes: 0
+reconstructed chroma bytes: 0
+neighbor state bytes: 0
+total bytes: 296
+```
+
+The arena size is slightly larger than the total to allow internal alignment of
+the opaque encoder control structure.
+
+## Output Buffers
+
+The caller-buffer APIs require enough output capacity for the requested header,
+slice, or complete frame. Query:
+
+```text
+sh264e_get_max_header_output_size
+sh264e_get_max_slice_output_size
+sh264e_get_max_output_size
+```
+
+For embedded JPEG paths, prefer the streaming output consumer APIs. They allow a
+small reusable output chunk buffer and synchronous forwarding to flash, storage,
+DMA, or a ring buffer instead of requiring a full-frame H.264 output buffer.
+
+## Raw Resize Work Buffer
+
+For raw I420 or NV12 source frames, use:
+
+```text
+sh264e_resize_get_slice_buffer_size
+sh264e_resize_make_slice
+```
+
+The caller owns the work buffer and the source frame. The resize helper returns
+one encoder slice at a time.
+
+## JPEG Decoder Arena
+
+For contiguous JPEG input, size the decoder arena with:
+
+```text
+sh264e_jpeg_get_work_size
+```
+
+For pull-only sequential JPEG input, size the decoder arena with:
+
+```text
+sh264e_jpeg_source_get_work_size
+```
+
+Both sizing paths parse the JPEG input. Source-reader sizing consumes the
+reader, so reset or recreate the source before the next sizing call or encode
+call.
+
+## JPEG Slice Work Buffer
+
+The conservative worst-case query is:
+
+```text
+sh264e_jpeg_get_slice_buffer_size
+```
+
+For a specific JPEG and output pixel format, use:
+
+```text
+sh264e_jpeg_get_slice_work_size
+sh264e_jpeg_source_get_slice_work_size
+```
+
+`sh264e_jpeg_get_last_slice_work_bytes` reports the effective slice staging
+used by the last JPEG encode.
+
+## JPEG Streaming Cache Diagnostics
+
+The production JPEG path uses MCU-row streaming rather than full-image decode.
+Use these public diagnostics after an encode:
+
+```text
+sh264e_jpeg_get_last_allocation_stats
+sh264e_jpeg_get_last_streaming_cache_bytes
+```
+
+The reported peak allocation excludes caller-owned compressed JPEG input,
+encoder arena, H.264 output buffers, RTOS task stacks, driver buffers, and any
+application-level queues.
+
+## Allocation Policy
+
+The package is built with `NJ_USE_LIBC=0` and no private JPEG test hooks.
+Production FreeRTOS integrations should decide explicitly where each buffer
+lives:
+
+* encoder arena
+* JPEG decoder arena
+* raw resize or JPEG slice work buffer
+* streaming output chunk buffer
+* source frame or compressed JPEG input
+* RTOS task stack and driver/DMA buffers
+
+Keep cache maintenance and DMA ownership outside the library boundary.

--- a/docs/freertos-cortex-m7/README-FREERTOS-CORTEX-M7.md
+++ b/docs/freertos-cortex-m7/README-FREERTOS-CORTEX-M7.md
@@ -1,0 +1,114 @@
+# FreeRTOS Cortex-M7 Package
+
+This package contains the production `simple_h264_enc_i` static library for
+FreeRTOS Cortex-M7 applications. It is a developer package, not a complete
+board support package.
+
+## Contents
+
+```text
+include/sh264e.h
+lib/libsimple_h264_enc_i.a
+docs/README-FREERTOS-CORTEX-M7.md
+docs/API.md
+docs/MEMORY.md
+build-info.txt
+manifest.txt
+```
+
+The library is built only from:
+
+* `src/sh264e.c`
+* `src/nanojpeg.c`
+* `include/sh264e.h`
+
+The package does not include tools, tests, host binaries, Android artifacts, or
+iOS artifacts.
+
+## Choose The ABI
+
+Use the soft-float package when the consuming FreeRTOS application is compiled
+without a hard-float ABI:
+
+```text
+simple_h264_enc_i-${VERSION}-freertos-cortex-m7-soft.tar.gz
+```
+
+Use the hard-float package when the application is compiled for the common
+Cortex-M7 FPv5 single-precision ABI:
+
+```text
+simple_h264_enc_i-${VERSION}-freertos-cortex-m7-fpv5-sp-hard.tar.gz
+```
+
+The application and every linked static library must use compatible CPU,
+Thumb, FPU, and float ABI settings. Do not mix `-mfloat-abi=soft` and
+`-mfloat-abi=hard` objects in the same firmware image.
+
+## Compiler Flags
+
+The package library is built with `arm-none-eabi-gcc` using:
+
+```sh
+-mcpu=cortex-m7
+-mthumb
+-O2
+-ffreestanding
+-fno-builtin
+-ffunction-sections
+-fdata-sections
+-DNJ_USE_LIBC=0
+-Iinclude
+```
+
+The ABI-specific flags are either:
+
+```sh
+-mfloat-abi=soft
+```
+
+or:
+
+```sh
+-mfpu=fpv5-sp-d16
+-mfloat-abi=hard
+```
+
+Use matching flags in the consuming firmware project. Keep
+`-ffunction-sections` and `-fdata-sections` enabled if the final firmware link
+uses `--gc-sections`.
+
+## Integration Steps
+
+1. Copy or reference `include/sh264e.h` from the package in the firmware include
+   path.
+2. Add `lib/libsimple_h264_enc_i.a` to the firmware link.
+3. Compile application code with matching Cortex-M7 and float ABI flags.
+4. Provide all input, output, JPEG arena, encoder arena, and slice-work buffers
+   from application-owned memory.
+5. Route encoded Annex B bytes from the streaming output consumer to flash,
+   storage, DMA, or a caller-owned ring buffer.
+
+The library performs no file I/O and does not own board drivers, RTOS tasks,
+DMA policy, flash layout, camera input, or retry policy.
+
+## Production Policy
+
+The package is built with the production policy:
+
+```text
+SH264E_BUILD_TOOLS=OFF
+SH264E_BUILD_TESTS=OFF
+SH264E_ENABLE_JPEG_TEST_HOOKS=OFF
+NJ_USE_LIBC=0
+```
+
+Private JPEG fault-injection hooks, prototype streaming symbols, and NanoJPEG
+full-image decode entry points are rejected by the package symbol audit.
+
+## Metadata
+
+`build-info.txt` records the version, git commit, compiler path and version,
+archive tools, target flags, source files, and production policy.
+
+`manifest.txt` records SHA-256 checksums for the package payload files.

--- a/scripts/build_freertos_cortex_m7_packages.sh
+++ b/scripts/build_freertos_cortex_m7_packages.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/build_freertos_cortex_m7_packages.sh [--version X.Y.Z] [--output-dir DIR] [--build-dir DIR]
+
+Build and validate FreeRTOS Cortex-M7 developer packages for the production
+static library. The script emits both soft-float and fpv5-sp-d16 hard-float
+package archives plus .sha256 checksum files.
+EOF
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_dir="$(cd "${script_dir}/.." && pwd)"
+version=""
+output_dir="${repo_dir}/build/freertos-cortex-m7-packages"
+build_dir=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version)
+            if [[ $# -lt 2 ]]; then
+                echo "--version requires a value" >&2
+                exit 2
+            fi
+            version="$2"
+            shift 2
+            ;;
+        --output-dir)
+            if [[ $# -lt 2 ]]; then
+                echo "$1 requires a value" >&2
+                exit 2
+            fi
+            output_dir="$2"
+            shift 2
+            ;;
+        --out-dir)
+            if [[ $# -lt 2 ]]; then
+                echo "$1 requires a value" >&2
+                exit 2
+            fi
+            output_dir="$2"
+            shift 2
+            ;;
+        --build-dir)
+            if [[ $# -lt 2 ]]; then
+                echo "--build-dir requires a value" >&2
+                exit 2
+            fi
+            build_dir="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ -z "${version}" ]]; then
+    version="$(sed -nE 's/^[[:space:]]*project\([[:space:]]*simple_h264_enc_i[[:space:]]+VERSION[[:space:]]+([0-9]+\.[0-9]+\.[0-9]+).*$/\1/p' "${repo_dir}/CMakeLists.txt")"
+fi
+if [[ -z "${version}" ]]; then
+    echo "Could not determine project version from CMakeLists.txt" >&2
+    exit 1
+fi
+
+cc="${ARM_NONE_EABI_GCC:-arm-none-eabi-gcc}"
+ar="${ARM_NONE_EABI_AR:-arm-none-eabi-ar}"
+nm="${ARM_NONE_EABI_NM:-arm-none-eabi-nm}"
+
+require_tool() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "Required tool not found: $1" >&2
+        exit 1
+    fi
+}
+
+require_tool "${cc}"
+require_tool "${ar}"
+require_tool "${nm}"
+require_tool tar
+require_tool gzip
+
+if command -v sha256sum >/dev/null 2>&1; then
+    checksum_file() {
+        sha256sum "$1"
+    }
+elif command -v shasum >/dev/null 2>&1; then
+    checksum_file() {
+        shasum -a 256 "$1"
+    }
+else
+    echo "Required SHA-256 tool not found: sha256sum or shasum" >&2
+    exit 1
+fi
+
+mkdir -p "${output_dir}"
+output_dir="$(cd "${output_dir}" && pwd)"
+if [[ -z "${build_dir}" ]]; then
+    build_dir="${output_dir}/_build"
+fi
+mkdir -p "${build_dir}"
+build_root="$(cd "${build_dir}" && pwd)"
+package_root="${output_dir}/_packages"
+rm -rf "${build_root}" "${package_root}"
+mkdir -p "${build_root}" "${package_root}"
+
+git_commit="$(git -C "${repo_dir}" rev-parse HEAD 2>/dev/null || printf 'unknown')"
+cc_path="$(command -v "${cc}")"
+ar_path="$(command -v "${ar}")"
+nm_path="$(command -v "${nm}")"
+cc_version="$("${cc}" --version | sed -n '1,3p')"
+
+common_flags=(
+    -mcpu=cortex-m7
+    -mthumb
+    -O2
+    -ffreestanding
+    -fno-builtin
+    -ffunction-sections
+    -fdata-sections
+    -DNJ_USE_LIBC=0
+    -DSH264E_ENABLE_JPEG_TEST_HOOKS=0
+    "-I${repo_dir}/include"
+)
+
+required_symbols=(
+    sh264e_encode_jpeg_idr_with_arena_stream
+    sh264e_encode_jpeg_source_idr_with_arena_stream
+    sh264e_jpeg_source_get_work_size
+    sh264e_jpeg_source_get_slice_work_size
+    sh264e_jpeg_get_last_allocation_stats
+    sh264e_jpeg_get_last_streaming_cache_bytes
+    sh264e_jpeg_get_last_slice_work_bytes
+    sh264e_encoder_get_memory_report
+)
+
+forbidden_symbol_regex='(^|[^A-Za-z0-9_])_?(sh264e_jpeg_set_test_allocation_limit|sh264e_jpeg_get_test_last_exact_resize_mask|sh264e_encode_jpeg_idr_streaming_prototype|sh264e_encode_jpeg_idr_streaming_prototype_with_arena|njDecodeComponents|njGetImage|njGetImageSize|njIsColor|njDecode)([^A-Za-z0-9_]|$)'
+
+write_manifest() {
+    local root="$1"
+    (
+        cd "${root}"
+        {
+            printf '# SHA-256 manifest\n'
+            printf '# manifest.txt is excluded to avoid a self-referential checksum.\n'
+            find . -type f ! -name manifest.txt -print | LC_ALL=C sort | while IFS= read -r file; do
+                checksum_file "${file}"
+            done
+        } > manifest.txt
+    )
+}
+
+validate_package() {
+    local archive="$1"
+    local package_name="$2"
+    local lib_path="$3"
+    local nm_out="$4"
+
+    if [[ ! -s "${archive}" ]]; then
+        echo "Package archive is missing or empty: ${archive}" >&2
+        exit 1
+    fi
+
+    local listing="${archive}.listing"
+    tar -tzf "${archive}" | tee "${listing}" >/dev/null
+
+    local required_path
+    for required_path in \
+        "${package_name}/include/sh264e.h" \
+        "${package_name}/lib/libsimple_h264_enc_i.a" \
+        "${package_name}/docs/README-FREERTOS-CORTEX-M7.md" \
+        "${package_name}/docs/API.md" \
+        "${package_name}/docs/MEMORY.md" \
+        "${package_name}/build-info.txt" \
+        "${package_name}/manifest.txt"
+    do
+        if ! grep -Fxq "${required_path}" "${listing}"; then
+            echo "Package ${archive} is missing required path: ${required_path}" >&2
+            exit 1
+        fi
+        if [[ ! -s "${package_root}/${required_path}" ]]; then
+            echo "Package ${archive} has an empty required path: ${required_path}" >&2
+            exit 1
+        fi
+    done
+    rm -f "${listing}"
+
+    "${ar}" t "${lib_path}" | grep -Fxq sh264e.o
+    "${ar}" t "${lib_path}" | grep -Fxq nanojpeg.o
+    "${nm}" -g --defined-only "${lib_path}" > "${nm_out}"
+
+    local symbol
+    for symbol in "${required_symbols[@]}"; do
+        if ! grep -Eq "(^|[^A-Za-z0-9_])_?${symbol}([^A-Za-z0-9_]|$)" "${nm_out}"; then
+            echo "Production package is missing public symbol: ${symbol}" >&2
+            exit 1
+        fi
+    done
+
+    if grep -Eq "${forbidden_symbol_regex}" "${nm_out}"; then
+        echo "Production package exposes a forbidden private/test symbol:" >&2
+        grep -E "${forbidden_symbol_regex}" "${nm_out}" >&2
+        exit 1
+    fi
+}
+
+build_variant() {
+    local abi="$1"
+    local variant_flags_text="$2"
+    shift 2
+    local variant_flags=("$@")
+
+    local build_dir="${build_root}/${abi}"
+    local package_name="simple_h264_enc_i-${version}-freertos-cortex-m7-${abi}"
+    local package_dir="${package_root}/${package_name}"
+    local archive="${output_dir}/${package_name}.tar.gz"
+    local lib_path="${package_dir}/lib/libsimple_h264_enc_i.a"
+
+    mkdir -p "${build_dir}" "${package_dir}/include" "${package_dir}/lib" "${package_dir}/docs"
+
+    "${cc}" "${common_flags[@]}" "${variant_flags[@]}" -std=c99 \
+        -c "${repo_dir}/src/sh264e.c" \
+        -o "${build_dir}/sh264e.o"
+    "${cc}" "${common_flags[@]}" "${variant_flags[@]}" -std=c99 \
+        -c "${repo_dir}/src/nanojpeg.c" \
+        -o "${build_dir}/nanojpeg.o"
+    "${ar}" rcs "${lib_path}" "${build_dir}/sh264e.o" "${build_dir}/nanojpeg.o"
+
+    cp "${repo_dir}/include/sh264e.h" "${package_dir}/include/sh264e.h"
+    cp "${repo_dir}/docs/freertos-cortex-m7/README-FREERTOS-CORTEX-M7.md" "${package_dir}/docs/README-FREERTOS-CORTEX-M7.md"
+    cp "${repo_dir}/docs/freertos-cortex-m7/API.md" "${package_dir}/docs/API.md"
+    cp "${repo_dir}/docs/freertos-cortex-m7/MEMORY.md" "${package_dir}/docs/MEMORY.md"
+
+    cat > "${package_dir}/build-info.txt" <<EOF
+package: ${package_name}
+version: ${version}
+git_commit: ${git_commit}
+compiler: ${cc_path}
+archiver: ${ar_path}
+nm: ${nm_path}
+compiler_version:
+${cc_version}
+target_cpu_flags: -mcpu=cortex-m7 -mthumb
+target_fpu_flags: ${variant_flags_text}
+compile_flags: ${common_flags[*]} ${variant_flags_text}
+archive_variant: freertos-cortex-m7-${abi}
+sources:
+  - src/sh264e.c
+  - src/nanojpeg.c
+headers:
+  - include/sh264e.h
+production_policy:
+  - tools disabled
+  - tests disabled
+  - private JPEG test hooks disabled
+  - NJ_USE_LIBC=0
+EOF
+
+    write_manifest "${package_dir}"
+
+    rm -f "${archive}" "${archive}.sha256"
+    tar -C "${package_root}" -cf - "${package_name}" | gzip -n > "${archive}"
+    checksum_file "${archive}" > "${archive}.sha256"
+
+    validate_package "${archive}" "${package_name}" "${lib_path}" "${build_dir}/defined-symbols.txt"
+    printf '%s\n' "${archive}"
+    printf '%s\n' "${archive}.sha256"
+}
+
+build_variant "soft" "-mfloat-abi=soft" -mfloat-abi=soft
+build_variant "fpv5-sp-hard" "-mfpu=fpv5-sp-d16 -mfloat-abi=hard" -mfpu=fpv5-sp-d16 -mfloat-abi=hard


### PR DESCRIPTION
Refs #116

## Summary

- Add a reusable FreeRTOS Cortex-M7 package builder for soft-float and FPv5-SP hard-float ARM static library archives.
- Add package-local developer docs for FreeRTOS integration, public API usage, and embedded memory sizing.
- Wire Linux validation and tag release publishing to build, validate, checksum, and upload the Cortex-M7 developer packages.

## Validation

- `bash -n scripts/build_freertos_cortex_m7_packages.sh`
- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "yaml ok #{p}" }' .github/workflows/linux-validation.yml .github/workflows/source-release.yml`
- GitHub Actions: Ubuntu full validation passed on PR #117, including Cortex-M7 package build and symbol/package checks.
- GitHub Actions: macOS host validation passed on PR #117.

Local macOS ARM package build was attempted, but this local `arm-none-eabi-gcc` install does not include Newlib headers and fails on `<stdlib.h>`. The Ubuntu workflow installs `libnewlib-arm-none-eabi` and passed the package build there.
