### PR TITLE
Cortex-M/macOS: validate simulator DWT and idle profiling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,43 @@ if(SH264E_BUILD_TESTS)
         )
     endif()
 
+    if(SH264E_BUILD_QEMU_TESTS AND SH264E_ARM_NONE_EABI_GCC AND SH264E_QEMU_SYSTEM_ARM)
+        set(SH264E_SIM_PROFILE_ELF ${CMAKE_CURRENT_BINARY_DIR}/sh264e_qemu_sim_profile_m7.elf)
+        add_custom_command(
+            OUTPUT ${SH264E_SIM_PROFILE_ELF}
+            COMMAND ${SH264E_ARM_NONE_EABI_GCC}
+                -mcpu=cortex-m7
+                -mthumb
+                -O2
+                -ffreestanding
+                -fno-builtin
+                -ffunction-sections
+                -fdata-sections
+                -T${CMAKE_CURRENT_SOURCE_DIR}/tests/qemu_cortexm.ld
+                -nostdlib
+                -Wl,--gc-sections
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/qemu_sim_profile_probe.c
+                -lgcc
+                -o ${SH264E_SIM_PROFILE_ELF}
+            DEPENDS
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/qemu_sim_profile_probe.c
+                ${CMAKE_CURRENT_SOURCE_DIR}/tests/qemu_cortexm.ld
+            VERBATIM
+        )
+        add_custom_target(sh264e_qemu_sim_profile_m7 ALL DEPENDS ${SH264E_SIM_PROFILE_ELF})
+        if(Python3_Interpreter_FOUND)
+            add_test(
+                NAME sh264e_qemu_sim_profile_m7
+                COMMAND ${Python3_EXECUTABLE}
+                    ${CMAKE_CURRENT_SOURCE_DIR}/tests/run_qemu_sim_profile.py
+                    --build-dir ${CMAKE_CURRENT_BINARY_DIR}
+                    --target sh264e_qemu_sim_profile_m7
+                    --timeout 5
+            )
+            set_tests_properties(sh264e_qemu_sim_profile_m7 PROPERTIES TIMEOUT 10)
+        endif()
+    endif()
+
     if(SH264E_CAN_BUILD_QEMU_TESTS)
         function(sh264e_add_qemu_firmware TARGET_NAME SOURCE CPU MACHINE)
             set(extra_compile_options "")

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The test suite covers:
 * Cortex-M QEMU scaler smoke tests when `arm-none-eabi-gcc` and `qemu-system-arm` are available and usable
 * Cortex-M QEMU scaler benchmark firmware correctness for default DSP-capable and portable C variants when those tools are available and usable
 * Cortex-M QEMU encoder benchmark firmware correctness for default DSP-capable and portable C variants when those tools are available and usable
+* Cortex-M7 simulator DWT/WFI profiling diagnostics through `tests/run_qemu_sim_profile.py`
 * production-profile symbol audit when `nm` or `llvm-nm` is available
 
 ## CI And Release

--- a/docs/CORTEX_M_SCALER_BENCHMARKS.md
+++ b/docs/CORTEX_M_SCALER_BENCHMARKS.md
@@ -121,6 +121,24 @@ Use `--target <name>` to run a subset, `--format csv` for machine-readable
 output, and `--list-targets` to print the known target metadata without running
 QEMU. The runner exits nonzero if any selected firmware exits nonzero.
 
+## Simulator DWT And WFI Profile
+
+Use `docs/CORTEX_M_SIMULATOR_PROFILE.md` when validating local macOS simulator
+DWT and idle behavior. The `sh264e_qemu_sim_profile_m7` probe is intentionally
+separate from encoder/scaler benchmark firmware and from QEMU proxy timing. It
+checks whether simulator-observed DWT `CYCCNT` advances during active work and
+whether `WFI` resumes from a configured SysTick interrupt.
+
+```sh
+cmake -S . -B build-qemu -DSH264E_BUILD_QEMU_TESTS=ON
+cmake --build build-qemu --target sh264e_qemu_sim_profile_m7
+python3 tests/run_qemu_sim_profile.py --build-dir build-qemu
+```
+
+Simulator profile output is diagnostic only. Do not report it as Cortex-M
+cycles, do not convert it to cycles per slice, and keep it separate from both
+the proxy timing table and the real-board DWT result table.
+
 ## Real-Board Capture
 
 Build the same benchmark variants, then flash or load the generated ELF for the

--- a/docs/CORTEX_M_SIMULATOR_PROFILE.md
+++ b/docs/CORTEX_M_SIMULATOR_PROFILE.md
@@ -1,0 +1,107 @@
+# Cortex-M Simulator Profile Validation
+
+This document defines the local macOS simulator validation path for Cortex-M
+DWT and idle behavior. It is a diagnostic harness only. Simulator observations
+must not be reported as Cortex-M4/M7 performance data and must stay separate
+from both real-board DWT captures and QEMU proxy timing rows.
+
+## Scope
+
+The supported simulator path uses the existing QEMU dependency:
+
+* `qemu-system-arm`
+* `arm-none-eabi-gcc`
+* CMake and Python 3
+
+The probe target is `sh264e_qemu_sim_profile_m7`. It builds a freestanding
+Cortex-M7 image that does not include the encoder library and does not require
+bare-metal C library headers. The probe verifies simulator behavior that the
+full benchmark firmware depends on:
+
+* DWT `CYCCNT` increments during a deterministic active loop.
+* `WFI` can sleep until a configured SysTick interrupt wakes the core.
+* DWT `CYCCNT` behavior during the idle wait is observable, zero/stubbed, or
+  unsupported.
+
+## macOS Setup
+
+Install the expected tools with Homebrew or an equivalent package manager:
+
+```sh
+brew install cmake qemu arm-none-eabi-gcc
+```
+
+Then configure and build the QEMU-enabled tree:
+
+```sh
+cmake -S . -B build-qemu -DSH264E_BUILD_QEMU_TESTS=ON
+cmake --build build-qemu --target sh264e_qemu_sim_profile_m7
+```
+
+Run the simulator profile harness:
+
+```sh
+python3 tests/run_qemu_sim_profile.py \
+  --build-dir build-qemu \
+  --target sh264e_qemu_sim_profile_m7
+```
+
+The runner emits a Markdown report with explicit simulator-only labels. A
+nonzero active-loop `CYCCNT` means DWT is usable for simulator diagnostics. A
+zero active-loop value means the simulator stubs or disables CYCCNT. The WFI
+row reports whether the simulator resumed from SysTick, returned without the
+expected interrupt, stayed blocked until timeout, or omitted the required
+metadata.
+
+## Initial macOS QEMU Observation
+
+Captured on 2026-04-19 with QEMU emulator version 10.2.1 on
+macOS-26.3-arm64-arm-64bit:
+
+| Probe | Observation | Raw value |
+| --- | --- | --- |
+| DWT `CYCCNT` active work | Zero/stubbed: active work completed but `CYCCNT` stayed zero | `active_cycles=0` |
+| `WFI` idle wait | Observable wake from SysTick, but `CYCCNT` stayed zero during idle wait | `wfi_cycles=0`, `systick_count=1` |
+
+This means the tested macOS QEMU path is useful for boot, semihosting, WFI
+wake, and control-flow diagnostics, but it is not useful for DWT cycle
+measurement. It cannot distinguish active work from idle wait by `CYCCNT`.
+
+## Full Benchmark Firmware Gap
+
+The existing encoder and scaler QEMU firmware targets remain the correctness
+preflight for benchmark code:
+
+```sh
+cmake --build build-qemu --target \
+  sh264e_qemu_scaler_bench_m7 \
+  sh264e_qemu_scaler_bench_m7_portable \
+  sh264e_qemu_encoder_bench_m7 \
+  sh264e_qemu_encoder_bench_m7_portable
+ctest --test-dir build-qemu -R 'sh264e_qemu_(scaler|encoder)_bench_m7' --output-on-failure
+```
+
+Some macOS `arm-none-eabi-gcc` packages do not include the Newlib header set
+needed by those library firmware targets. In that case CMake prints:
+
+```text
+Skipping QEMU firmware tests: arm-none-eabi-gcc cannot compile <stdlib.h>
+```
+
+That is a host toolchain packaging gap, not a simulator result. Install a
+bare-metal toolchain that can compile `<stdlib.h>` to run the full encoder and
+scaler firmware locally. The Linux validation workflow installs the required
+Newlib package and remains the CI path for those targets.
+
+## Reporting Policy
+
+Do not put simulator profile rows in the real-board result table. If a report
+is copied into `docs/CORTEX_M_SCALER_BENCHMARKS.md`, label it as simulator
+validation only and keep it separate from:
+
+* real-board DWT cycle rows, which are authoritative for performance claims
+* QEMU proxy timing rows, which are host/QEMU wall-time trend metrics
+
+Issue #93 remains the real-board baseline item. This simulator harness only
+answers whether the local simulator can support preflight diagnostics for DWT
+and WFI behavior.

--- a/tests/qemu_sim_profile_probe.c
+++ b/tests/qemu_sim_profile_probe.c
@@ -1,0 +1,156 @@
+typedef unsigned int uint32_t;
+
+#define DEMCR (*(volatile uint32_t *)0xE000EDFCu)
+#define DWT_CTRL (*(volatile uint32_t *)0xE0001000u)
+#define DWT_CYCCNT (*(volatile uint32_t *)0xE0001004u)
+#define SYST_CSR (*(volatile uint32_t *)0xE000E010u)
+#define SYST_RVR (*(volatile uint32_t *)0xE000E014u)
+#define SYST_CVR (*(volatile uint32_t *)0xE000E018u)
+
+#define DEMCR_TRCENA (1u << 24)
+#define DWT_CTRL_CYCCNTENA 1u
+#define SYST_CSR_ENABLE 1u
+#define SYST_CSR_TICKINT (1u << 1)
+#define SYST_CSR_CLKSOURCE (1u << 2)
+
+extern unsigned long _estack;
+extern unsigned long __bss_start__;
+extern unsigned long __bss_end__;
+
+static volatile uint32_t active_sink;
+static volatile uint32_t systick_count;
+
+static void semihost_write0(const char *text)
+{
+    register uint32_t r0 __asm("r0") = 0x04u;
+    register const char *r1 __asm("r1") = text;
+    __asm volatile("bkpt 0xab" : "+r"(r0), "+r"(r1) : : "memory");
+}
+
+static void semihost_exit(int code)
+{
+    uint32_t args[2];
+    register uint32_t r0 __asm("r0") = 0x20u;
+    register uint32_t r1 __asm("r1");
+
+    args[0] = 0x20026u;
+    args[1] = (uint32_t)code;
+    r1 = (uint32_t)args;
+    __asm volatile("bkpt 0xab" : "+r"(r0), "+r"(r1) : : "memory");
+    for (;;) {
+    }
+}
+
+static void write_u32_dec(uint32_t value)
+{
+    char buffer[11];
+    char *p = buffer + sizeof(buffer);
+
+    *--p = '\0';
+    if (value == 0u) {
+        *--p = '0';
+    } else {
+        while (value != 0u) {
+            *--p = (char)('0' + (value % 10u));
+            value /= 10u;
+        }
+    }
+    semihost_write0(p);
+}
+
+static void write_kv_u32(const char *key, uint32_t value)
+{
+    semihost_write0(key);
+    semihost_write0("=");
+    write_u32_dec(value);
+    semihost_write0("\n");
+}
+
+static void dwt_reset(void)
+{
+    DEMCR |= DEMCR_TRCENA;
+    DWT_CYCCNT = 0u;
+    DWT_CTRL |= DWT_CTRL_CYCCNTENA;
+}
+
+static uint32_t run_active_probe(void)
+{
+    uint32_t i;
+
+    dwt_reset();
+    for (i = 0; i < 200000u; i++) {
+        active_sink = (active_sink * 33u) ^ (i + 0x9e3779b9u);
+    }
+    return DWT_CYCCNT;
+}
+
+static uint32_t run_wfi_probe(void)
+{
+    uint32_t cycles;
+
+    systick_count = 0u;
+    SYST_RVR = 1000u;
+    SYST_CVR = 0u;
+    SYST_CSR = SYST_CSR_ENABLE | SYST_CSR_TICKINT | SYST_CSR_CLKSOURCE;
+    dwt_reset();
+    __asm volatile("cpsie i" : : : "memory");
+    __asm volatile("wfi" : : : "memory");
+    cycles = DWT_CYCCNT;
+    SYST_CSR = 0u;
+    return cycles;
+}
+
+void Reset_Handler(void)
+{
+    unsigned long *p;
+    uint32_t active_cycles;
+    uint32_t wfi_cycles;
+
+    for (p = &__bss_start__; p < &__bss_end__; p++) {
+        *p = 0u;
+    }
+
+    semihost_write0("sh264e_sim_profile_probe=1\n");
+    semihost_write0("target=cortex-m7\n");
+    active_cycles = run_active_probe();
+    write_kv_u32("active_cycles", active_cycles);
+    write_kv_u32("active_sink", active_sink);
+
+    semihost_write0("wfi_probe=begin\n");
+    wfi_cycles = run_wfi_probe();
+    semihost_write0("wfi_probe=end\n");
+    write_kv_u32("wfi_cycles", wfi_cycles);
+    write_kv_u32("systick_count", systick_count);
+
+    semihost_exit(0);
+}
+
+void SysTick_Handler(void)
+{
+    systick_count++;
+}
+
+void Default_Handler(void)
+{
+    semihost_exit(99);
+}
+
+__attribute__((section(".isr_vector"), used))
+void (*const g_vector_table[])(void) = {
+    (void (*)(void))(&_estack),
+    Reset_Handler,
+    Default_Handler,
+    Default_Handler,
+    Default_Handler,
+    Default_Handler,
+    Default_Handler,
+    0,
+    0,
+    0,
+    0,
+    Default_Handler,
+    Default_Handler,
+    0,
+    Default_Handler,
+    SysTick_Handler,
+};

--- a/tests/run_qemu_sim_profile.py
+++ b/tests/run_qemu_sim_profile.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Characterize Cortex-M simulator DWT and WFI behavior."""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional, Sequence
+
+
+@dataclass(frozen=True)
+class ProbeTarget:
+    name: str
+    machine: str
+    cpu: str
+    elf_name: str
+
+
+TARGETS = (
+    ProbeTarget(
+        "sh264e_qemu_sim_profile_m7",
+        "mps2-an500",
+        "cortex-m7",
+        "sh264e_qemu_sim_profile_m7.elf",
+    ),
+)
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a Cortex-M simulator profiling probe and label DWT/WFI "
+            "observations as simulator validation only."
+        )
+    )
+    parser.add_argument("--build-dir", default="build-qemu")
+    parser.add_argument("--qemu", default=None, help="Path to qemu-system-arm.")
+    parser.add_argument("--target", choices=[target.name for target in TARGETS], default=TARGETS[0].name)
+    parser.add_argument("--timeout", type=float, default=5.0)
+    parser.add_argument("--list-targets", action="store_true")
+    args = parser.parse_args(argv)
+    if args.timeout <= 0.0:
+        parser.error("--timeout must be positive")
+    return args
+
+
+def selected_target(name: str) -> ProbeTarget:
+    for target in TARGETS:
+        if target.name == name:
+            return target
+    raise AssertionError(name)
+
+
+def qemu_version(qemu: str) -> str:
+    try:
+        result = subprocess.run(
+            [qemu, "--version"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            timeout=5.0,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return f"unavailable ({exc})"
+    return result.stdout.splitlines()[0].strip() if result.stdout.splitlines() else "unknown"
+
+
+def host_summary() -> str:
+    cpu = platform.processor() or platform.machine() or "unknown CPU"
+    if sys.platform == "darwin":
+        try:
+            result = subprocess.run(
+                ["sysctl", "-n", "machdep.cpu.brand_string"],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=2.0,
+            )
+            cpu = result.stdout.strip() or cpu
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    return f"{platform.platform()} / {cpu}"
+
+
+def qemu_command(qemu: str, target: ProbeTarget, elf: Path) -> list[str]:
+    return [
+        qemu,
+        "-M",
+        target.machine,
+        "-cpu",
+        target.cpu,
+        "-kernel",
+        str(elf),
+        "-semihosting",
+        "-nographic",
+        "-monitor",
+        "none",
+        "-serial",
+        "none",
+    ]
+
+
+def parse_probe_output(text: str) -> Dict[str, str]:
+    values: Dict[str, str] = {}
+    for line in text.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            values[key.strip()] = value.strip()
+    return values
+
+
+def parse_u32(values: Dict[str, str], key: str) -> Optional[int]:
+    value = values.get(key)
+    if value is None:
+        return None
+    try:
+        return int(value, 10)
+    except ValueError:
+        return None
+
+
+def characterize_dwt(active_cycles: Optional[int]) -> str:
+    if active_cycles is None:
+        return "unsupported: active_cycles was not reported"
+    if active_cycles == 0:
+        return "zero/stubbed: active work completed but CYCCNT stayed zero"
+    return "usable for simulator diagnostics: CYCCNT advanced during active work"
+
+
+def characterize_wfi(values: Dict[str, str], timed_out: bool) -> str:
+    if timed_out:
+        if values.get("wfi_probe") == "begin":
+            return "blocked: WFI did not resume before timeout"
+        return "unsupported: probe timed out before WFI observation"
+    if values.get("wfi_probe") != "end":
+        return "unsupported: WFI completion marker was not reported"
+    systick_count = parse_u32(values, "systick_count")
+    wfi_cycles = parse_u32(values, "wfi_cycles")
+    if systick_count is None or wfi_cycles is None:
+        return "unstable: WFI completed but idle metadata was incomplete"
+    if systick_count == 0:
+        return "unstable: WFI returned without the configured SysTick wake signal"
+    if wfi_cycles == 0:
+        return "zero/stubbed: WFI woke from SysTick but CYCCNT stayed zero"
+    return "observable: WFI woke from SysTick and CYCCNT advanced during idle wait"
+
+
+def print_report(
+    target: ProbeTarget,
+    qemu: str,
+    values: Dict[str, str],
+    timed_out: bool,
+    returncode: Optional[int],
+) -> None:
+    active_cycles = parse_u32(values, "active_cycles")
+    wfi_cycles = parse_u32(values, "wfi_cycles")
+    systick_count = parse_u32(values, "systick_count")
+    print("# Cortex-M Simulator Profile")
+    print()
+    print("This report is simulator validation only. It is not Cortex-M performance data.")
+    print()
+    print(f"- QEMU version: {qemu_version(qemu)}")
+    print(f"- Host: {host_summary()}")
+    print(f"- Target firmware: `{target.name}`")
+    print(f"- Machine / CPU: `{target.machine}` / `{target.cpu}`")
+    print(f"- Exit status: {'timeout' if timed_out else returncode}")
+    print()
+    print("| Probe | Observation | Raw value |")
+    print("| --- | --- | --- |")
+    print(f"| DWT CYCCNT active work | {characterize_dwt(active_cycles)} | {active_cycles if active_cycles is not None else 'N/A'} |")
+    print(f"| WFI idle wait | {characterize_wfi(values, timed_out)} | cycles={wfi_cycles if wfi_cycles is not None else 'N/A'}, systick_count={systick_count if systick_count is not None else 'N/A'} |")
+    print()
+    print("Keep these rows separate from real-board DWT captures and QEMU proxy timing rows.")
+
+
+def main(argv: Sequence[str]) -> int:
+    args = parse_args(argv)
+    build_dir = Path(args.build_dir)
+    target = selected_target(args.target)
+    if args.list_targets:
+        for item in TARGETS:
+            print(f"{item.name}\t{item.machine}\t{item.cpu}\t{build_dir / item.elf_name}")
+        return 0
+
+    qemu = args.qemu or shutil.which("qemu-system-arm")
+    if not qemu:
+        print("error: qemu-system-arm was not found; pass --qemu", file=sys.stderr)
+        return 2
+
+    elf = build_dir / target.elf_name
+    if not elf.exists():
+        print(f"error: missing simulator profile ELF: {elf}", file=sys.stderr)
+        return 2
+
+    timed_out = False
+    returncode: Optional[int] = None
+    stdout = ""
+    stderr = ""
+    try:
+        result = subprocess.run(
+            qemu_command(qemu, target, elf),
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=args.timeout,
+        )
+        returncode = result.returncode
+        stdout = result.stdout
+        stderr = result.stderr
+    except subprocess.TimeoutExpired as exc:
+        timed_out = True
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+
+    values = parse_probe_output(stdout + "\n" + stderr)
+    print_report(target, qemu, values, timed_out, returncode)
+
+    if timed_out and values.get("wfi_probe") == "begin":
+        return 0
+    if timed_out:
+        return 1
+    return 0 if returncode == 0 and "active_cycles" in values else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
Refs #118

## Summary

- Add a freestanding Cortex-M7 QEMU simulator profile probe for DWT `CYCCNT` and `WFI`/SysTick wake behavior.
- Add `tests/run_qemu_sim_profile.py` to run the probe and emit simulator-only Markdown diagnostics.
- Document the macOS simulator setup, current QEMU 10.2.1 observation, and the local full benchmark firmware toolchain-header gap.

## Validation

- `cmake -S . -B build-issue118-qemu -DSH264E_BUILD_QEMU_TESTS=ON`
- `cmake --build build-issue118-qemu --target sh264e_qemu_sim_profile_m7`
- `python3 tests/run_qemu_sim_profile.py --build-dir build-issue118-qemu --target sh264e_qemu_sim_profile_m7`
- `ctest --test-dir build-issue118-qemu -R 'sim_profile|qemu.*encoder|qemu.*scaler|proxy' --output-on-failure`
- `cmake -S . -B build-issue118 && cmake --build build-issue118 && ctest --test-dir build-issue118 --output-on-failure`
- `python3 -m py_compile tests/run_qemu_sim_profile.py tests/run_qemu_proxy_timing.py`
- `git diff --check`

Local macOS observation: QEMU 10.2.1 wakes `WFI` from SysTick, but DWT `CYCCNT` stays zero during both active work and idle wait. This is documented as simulator validation only, not Cortex-M performance data.

The existing full encoder/scaler QEMU firmware targets are still skipped locally because this Homebrew `arm-none-eabi-gcc` cannot compile `<stdlib.h>` without Newlib headers; that gap is documented and the Linux CI path remains authoritative for those firmware targets.
