### PR TITLE
h264: compute NV12 chroma DC pair sums

### DIFF
--- a/docs/CORTEX_M_OPTIMIZATION_PLAN.md
+++ b/docs/CORTEX_M_OPTIMIZATION_PLAN.md
@@ -150,6 +150,9 @@ unavailable-neighbor predictor.
 Defining `SH264E_DISABLE_ARM_DSP` keeps the portable C loops, and both paths
 preserve the encoder bitstream checksum. The change adds no encoder-owned
 persistent SRAM.
+For NV12 input, the chroma DC path computes U and V 8x8 sums during one
+traversal of each interleaved UV block before applying the same quantization
+and CAVLC syntax as the I420 path.
 
 ## Scaler Fast-Path Status
 

--- a/docs/CORTEX_M_SCALER_BENCHMARKS.md
+++ b/docs/CORTEX_M_SCALER_BENCHMARKS.md
@@ -142,6 +142,15 @@ Use `--target <name>` to run a subset, `--format csv` for machine-readable
 output, and `--list-targets` to print the known target metadata without running
 QEMU. The runner exits nonzero if any selected firmware exits nonzero.
 
+For the NV12 chroma pair-sum optimization, compare the before/after trend using
+the `sh264e_qemu_encoder_nv12_bench_m4`,
+`sh264e_qemu_encoder_nv12_bench_m4_portable`,
+`sh264e_qemu_encoder_nv12_bench_m7`, and
+`sh264e_qemu_encoder_nv12_bench_m7_portable` proxy timing rows. If the local
+ARM toolchain cannot build those ELFs, record the missing-tool output with the
+host CTest result and let the Ubuntu QEMU validation remain the correctness
+preflight.
+
 ## Simulator DWT And WFI Profile
 
 Use `docs/CORTEX_M_SIMULATOR_PROFILE.md` when validating local macOS simulator

--- a/docs/ENCODER_MEMORY_REPORT.md
+++ b/docs/ENCODER_MEMORY_REPORT.md
@@ -69,6 +69,9 @@ report, the public diagnostic output, and the regression tests in the same
 change. Cortex-M fast paths should not add persistent encoder SRAM by default.
 The luma/chroma DC residual `USADA8`/`USAD8` fast path is compute-only and does
 not change any encoder-owned memory block or the reported `296` byte total.
+The NV12 chroma pair-sum path also remains compute-only: it traverses each
+interleaved UV 8x8 block once to compute both chroma DC sums and does not add
+encoder arena storage.
 The byte-oriented bit-writer accumulator is internal writer state and does not
 change the `256` byte RBSP scratch block, encoder arena size, or reported
 `296` byte total.

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -2334,6 +2334,37 @@ static uint32_t chroma_nv12_sum_u8x8(const sh264e_slice_t *slice,
     return sum;
 }
 
+static void chroma_nv12_sum_u8x8_pair(const sh264e_slice_t *slice,
+                                      unsigned src_x,
+                                      unsigned y,
+                                      uint32_t *out_u_sum,
+                                      uint32_t *out_v_sum)
+{
+    unsigned row;
+    uint32_t u_sum = 0u;
+    uint32_t v_sum = 0u;
+
+    for (row = 0; row < 8u; row++) {
+        const uint8_t *src = slice->plane[1] + (size_t)(y + row) * (size_t)slice->stride[1] +
+                             (size_t)src_x * 2u;
+#if defined(SH264E_USE_ARM_DSP)
+        u_sum = arm_usada8(pack_u8x4(src[0], src[2], src[4], src[6]), 0u, u_sum);
+        v_sum = arm_usada8(pack_u8x4(src[1], src[3], src[5], src[7]), 0u, v_sum);
+        u_sum = arm_usada8(pack_u8x4(src[8], src[10], src[12], src[14]), 0u, u_sum);
+        v_sum = arm_usada8(pack_u8x4(src[9], src[11], src[13], src[15]), 0u, v_sum);
+#else
+        unsigned col;
+        for (col = 0; col < 8u; col++) {
+            u_sum += src[(size_t)col * 2u];
+            v_sum += src[(size_t)col * 2u + 1u];
+        }
+#endif
+    }
+
+    *out_u_sum = u_sum;
+    *out_v_sum = v_sum;
+}
+
 static int chroma8x8_sum_delta(const sh264e_slice_t *slice,
                                unsigned plane,
                                unsigned src_x,
@@ -2347,6 +2378,21 @@ static int chroma8x8_sum_delta(const sh264e_slice_t *slice,
         sum = chroma_nv12_sum_u8x8(slice, plane, src_x, y);
     }
     return (int)sum - (SH264E_DC_PRED * 64);
+}
+
+static int quantize_chroma8x8_sum(sh264e_encoder_t *encoder, uint32_t sum)
+{
+    const int sum_delta = (int)sum - (SH264E_DC_PRED * 64);
+    int level = quantize_dc_delta((sum_delta + (sum_delta >= 0 ? 32 : -32)) / 64,
+                                  encoder->config.qp);
+
+    if (level > 0) {
+        level = 1;
+    } else if (level < 0) {
+        level = -1;
+    }
+
+    return level;
 }
 
 static int encode_luma4x4(sh264e_encoder_t *encoder,
@@ -2383,6 +2429,27 @@ static int encode_chroma8x8_dc(sh264e_encoder_t *encoder,
     }
 
     return level;
+}
+
+static void encode_chroma8x8_dc_pair(sh264e_encoder_t *encoder,
+                                     const sh264e_slice_t *slice,
+                                     unsigned mb_x,
+                                     int out_chroma_dc[2])
+{
+    const unsigned src_x = mb_x * (SH264E_MB_SIZE / 2u);
+
+    if (slice->pixfmt == SH264E_PIXFMT_NV12) {
+        uint32_t u_sum;
+        uint32_t v_sum;
+
+        chroma_nv12_sum_u8x8_pair(slice, src_x, 0u, &u_sum, &v_sum);
+        out_chroma_dc[0] = quantize_chroma8x8_sum(encoder, u_sum);
+        out_chroma_dc[1] = quantize_chroma8x8_sum(encoder, v_sum);
+        return;
+    }
+
+    out_chroma_dc[0] = encode_chroma8x8_dc(encoder, slice, 1u, mb_x, 0u, 0u);
+    out_chroma_dc[1] = encode_chroma8x8_dc(encoder, slice, 2u, mb_x, 0u, 0u);
 }
 
 static unsigned cavlc_coeff_token_table_for_nc(unsigned nC)
@@ -2533,8 +2600,7 @@ static sh264e_status_t write_idr_mb_slice_payload(sh264e_encoder_t *encoder,
         }
     }
 
-    chroma_dc[0] = encode_chroma8x8_dc(encoder, slice, 1u, mb_x, 0u, 0u);
-    chroma_dc[1] = encode_chroma8x8_dc(encoder, slice, 2u, mb_x, 0u, 0u);
+    encode_chroma8x8_dc_pair(encoder, slice, mb_x, chroma_dc);
     cbp_chroma = (chroma_dc[0] != 0 || chroma_dc[1] != 0) ? 1u : 0u;
     cbp = cbp_luma + cbp_chroma * 16u;
 

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -518,6 +518,22 @@ static void make_i420_slice(const uint8_t *input, unsigned slice_index, sh264e_s
     slice->stride[2] = SH264E_V1_WIDTH / 2u;
 }
 
+static void make_nv12_from_i420(const uint8_t *i420, uint8_t *nv12)
+{
+    const size_t y_size = (size_t)SH264E_V1_WIDTH * SH264E_V1_HEIGHT;
+    const size_t c_size = (size_t)(SH264E_V1_WIDTH / 2u) * (SH264E_V1_HEIGHT / 2u);
+    const uint8_t *u = i420 + y_size;
+    const uint8_t *v = u + c_size;
+    uint8_t *uv = nv12 + y_size;
+    size_t i;
+
+    memcpy(nv12, i420, y_size);
+    for (i = 0; i < c_size; i++) {
+        uv[i * 2u] = u[i];
+        uv[i * 2u + 1u] = v[i];
+    }
+}
+
 int main(void)
 {
     sh264e_config_t config;
@@ -527,6 +543,8 @@ int main(void)
     sh264e_status_t status;
     uint8_t *input = NULL;
     uint8_t *output = NULL;
+    uint8_t *nv12_input = NULL;
+    uint8_t *nv12_output = NULL;
     size_t input_size;
     size_t output_capacity = 0;
     size_t header_capacity = 0;
@@ -539,6 +557,7 @@ int main(void)
     uint8_t *resize_work = NULL;
     uint8_t *encoder_arena_alloc = NULL;
     sh264e_encoder_t *arena_encoder = NULL;
+    sh264e_encoder_t *nv12_encoder = NULL;
     sh264e_jpeg_allocation_stats_t jpeg_alloc_stats;
     sh264e_encoder_memory_report_t encoder_memory_report;
     sh264e_jpeg_source_t bad_jpeg_source;
@@ -717,12 +736,17 @@ int main(void)
     input_size = (size_t)SH264E_V1_WIDTH * SH264E_V1_HEIGHT * 3u / 2u;
     input = (uint8_t *)malloc(input_size);
     output = (uint8_t *)malloc(output_capacity);
+    nv12_input = (uint8_t *)malloc(input_size);
+    nv12_output = (uint8_t *)malloc(output_capacity);
     slice_output = (uint8_t *)malloc(slice_capacity);
-    if (input == NULL || output == NULL || slice_output == NULL) {
+    if (input == NULL || output == NULL || nv12_input == NULL ||
+        nv12_output == NULL || slice_output == NULL) {
         fprintf(stderr, "allocation failed\n");
         sh264e_encoder_destroy(encoder);
         free(input);
         free(output);
+        free(nv12_input);
+        free(nv12_output);
         free(slice_output);
         return 1;
     }
@@ -876,6 +900,39 @@ int main(void)
     }
 
     {
+        sh264e_config_t nv12_config = config;
+        sh264e_frame_t nv12_frame;
+        size_t nv12_output_size = 0u;
+
+        make_nv12_from_i420(input, nv12_input);
+        nv12_config.pixfmt = SH264E_PIXFMT_NV12;
+        ok &= expect_status("create NV12 encoder",
+                            sh264e_encoder_create(&nv12_config, &nv12_encoder),
+                            SH264E_OK);
+        memset(&nv12_frame, 0, sizeof(nv12_frame));
+        nv12_frame.width = SH264E_V1_WIDTH;
+        nv12_frame.height = SH264E_V1_HEIGHT;
+        nv12_frame.pixfmt = SH264E_PIXFMT_NV12;
+        nv12_frame.plane[0] = nv12_input;
+        nv12_frame.plane[1] = nv12_input + (size_t)SH264E_V1_WIDTH * SH264E_V1_HEIGHT;
+        nv12_frame.stride[0] = SH264E_V1_WIDTH;
+        nv12_frame.stride[1] = SH264E_V1_WIDTH;
+        if (nv12_encoder != NULL) {
+            status = sh264e_encode_idr(nv12_encoder, &nv12_frame,
+                                       nv12_output, output_capacity, &nv12_output_size);
+            ok &= expect_status("NV12 equivalent encode idr", status, SH264E_OK);
+            if (status == SH264E_OK &&
+                (nv12_output_size != output_size ||
+                 memcmp(nv12_output, output, output_size) != 0)) {
+                fprintf(stderr, "NV12 equivalent encode differs from I420 output\n");
+                ok = 0;
+            }
+            sh264e_encoder_destroy(nv12_encoder);
+            nv12_encoder = NULL;
+        }
+    }
+
+    {
         sh264e_slice_t slice;
         unsigned i;
 
@@ -923,9 +980,12 @@ int main(void)
     }
 
     sh264e_encoder_destroy(arena_encoder);
+    sh264e_encoder_destroy(nv12_encoder);
     sh264e_encoder_destroy(encoder);
     free(input);
     free(output);
+    free(nv12_input);
+    free(nv12_output);
     free(slice_output);
     free(resize_work);
     free(small_input);


### PR DESCRIPTION
## Summary

Refs #123

- Add an NV12-specific chroma DC pair-sum helper that traverses each interleaved UV 8x8 block once and accumulates U/V sums together.
- Keep I420 on the existing per-plane path and preserve the same quantization/CAVLC syntax for both pixel formats.
- Add API regression coverage that converts the deterministic I420 fixture to equivalent NV12 and asserts the encoded Annex B output is byte-identical.
- Document that the NV12 pair-sum path is compute-only and does not add encoder arena storage, plus identify the NV12 QEMU proxy timing rows to use for before/after trends.

## Validation

- `cmake -S . -B build-issue123`
- `cmake --build build-issue123`
- `ctest --test-dir build-issue123 -R sh264e_api --output-on-failure`
- `ctest --test-dir build-issue123 --output-on-failure`
- `python3 tests/run_qemu_proxy_timing.py --list-targets | rg "encoder NV12|name|target|sh264e_qemu_encoder_nv12"`
- `cmake -S . -B build-qemu-issue123 -DSH264E_BUILD_QEMU_TESTS=ON`
- `cmake --build build-qemu-issue123`
- `python3 tests/run_qemu_proxy_timing.py --build-dir build-qemu-issue123 --target sh264e_qemu_encoder_nv12_bench_m4 --repeat 5` failed locally because QEMU benchmark ELFs were skipped: CMake reported `Skipping QEMU firmware tests: arm-none-eabi-gcc cannot compile <stdlib.h>`.
- `git diff --check`
