### PR TITLE
h264: specialize fixed nc0 residual writer

### DIFF
--- a/docs/CORTEX_M_OPTIMIZATION_PLAN.md
+++ b/docs/CORTEX_M_OPTIMIZATION_PLAN.md
@@ -189,6 +189,10 @@ fixed I_NxN macroblock prefix into constant bit writes while leaving
 `first_mb_in_slice`, coded block pattern, and residual syntax on their variable
 paths. Unaligned CAVLC and RBSP trailing-bit writes still preserve the same
 MSB-first bit order and byte output.
+The luma DC-only residual writer now uses the fixed unavailable-neighbor
+`nC=0` coeff-token codes directly instead of selecting a CAVLC coeff-token
+table at runtime. No lookup table was added, so the change does not move data
+into SRAM or `.rodata`.
 
 The JPEG/output-consumer streaming path now writes each completed IDR
 macroblock-slice RBSP byte directly through the Annex B emulation-prevention

--- a/docs/CORTEX_M_SCALER_BENCHMARKS.md
+++ b/docs/CORTEX_M_SCALER_BENCHMARKS.md
@@ -160,6 +160,12 @@ as controls for the output callback path. The optimization changes source
 analysis structure only, so bitstream checksum parity remains the correctness
 gate.
 
+For the fixed `nC=0` luma residual-writer specialization, compare the
+before/after trend using the same I420 caller-buffer encoder rows. The
+specialization changes CAVLC syntax emission control flow only, so bitstream
+checksum parity remains the correctness gate and no scaler/JPEG rows are
+expected to move.
+
 For the exact-ratio row-kernel scaler optimization, compare the before/after
 trend using the scaler exact 2x rows
 `sh264e_qemu_scaler_bench_m4`, `sh264e_qemu_scaler_bench_m4_portable`,

--- a/docs/ENCODER_MEMORY_REPORT.md
+++ b/docs/ENCODER_MEMORY_REPORT.md
@@ -76,6 +76,9 @@ The luma macroblock analysis path remains compute-only: it reuses the existing
 per-macroblock `levels[16]` storage to accumulate all 16 luma 4x4 DC sums from
 one 16x16 source scan before quantization, so the encoder arena size and
 reported `296` byte total are unchanged.
+The fixed `nC=0` luma residual writer removes runtime coeff-token table
+selection from the independent-MB hot path without adding lookup tables, so it
+does not add SRAM, `.rodata`, or encoder arena storage.
 The byte-oriented bit-writer accumulator is internal writer state and does not
 change the `256` byte RBSP scratch block, encoder arena size, or reported
 `296` byte total.

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -2659,46 +2659,12 @@ static void encode_chroma8x8_dc_pair(sh264e_encoder_t *encoder,
     out_chroma_dc[1] = encode_chroma8x8_dc(encoder, slice, 2u, mb_x, 0u, 0u);
 }
 
-static unsigned cavlc_coeff_token_table_for_nc(unsigned nC)
-{
-    if (nC < 2u) {
-        return 0u;
-    }
-    if (nC < 4u) {
-        return 1u;
-    }
-    if (nC < 8u) {
-        return 2u;
-    }
-    return 3u;
-}
-
-static void write_coeff_token_one_or_zero(sh264e_bit_writer_t *bw, int has_coeff, unsigned nC)
-{
-    static const uint8_t len[4][2] = {
-        {1, 6},
-        {2, 6},
-        {4, 6},
-        {6, 6}
-    };
-    static const uint8_t bits[4][2] = {
-        {1, 5},
-        {3, 11},
-        {15, 15},
-        {3, 0}
-    };
-    const unsigned table = cavlc_coeff_token_table_for_nc(nC);
-    const unsigned index = has_coeff != 0 ? 1u : 0u;
-
-    bw_write_bits(bw, bits[table][index], len[table][index]);
-}
-
 static int write_cavlc_level(sh264e_bit_writer_t *bw, int level);
 
-static void write_luma_residual_dc_only(sh264e_bit_writer_t *bw, int level, unsigned nC)
+static void write_luma_residual_dc_only_nc0(sh264e_bit_writer_t *bw, int level)
 {
     if (level == 0) {
-        write_coeff_token_one_or_zero(bw, 0, nC);
+        bw_write_bit(bw, 1);             /* TotalCoeff=0 for fixed nC=0 luma */
         return;
     }
     if (level == 1) {
@@ -2706,7 +2672,7 @@ static void write_luma_residual_dc_only(sh264e_bit_writer_t *bw, int level, unsi
     } else if (level == -1) {
         level = -2;
     }
-    write_coeff_token_one_or_zero(bw, 1, nC);
+    bw_write_bits(bw, 0x05u, 6);         /* TotalCoeff=1, TrailingOnes=0 for nC=0 */
     if (!write_cavlc_level(bw, level)) {
         bw->error = 1;
         return;
@@ -2809,7 +2775,7 @@ static sh264e_status_t write_idr_mb_slice_payload(sh264e_encoder_t *encoder,
         bw_write_bit(bw, 1);                     /* mb_qp_delta: se(0) */
         for (b = 0; b < 16u; b++) {
             if ((cbp_luma & (1u << (b / 4u))) != 0u) {
-                write_luma_residual_dc_only(bw, levels[b], 0u);
+                write_luma_residual_dc_only_nc0(bw, levels[b]);
             }
         }
         if (cbp_chroma != 0u) {


### PR DESCRIPTION
Refs #126

## Summary
- specialize the luma DC-only residual writer for fixed unavailable-neighbor `nC=0`
- remove the hot-path coeff-token table selection and emit the fixed `nC=0` zero/one-coefficient codes directly
- avoid adding lookup tables, public APIs, persistent SRAM, `.rodata`, or encoder arena storage
- update Cortex-M optimization, benchmark, and encoder memory docs for the fixed `nC=0` residual writer status

## Validation
- `cmake -S . -B build-issue126`
- `cmake --build build-issue126`
- `ctest --test-dir build-issue126 --output-on-failure`
- byte-identical progressive I420 output versus `origin/main`: SHA-256 `dbd453bac68606603100d8db9c3b92917bea54871d7f290502eb6179bd210a79`
- byte-identical progressive NV12 output versus `origin/main`: SHA-256 `e3b6a27665de9c9dc7266ec6d82402b0c404c52bd14fdab883c39d7285f409ac`
- `git diff --check`

## Local QEMU caveat
- CMake reported: `Skipping QEMU firmware tests: arm-none-eabi-gcc cannot compile <stdlib.h>`
- `python3 tests/run_qemu_proxy_timing.py --build-dir build-issue126 --repeat 5` could not run because the QEMU benchmark ELF files were not generated by the local toolchain configuration.
