### PR TITLE
tests: cover general ratio scaler reference

### DIFF
--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -841,6 +841,10 @@ int main(void)
     ok &= expect_resize_reference_slice("0.5x NV12 resize reference",
                                         5120u, 2880u, SH264E_PIXFMT_NV12,
                                         SH264E_V1_SLICE_COUNT - 1u);
+    ok &= expect_resize_reference_slice("general I420 resize reference",
+                                        1920u, 1080u, SH264E_PIXFMT_I420, 45u);
+    ok &= expect_resize_reference_slice("general NV12 resize reference",
+                                        1920u, 1080u, SH264E_PIXFMT_NV12, 73u);
 
     memset(&frame, 0, sizeof(frame));
     frame.width = SH264E_V1_WIDTH;


### PR DESCRIPTION
Refs #141

## Summary
- Added host API byte-exact general-ratio scaler reference coverage for `1920x1080 -> 2560x1440` I420.
- Added matching NV12 general-ratio reference coverage.
- Used non-zero slice indexes so the vertical mapper path is exercised beyond slice 0.

## Validation
- `cmake -S . -B build-issue141`
- `cmake --build build-issue141`
- `ctest --test-dir build-issue141 -R sh264e_api --output-on-failure`
- `ctest --test-dir build-issue141 --output-on-failure`
- `git diff --check`
