### PR TITLE
h264: write caller-buffer IDR slices directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Cr component frame. One-shot JPEG APIs may still require a caller-provided
 complete H.264 output buffer; that output model is separate from JPEG decoded
 image memory.
 The JPEG tool uses the streaming H.264 output consumer API for its production arena path, so it flushes the Annex B byte stream as it is produced instead of allocating `sh264e_get_max_output_size()` bytes for the complete frame. For the current 2560x1440 encoder geometry this replaces the 5,588,224-byte one-shot output capacity with a reusable 4,096-byte output chunk buffer. Embedded callers can use the same API to forward chunks to flash, storage, DMA, or a ring buffer without a full-frame or full-slice output buffer.
-IDR macroblock-slice NALUs on this path are written directly from the bit writer into the Annex B chunk writer as bytes become complete, including emulation-prevention insertion. The caller-buffer APIs still produce byte-identical Annex B output through their existing RBSP scratch path.
+IDR macroblock-slice NALUs on this path and the caller-buffer path are written directly from the bit writer into the Annex B writer as bytes become complete, including emulation-prevention insertion. SPS/PPS still use the fixed RBSP scratch block, so the reported encoder arena size is unchanged.
 
 For Cortex-M validation, CMake builds QEMU smoke firmware for M3/M4/M7 when the ARM bare-metal toolchain and QEMU are available. CMake first probes whether `arm-none-eabi-gcc` can compile the library's standard-header usage; if the toolchain is only partially installed, QEMU firmware tests are skipped instead of breaking the host build.
 

--- a/docs/CORTEX_M_OPTIMIZATION_PLAN.md
+++ b/docs/CORTEX_M_OPTIMIZATION_PLAN.md
@@ -230,10 +230,10 @@ The luma DC-only residual writer now uses the fixed unavailable-neighbor
 table at runtime. No lookup table was added, so the change does not move data
 into SRAM or `.rodata`.
 
-The JPEG/output-consumer streaming path now writes each completed IDR
-macroblock-slice RBSP byte directly through the Annex B emulation-prevention
-streamer instead of staging the macroblock in `encoder->rbsp` and replaying it.
-SPS/PPS and caller-buffer progressive APIs still use the 256-byte
-one-macroblock RBSP scratch, so the public encoder memory report and arena size
-stay unchanged. The direct path preserves byte-identical Annex B output and
-consumer failure propagation.
+The JPEG/output-consumer streaming path and caller-buffer progressive path now
+write each completed IDR macroblock-slice RBSP byte directly through the Annex B
+emulation-prevention writer instead of staging the macroblock in `encoder->rbsp`
+and replaying it. SPS/PPS still use the 256-byte one-macroblock RBSP scratch,
+so the public encoder memory report and arena size stay unchanged. The direct
+paths preserve byte-identical Annex B output, bounded-buffer overflow behavior,
+and consumer failure propagation.

--- a/docs/ENCODER_MEMORY_REPORT.md
+++ b/docs/ENCODER_MEMORY_REPORT.md
@@ -82,15 +82,14 @@ does not add SRAM, `.rodata`, or encoder arena storage.
 The byte-oriented bit-writer accumulator is internal writer state and does not
 change the `256` byte RBSP scratch block, encoder arena size, or reported
 `296` byte total.
-The streaming output-consumer path bypasses the RBSP scratch for IDR
-macroblock-slice NALUs by sending completed RBSP bytes directly through the
-Annex B emulation-prevention chunk writer. The scratch block remains part of
-the encoder report because SPS/PPS and caller-buffer progressive APIs still use
-it, so the reported total and caller-provided arena size are unchanged.
-The next caller-buffer output optimization should evaluate using the same direct
-Annex B writer model for caller-buffer IDR output. If that removes or changes
-the remaining RBSP scratch requirement, this report, the public diagnostic
-output, and the memory regression tests must be updated together.
+The streaming output-consumer path and caller-buffer progressive path bypass
+the RBSP scratch for IDR macroblock-slice NALUs by sending completed RBSP bytes
+directly through the Annex B emulation-prevention writer. The scratch block
+remains part of the encoder report because SPS/PPS still use it, so the
+reported total and caller-provided arena size are unchanged. If a future change
+removes or changes the remaining SPS/PPS scratch requirement, this report, the
+public diagnostic output, and the memory regression tests must be updated
+together.
 
 The JPEG tool prints the same report:
 

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -2090,6 +2090,10 @@ static sh264e_status_t chunk_writer_flush(sh264e_chunk_writer_t *writer)
     if (writer->size == 0u) {
         return SH264E_OK;
     }
+    if (writer->consumer == NULL) {
+        writer->total = writer->size;
+        return SH264E_OK;
+    }
     status = writer->consumer(writer->user, writer->buffer, writer->size);
     if (status != SH264E_OK) {
         return status;
@@ -2104,6 +2108,9 @@ static sh264e_status_t chunk_writer_put_byte(sh264e_chunk_writer_t *writer, uint
     sh264e_status_t status;
 
     if (writer->size == writer->capacity) {
+        if (writer->consumer == NULL) {
+            return SH264E_ERR_BUFFER_TOO_SMALL;
+        }
         status = chunk_writer_flush(writer);
         if (status != SH264E_OK) {
             return status;
@@ -2125,6 +2132,9 @@ static sh264e_status_t chunk_writer_put_bytes(sh264e_chunk_writer_t *writer,
             sh264e_status_t status = chunk_writer_flush(writer);
             if (status != SH264E_OK) {
                 return status;
+            }
+            if (writer->consumer == NULL) {
+                return SH264E_ERR_BUFFER_TOO_SMALL;
             }
             available = writer->capacity;
         }
@@ -2791,43 +2801,6 @@ static sh264e_status_t write_idr_mb_slice_payload(sh264e_encoder_t *encoder,
     return SH264E_OK;
 }
 
-static sh264e_status_t write_idr_mb_slice_rbsp(sh264e_encoder_t *encoder,
-                                               const sh264e_slice_t *slice,
-                                               unsigned row_index,
-                                               unsigned mb_x,
-                                               size_t *out_rbsp_size)
-{
-    sh264e_bit_writer_t bw;
-    sh264e_status_t status;
-
-    bw_init(&bw, encoder->rbsp, encoder->rbsp_capacity);
-
-    status = write_idr_mb_slice_payload(encoder, slice, row_index, mb_x, &bw);
-    if (status != SH264E_OK) {
-        return status;
-    }
-    *out_rbsp_size = bw_size(&bw);
-    return SH264E_OK;
-}
-
-static sh264e_status_t make_idr_slice(sh264e_encoder_t *encoder,
-                                      const sh264e_slice_t *slice,
-                                      unsigned row_index,
-                                      unsigned mb_x,
-                                      uint8_t *out,
-                                      size_t capacity,
-                                      size_t *offset)
-{
-    sh264e_status_t status;
-    size_t rbsp_size = 0u;
-
-    status = write_idr_mb_slice_rbsp(encoder, slice, row_index, mb_x, &rbsp_size);
-    if (status != SH264E_OK) {
-        return status;
-    }
-    return append_annexb_nalu(out, capacity, offset, 0x65u, encoder->rbsp, rbsp_size);
-}
-
 static sh264e_status_t stream_idr_slice_nalu_direct(sh264e_encoder_t *encoder,
                                                     const sh264e_slice_t *slice,
                                                     unsigned row_index,
@@ -2849,6 +2822,37 @@ static sh264e_status_t stream_idr_slice_nalu_direct(sh264e_encoder_t *encoder,
     if (status != SH264E_OK) {
         return status;
     }
+    return SH264E_OK;
+}
+
+static sh264e_status_t write_idr_slice_nalu_direct_to_buffer(sh264e_encoder_t *encoder,
+                                                             const sh264e_slice_t *slice,
+                                                             unsigned row_index,
+                                                             unsigned mb_x,
+                                                             uint8_t *out,
+                                                             size_t capacity,
+                                                             size_t *offset)
+{
+    sh264e_chunk_writer_t writer;
+    sh264e_status_t status;
+
+    if (out == NULL || offset == NULL) {
+        return SH264E_ERR_INVALID_ARGUMENT;
+    }
+    if (*offset > capacity) {
+        return SH264E_ERR_BUFFER_TOO_SMALL;
+    }
+
+    memset(&writer, 0, sizeof(writer));
+    writer.buffer = out;
+    writer.capacity = capacity;
+    writer.size = *offset;
+
+    status = stream_idr_slice_nalu_direct(encoder, slice, row_index, mb_x, &writer);
+    if (status != SH264E_OK) {
+        return status;
+    }
+    *offset = writer.size;
     return SH264E_OK;
 }
 
@@ -3732,8 +3736,13 @@ static sh264e_status_t sh264e_encode_idr_slice_internal(sh264e_encoder_t *encode
     {
         unsigned mb_x;
         for (mb_x = 0; mb_x < SH264E_MBS_X; mb_x++) {
-            status = make_idr_slice(encoder, slice, encoder->slices_encoded, mb_x,
-                                    out, out_capacity, &offset);
+            status = write_idr_slice_nalu_direct_to_buffer(encoder,
+                                                           slice,
+                                                           encoder->slices_encoded,
+                                                           mb_x,
+                                                           out,
+                                                           out_capacity,
+                                                           &offset);
             if (status != SH264E_OK) {
                 return status;
             }


### PR DESCRIPTION
## Summary
- Routed caller-buffer IDR macroblock-slice NALUs through the existing direct Annex B bit-writer path instead of staging each macroblock in `encoder->rbsp` and replaying it.
- Extended the internal chunk writer to support a bounded caller-buffer sink that returns `SH264E_ERR_BUFFER_TOO_SMALL` on overflow.
- Updated memory/optimization docs to clarify that SPS/PPS still keep the 256-byte RBSP scratch requirement, so public memory accounting is unchanged.

Refs #135

## Validation
- `cmake -S . -B build-issue135`
- `cmake --build build-issue135`
- `ctest --test-dir build-issue135 --output-on-failure`
- `cmake -S . -B build-qemu-issue135 -DSH264E_BUILD_QEMU_TESTS=ON`
- `cmake --build build-qemu-issue135`
- `ctest --test-dir build-qemu-issue135 -R 'sh264e_qemu_encoder_(bench|i420_stream|nv12_bench)' --output-on-failure` returned no matching tests because this host reports `Skipping QEMU firmware tests: arm-none-eabi-gcc cannot compile <stdlib.h>`.
- `python3 tests/run_qemu_proxy_timing.py --build-dir build-qemu-issue135 --repeat 5 --target sh264e_qemu_encoder_bench_m4 --target sh264e_qemu_encoder_i420_stream_bench_m4 --target sh264e_qemu_encoder_nv12_bench_m4` failed locally because the QEMU benchmark ELF files were not generated under the incomplete Cortex-M toolchain.
- Compared generated I420 and NV12 caller-buffer progressive bitstreams against `origin/main`; both were byte-identical.
- `git diff --check`
