### PR TITLE
qemu: fix scaler benchmark checksums

### DIFF
--- a/docs/CORTEX_M_SCALER_BENCHMARKS.md
+++ b/docs/CORTEX_M_SCALER_BENCHMARKS.md
@@ -15,20 +15,24 @@ source rows reached by the measured slice window, so benchmark-only buffers do
 not represent library persistent SRAM. Each run generates `BENCH_ITERS` encoder
 slices and writes:
 
-* `sh264e_bench_checksum` - nonzero correctness guard for the generated slices.
+* `sh264e_bench_checksum` - fixed expected checksum for the generated slices.
 * `sh264e_bench_cycles` - DWT cycle count around the resize loop.
 
 Portable and DSP builds must produce the same checksum for the same target
 fixture. Treat a checksum mismatch as a correctness failure before comparing
 cycles.
 
-Scaler QEMU benchmark checksums should be fixed per target and variant once the
-fixture is stable. The checksum should cover the full generated slice output, or
-an equivalently strong deterministic byte stream, so QEMU catches phase, edge,
-and row-index regressions instead of merely proving that some output was
-produced. Sparse nonzero checksums are acceptable only for temporary bring-up
-firmware and should not be the final correctness gate for scaler optimization
-issues.
+Scaler QEMU benchmark checksums are fixed per target and cover the full
+generated luma plus NV12 chroma slice output for the measured slice window. This
+lets QEMU catch phase, edge, and row-index regressions instead of merely proving
+that some output was produced. Expected values are:
+
+| Scaler fixture | Expected checksum |
+| --- | --- |
+| 1:1 bypass | `0x0c2f7d05` |
+| Exact `1280x720 -> 2560x1440` 2x | `0x6e421d33` |
+| Exact `5120x2880 -> 2560x1440` 0.5x | `0x85f66d05` |
+| General `1920x1080 -> 2560x1440` bilinear | `0x8b3bf894` |
 
 ## Encoder Scope
 

--- a/tests/qemu_scaler_bench.c
+++ b/tests/qemu_scaler_bench.c
@@ -22,6 +22,18 @@
 #define SRC_CHROMA_ROWS (SRC_LUMA_ROWS / 2u)
 #define WORK_SIZE ((size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_LUMA_HEIGHT + \
                    (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT)
+#define FNV1A_OFFSET 2166136261u
+#define FNV1A_PRIME 16777619u
+
+#if SH264E_QEMU_SCALER_BYPASS
+#define EXPECTED_CHECKSUM 0x0c2f7d05u
+#elif SH264E_QEMU_SCALER_HALF
+#define EXPECTED_CHECKSUM 0x85f66d05u
+#elif SH264E_QEMU_SCALER_GENERAL
+#define EXPECTED_CHECKSUM 0x8b3bf894u
+#else
+#define EXPECTED_CHECKSUM 0x6e421d33u
+#endif
 
 #define DEMCR (*(volatile uint32_t *)0xE000EDFCu)
 #define DWT_CTRL (*(volatile uint32_t *)0xE0001000u)
@@ -81,6 +93,32 @@ static uint32_t dwt_stop(void)
     return DWT_CYCCNT;
 }
 
+static uint32_t checksum_bytes(uint32_t checksum, const uint8_t *data, size_t size)
+{
+    size_t i;
+
+    for (i = 0; i < size; i++) {
+        checksum ^= data[i];
+        checksum *= FNV1A_PRIME;
+    }
+    return checksum;
+}
+
+static uint32_t checksum_slice(uint32_t checksum, const sh264e_slice_t *slice)
+{
+    checksum = checksum_bytes(checksum,
+                              slice->plane[0],
+                              (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_LUMA_HEIGHT);
+    checksum = checksum_bytes(checksum,
+                              slice->plane[1],
+                              (size_t)SH264E_V1_WIDTH * SH264E_V1_SLICE_CHROMA_HEIGHT);
+    checksum ^= (uint32_t)slice->stride[0];
+    checksum *= FNV1A_PRIME;
+    checksum ^= (uint32_t)slice->stride[1];
+    checksum *= FNV1A_PRIME;
+    return checksum;
+}
+
 static int run_benchmark(void)
 {
     sh264e_frame_t frame;
@@ -93,7 +131,7 @@ static int run_benchmark(void)
         WORK_SIZE;
 #endif
     uint32_t iter;
-    uint32_t checksum = 2166136261u;
+    uint32_t checksum = FNV1A_OFFSET;
 
     memset(&frame, 0, sizeof(frame));
     frame.width = SRC_W;
@@ -120,19 +158,22 @@ static int run_benchmark(void)
                                      work_ptr, work_capacity, &slice) != SH264E_OK) {
             return 3;
         }
-        checksum ^= slice.plane[0][iter * 97u];
-        checksum *= 16777619u;
-        checksum ^= slice.plane[1][iter * 53u];
-        checksum *= 16777619u;
-        checksum ^= (uint32_t)slice.stride[0];
-        checksum *= 16777619u;
-        checksum ^= (uint32_t)slice.stride[1];
-        checksum *= 16777619u;
     }
     sh264e_bench_cycles = dwt_stop();
+
+    for (iter = 0; iter < BENCH_ITERS; iter++) {
+        uint8_t *work_ptr = expected_work_size == 0u ? NULL : work;
+        size_t work_capacity = expected_work_size == 0u ? 0u : sizeof(work);
+
+        if (sh264e_resize_make_slice(&frame, iter % SH264E_V1_SLICE_COUNT,
+                                     work_ptr, work_capacity, &slice) != SH264E_OK) {
+            return 3;
+        }
+        checksum = checksum_slice(checksum, &slice);
+    }
     sh264e_bench_checksum = checksum;
 
-    if (checksum == 0u) {
+    if (checksum != EXPECTED_CHECKSUM) {
         return 4;
     }
     return 0;


### PR DESCRIPTION
Refs #143

## Summary
- Replaced sparse nonzero scaler benchmark checks with fixed expected checksums for 1:1, exact 2x, exact 0.5x, and general bilinear fixtures.
- Hash every generated luma and NV12 chroma byte across the benchmark slice window, plus output strides, so phase/row/edge regressions fail deterministically.
- Keep DWT timing focused on the resize loop by running the full checksum pass separately.
- Documented the expected scaler fixture checksums.

## Validation
- `cmake -S . -B build-issue143`
- `cmake --build build-issue143`
- `ctest --test-dir build-issue143 --output-on-failure`
- `cmake -S . -B build-qemu-issue143 -DSH264E_BUILD_QEMU_TESTS=ON`
- `cmake --build build-qemu-issue143`
- `ctest --test-dir build-qemu-issue143 -R 'sh264e_qemu_scaler' --output-on-failure` found no firmware tests locally because this host reports `Skipping QEMU firmware tests: arm-none-eabi-gcc cannot compile <stdlib.h>`.
- `python3 tests/run_qemu_proxy_timing.py --build-dir build-qemu-issue143 --repeat 5` could not run locally because the QEMU ELF targets were not generated under this incomplete Cortex-M toolchain.
- `git diff --check`

Expected checksum constants were computed from the deterministic scaler fixtures with the same full-slice FNV-1a byte stream used by `tests/qemu_scaler_bench.c`.
