### PR TITLE
h264: batch streaming output by input row

### DIFF
--- a/docs/JPEG_STREAMING_MEMORY_REPORT.md
+++ b/docs/JPEG_STREAMING_MEMORY_REPORT.md
@@ -174,11 +174,13 @@ build/sh264e_encode_jpeg --format i420 \
   build/issue96_default_2880_i420.h264
 ```
 
-Expected metric lines:
+Expected metric lines. The `362` output-consumer chunks are two SPS/PPS
+header chunks plus four 4 KiB chunks for each of the 90 encoded input rows
+after row-level IDR NALU batching.
 
 ```text
 1280x720:
-jpeg output consumer chunks: 14402
+jpeg output consumer chunks: 362
 jpeg output chunk buffer bytes: 4096
 jpeg work arena bytes: 92304
 jpeg slice work bytes: 61440
@@ -188,7 +190,7 @@ jpeg streaming cache bytes: 61440
 jpeg output buffer bytes: 4096
 
 2560x1440:
-jpeg output consumer chunks: 14402
+jpeg output consumer chunks: 362
 jpeg output chunk buffer bytes: 4096
 jpeg work arena bytes: 123024
 jpeg slice work bytes: 0
@@ -198,7 +200,7 @@ jpeg streaming cache bytes: 61440
 jpeg output buffer bytes: 4096
 
 5120x2880:
-jpeg output consumer chunks: 14402
+jpeg output consumer chunks: 362
 jpeg output chunk buffer bytes: 4096
 jpeg work arena bytes: 491664
 jpeg slice work bytes: 61440

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -2606,28 +2606,16 @@ static sh264e_status_t stream_idr_slice_nalu_direct(sh264e_encoder_t *encoder,
                                                     const sh264e_slice_t *slice,
                                                     unsigned row_index,
                                                     unsigned mb_x,
-                                                    uint8_t *chunk_buffer,
-                                                    size_t chunk_capacity,
-                                                    size_t *out_size,
-                                                    sh264e_output_consumer_t consumer,
-                                                    void *consumer_user)
+                                                    sh264e_chunk_writer_t *writer)
 {
-    sh264e_chunk_writer_t writer;
     sh264e_bit_writer_t bw;
     sh264e_status_t status;
 
-    if (chunk_buffer == NULL || out_size == NULL || consumer == NULL ||
-        chunk_capacity == 0u) {
+    if (writer == NULL) {
         return SH264E_ERR_INVALID_ARGUMENT;
     }
 
-    memset(&writer, 0, sizeof(writer));
-    writer.buffer = chunk_buffer;
-    writer.capacity = chunk_capacity;
-    writer.consumer = consumer;
-    writer.user = consumer_user;
-
-    status = bw_begin_annexb_nalu(&bw, &writer, 0x65u);
+    status = bw_begin_annexb_nalu(&bw, writer, 0x65u);
     if (status != SH264E_OK) {
         return status;
     }
@@ -2635,11 +2623,6 @@ static sh264e_status_t stream_idr_slice_nalu_direct(sh264e_encoder_t *encoder,
     if (status != SH264E_OK) {
         return status;
     }
-    status = chunk_writer_flush(&writer);
-    if (status != SH264E_OK) {
-        return status;
-    }
-    *out_size = writer.total;
     return SH264E_OK;
 }
 
@@ -3607,8 +3590,8 @@ static sh264e_status_t sh264e_encode_idr_slice_to_consumer_internal(
     void *consumer_user,
     int require_config_pixfmt)
 {
+    sh264e_chunk_writer_t writer;
     sh264e_status_t status;
-    size_t total = 0u;
 
     if (encoder == NULL || slice == NULL || chunk_buffer == NULL ||
         out_size == NULL || consumer == NULL) {
@@ -3631,22 +3614,30 @@ static sh264e_status_t sh264e_encode_idr_slice_to_consumer_internal(
         return SH264E_ERR_BUFFER_TOO_SMALL;
     }
 
+    memset(&writer, 0, sizeof(writer));
+    writer.buffer = chunk_buffer;
+    writer.capacity = chunk_capacity;
+    writer.consumer = consumer;
+    writer.user = consumer_user;
+
     {
         unsigned mb_x;
         for (mb_x = 0; mb_x < SH264E_MBS_X; mb_x++) {
-            size_t nalu_size = 0u;
             status = stream_idr_slice_nalu_direct(encoder, slice, encoder->slices_encoded,
-                                                  mb_x, chunk_buffer, chunk_capacity,
-                                                  &nalu_size, consumer, consumer_user);
+                                                  mb_x, &writer);
             if (status != SH264E_OK) {
                 return status;
             }
-            total += nalu_size;
         }
     }
 
+    status = chunk_writer_flush(&writer);
+    if (status != SH264E_OK) {
+        return status;
+    }
+
     encoder->slices_encoded++;
-    *out_size = total;
+    *out_size = writer.total;
     return SH264E_OK;
 }
 

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -52,7 +52,9 @@ PRODUCTION_MEMORY_2880P_420 = {
     "peak": 491_520,
     "cache": STREAMING_CACHE_BYTES_2880P_420,
 }
-H264_OUTPUT_CONSUMER_CHUNKS_MIN = 2 + (WIDTH // 16) * (HEIGHT // 16)
+H264_OUTPUT_CONSUMER_CHUNKS_LEGACY_PER_MB = 2 + (WIDTH // 16) * (HEIGHT // 16)
+H264_OUTPUT_CONSUMER_CHUNKS_MIN = 2 + (HEIGHT // 16)
+H264_OUTPUT_CONSUMER_CHUNKS_ROW_BATCHED = 362
 H264_OUTPUT_CHUNK_BYTES = 4_096
 H264_TINY_OUTPUT_CHUNK_BYTES = 7
 H264_ONE_SHOT_OUTPUT_BYTES = 5_588_224
@@ -520,6 +522,16 @@ def encode_jpeg(args, fmt, jpeg_input, bitstream, extra_args=None,
             raise RuntimeError(
                 f"JPEG output consumer chunk count changed: got {chunks}, expected at least {H264_OUTPUT_CONSUMER_CHUNKS_MIN}"
             )
+        if chunks != H264_OUTPUT_CONSUMER_CHUNKS_ROW_BATCHED:
+            raise RuntimeError(
+                "JPEG default output consumer row batching changed: "
+                f"got {chunks}, expected {H264_OUTPUT_CONSUMER_CHUNKS_ROW_BATCHED}"
+            )
+        if chunks >= H264_OUTPUT_CONSUMER_CHUNKS_LEGACY_PER_MB:
+            raise RuntimeError(
+                "JPEG default output consumer regressed to per-macroblock callbacks: "
+                f"got {chunks}, legacy {H264_OUTPUT_CONSUMER_CHUNKS_LEGACY_PER_MB}"
+            )
         chunk_bytes = parse_jpeg_metric(result.stdout, "jpeg output chunk buffer bytes:")
         if chunk_bytes != H264_OUTPUT_CHUNK_BYTES:
             raise RuntimeError(
@@ -633,6 +645,17 @@ def encode_jpeg_output_consumer(args, fmt, jpeg_input, bitstream, extra_args=Non
         raise RuntimeError(
             f"JPEG output consumer regressed to one-shot output buffering: got {chunk_bytes}"
         )
+    if expected_chunk_bytes == H264_OUTPUT_CHUNK_BYTES:
+        if chunks != H264_OUTPUT_CONSUMER_CHUNKS_ROW_BATCHED:
+            raise RuntimeError(
+                "JPEG output consumer row batching changed: "
+                f"got {chunks}, expected {H264_OUTPUT_CONSUMER_CHUNKS_ROW_BATCHED}"
+            )
+        if chunks >= H264_OUTPUT_CONSUMER_CHUNKS_LEGACY_PER_MB:
+            raise RuntimeError(
+                "JPEG output consumer regressed to per-macroblock callbacks: "
+                f"got {chunks}, legacy {H264_OUTPUT_CONSUMER_CHUNKS_LEGACY_PER_MB}"
+            )
     if "jpeg current allocation bytes: 0" not in result.stdout:
         raise RuntimeError(f"JPEG output consumer leaked tracked allocations: {result.stdout!r}")
 


### PR DESCRIPTION
## Summary

Refs #122

- Reuse one `sh264e_chunk_writer_t` across all 160 independent-MB IDR NALUs for each encoded input row.
- Flush the streaming output consumer at buffer-full boundaries and once at row end instead of once per macroblock NALU.
- Keep caller-buffer output unchanged and preserve the existing streaming byte-for-byte comparison coverage.
- Update output-consumer regression checks and memory-report metrics for the row-batched 4 KiB callback count of 362 chunks.

## Validation

- `cmake -S . -B build-issue122`
- `cmake --build build-issue122`
- `ctest --test-dir build-issue122 -R sh264e_ffmpeg_integration --output-on-failure`
- `ctest --test-dir build-issue122 --output-on-failure`
- `python3 -m py_compile tests/run_ffmpeg_integration.py tests/run_qemu_proxy_timing.py`
- `cmake -S . -B build-qemu-issue122 -DSH264E_BUILD_QEMU_TESTS=ON`
- `cmake --build build-qemu-issue122`
- `python3 tests/run_qemu_proxy_timing.py --build-dir build-qemu-issue122 --repeat 5` failed locally because QEMU benchmark ELFs were skipped: CMake reported `Skipping QEMU firmware tests: arm-none-eabi-gcc cannot compile <stdlib.h>`.
- `git diff --check`
