### PR TITLE
Scaler/JPEG: specialize streaming general x loop

### DIFF
--- a/docs/CORTEX_M_OPTIMIZATION_PLAN.md
+++ b/docs/CORTEX_M_OPTIMIZATION_PLAN.md
@@ -260,6 +260,10 @@ without adding persistent x-map storage or slice-work memory.
 The JPEG MCU-row streaming path now uses the same exact-ratio quarter-step
 sampler for matching 2x and 0.5x source JPEGs while preserving the 1:1
 zero-slice-work path and rolling row-cache behavior.
+For non-exact-ratio JPEG dimensions, the MCU-row streaming scaler uses the same
+row-level general x-loop structure as the raw scaler, including direct
+fixed-point x-state advancement for the unclamped middle span and separate
+clamped-edge handling for I420 and NV12 output.
 The exact-ratio blend now uses quarter-step integer weights. DSP-capable ARM
 builds use `smlad` where it remains useful for exact-ratio pair sums, while the
 2x and 0.5x fixed phases reuse portable 32-bit partial sums before the final

--- a/docs/CORTEX_M_SCALER_BENCHMARKS.md
+++ b/docs/CORTEX_M_SCALER_BENCHMARKS.md
@@ -234,9 +234,13 @@ the correctness gate before proxy timing is used to judge this change.
 
 For the JPEG streaming general x-loop specialization, compare the JPEG stream
 exact 2x and exact 0.5x rows as controls and add a general-ratio JPEG streaming
-benchmark row only if the fixture can remain small and deterministic. The host
-ffmpeg integration test remains responsible for compressed JPEG parser coverage
-and for decoded-frame comparison of the 0.5x downscale path.
+benchmark row only if the fixture can remain small and deterministic. The JPEG
+streaming general path now applies the row-level fixed-point x-loop structure to
+retained MCU rows for I420 output and to the Cb/Cr-to-NV12 bridge without adding
+persistent x-map storage. The host ffmpeg integration test covers a compressed
+`1920x1080 -> 2560x1440` general-ratio JPEG fixture, while remaining
+responsible for compressed JPEG parser coverage and decoded-frame comparison of
+the 0.5x downscale path.
 
 ## Simulator DWT And WFI Profile
 

--- a/docs/JPEG_STREAMING_MEMORY_REPORT.md
+++ b/docs/JPEG_STREAMING_MEMORY_REPORT.md
@@ -131,6 +131,9 @@ representative JPEG fixtures. It also keeps broader color-subsampling coverage
 that fails if the production arena path regresses to full component-plane
 allocation or if the default JPEG tool path regresses to allocating
 `sh264e_get_max_output_size()` for H.264 output.
+The ffmpeg integration suite also includes a `1920x1080 -> 2560x1440` 4:2:0
+JPEG fixture so non-exact-ratio MCU-row streaming resize remains covered for
+both I420 and NV12 output without allocating full decoded component planes.
 
 The source-input stress cases feed generated JPEGs through chunk limits of 1, 2,
 7, 64, and 1024 bytes. Those cases force marker parsing and entropy decode

--- a/src/sh264e.c
+++ b/src/sh264e.c
@@ -764,18 +764,6 @@ static void bilinear_blend_quarter_phase13_u8(uint8_t p00,
     *phase3 = bilinear_finish_quarter_u8(top_phase3, bottom_phase3, wy_quarters);
 }
 
-static uint8_t bilinear_sample_plane_rows(const uint8_t *row0,
-                                          const uint8_t *row1,
-                                          uint32_t src_width,
-                                          sh264e_scale_coord_t sx,
-                                          uint32_t wy)
-{
-    const uint32_t x0 = sx.index;
-    const uint32_t x1 = x0 + 1u < src_width ? x0 + 1u : x0;
-
-    return bilinear_blend_u8(row0[x0], row0[x1], row1[x0], row1[x1], sx.fraction, wy);
-}
-
 static void scale_general_plane_row(const uint8_t *row0,
                                     const uint8_t *row1,
                                     uint32_t src_width,
@@ -864,6 +852,65 @@ static void scale_general_nv12_chroma_row(const uint8_t *row0,
                                                      row0[last_offset + 1u],
                                                      row1[last_offset + 1u],
                                                      row1[last_offset + 1u],
+                                                     0u, wy);
+    }
+}
+
+static void scale_general_component_pair_to_nv12_row(const uint8_t *cb_row0,
+                                                     const uint8_t *cb_row1,
+                                                     const uint8_t *cr_row0,
+                                                     const uint8_t *cr_row1,
+                                                     uint32_t src_width,
+                                                     uint8_t *dst_row,
+                                                     uint32_t dst_width,
+                                                     uint32_t wy)
+{
+    const uint64_t max_pos = (uint64_t)(src_width - 1u) * (uint64_t)SH264E_SCALE_FP_ONE;
+    const uint32_t last_x = src_width - 1u;
+    sh264e_axis_mapper_t x_mapper = scale_axis_mapper_init(src_width, dst_width, 0u);
+    uint32_t x = 0;
+
+    for (; x < dst_width && x_mapper.pos <= 0; x++) {
+        const size_t dst_offset = (size_t)x * 2u;
+
+        dst_row[dst_offset] = bilinear_blend_u8(cb_row0[0], cb_row0[0],
+                                                cb_row1[0], cb_row1[0],
+                                                0u, wy);
+        dst_row[dst_offset + 1u] = bilinear_blend_u8(cr_row0[0], cr_row0[0],
+                                                     cr_row1[0], cr_row1[0],
+                                                     0u, wy);
+        scale_axis_mapper_advance(&x_mapper);
+    }
+    for (; x < dst_width && (uint64_t)x_mapper.pos < max_pos; x++) {
+        const uint64_t raw_pos = (uint64_t)x_mapper.pos;
+        const uint32_t x0 = (uint32_t)(raw_pos >> SH264E_SCALE_FP_BITS);
+        const uint32_t wx = (uint32_t)(raw_pos & (uint64_t)(SH264E_SCALE_FP_ONE - 1u));
+        const size_t dst_offset = (size_t)x * 2u;
+
+        dst_row[dst_offset] = bilinear_blend_u8(cb_row0[x0],
+                                                cb_row0[x0 + 1u],
+                                                cb_row1[x0],
+                                                cb_row1[x0 + 1u],
+                                                wx, wy);
+        dst_row[dst_offset + 1u] = bilinear_blend_u8(cr_row0[x0],
+                                                     cr_row0[x0 + 1u],
+                                                     cr_row1[x0],
+                                                     cr_row1[x0 + 1u],
+                                                     wx, wy);
+        scale_axis_mapper_advance(&x_mapper);
+    }
+    for (; x < dst_width; x++) {
+        const size_t dst_offset = (size_t)x * 2u;
+
+        dst_row[dst_offset] = bilinear_blend_u8(cb_row0[last_x],
+                                                cb_row0[last_x],
+                                                cb_row1[last_x],
+                                                cb_row1[last_x],
+                                                0u, wy);
+        dst_row[dst_offset + 1u] = bilinear_blend_u8(cr_row0[last_x],
+                                                     cr_row0[last_x],
+                                                     cr_row1[last_x],
+                                                     cr_row1[last_x],
                                                      0u, wy);
     }
 }
@@ -1241,15 +1288,8 @@ static void streaming_scale_component_slice(const sh264e_jpeg_stream_component_t
         const uint32_t y1 = y0 + 1u < src->height ? y0 + 1u : y0;
         const uint8_t *row0 = streaming_component_row_ptr(src, y0);
         const uint8_t *row1 = streaming_component_row_ptr(src, y1);
-        sh264e_axis_mapper_t x_mapper = scale_axis_mapper_init(src->width, dst_width, 0u);
-        uint32_t x;
 
-        for (x = 0; x < dst_width; x++) {
-            const sh264e_scale_coord_t sx = scale_coord_from_raw(x_mapper.pos, src->width);
-
-            dst_row[x] = bilinear_sample_plane_rows(row0, row1, src->width, sx, sy.fraction);
-            scale_axis_mapper_advance(&x_mapper);
-        }
+        scale_general_plane_row(row0, row1, src->width, dst_row, dst_width, sy.fraction);
         scale_axis_mapper_advance(&y_mapper);
     }
 }
@@ -1316,16 +1356,10 @@ static void streaming_scale_nv12_component_chroma_slice(const sh264e_jpeg_stream
         const uint8_t *cb_row1 = streaming_component_row_ptr(cb, y1);
         const uint8_t *cr_row0 = streaming_component_row_ptr(cr, y0);
         const uint8_t *cr_row1 = streaming_component_row_ptr(cr, y1);
-        sh264e_axis_mapper_t x_mapper = scale_axis_mapper_init(cb->width, SH264E_CHROMA_WIDTH, 0u);
-        uint32_t x;
 
-        for (x = 0; x < SH264E_CHROMA_WIDTH; x++) {
-            const sh264e_scale_coord_t sx = scale_coord_from_raw(x_mapper.pos, cb->width);
-
-            row[(size_t)x * 2u] = bilinear_sample_plane_rows(cb_row0, cb_row1, cb->width, sx, sy.fraction);
-            row[(size_t)x * 2u + 1u] = bilinear_sample_plane_rows(cr_row0, cr_row1, cr->width, sx, sy.fraction);
-            scale_axis_mapper_advance(&x_mapper);
-        }
+        scale_general_component_pair_to_nv12_row(cb_row0, cb_row1, cr_row0, cr_row1,
+                                                 cb->width, row, SH264E_CHROMA_WIDTH,
+                                                 sy.fraction);
         scale_axis_mapper_advance(&y_mapper);
     }
 }

--- a/tests/run_ffmpeg_integration.py
+++ b/tests/run_ffmpeg_integration.py
@@ -14,6 +14,8 @@ SMALL_WIDTH = 1280
 SMALL_HEIGHT = 720
 LARGE_WIDTH = 2560
 LARGE_HEIGHT = 1440
+GENERAL_WIDTH = 1920
+GENERAL_HEIGHT = 1080
 DOWNSCALE_WIDTH = 5120
 DOWNSCALE_HEIGHT = 2880
 JPEG_SLICE_WORK_BYTES = WIDTH * 16 + (WIDTH // 2) * 8 * 2
@@ -36,6 +38,7 @@ FULL_COMPONENT_BYTES_720P = {
     "yuvj444p": 2_764_800,
 }
 FULL_COMPONENT_BYTES_1440P_420 = 5_529_600
+FULL_COMPONENT_BYTES_GENERAL_420 = 3_110_400
 FULL_COMPONENT_BYTES_2880P_420 = 22_118_400
 PRODUCTION_MEMORY_720P_420 = {
     "work": 92_304,
@@ -896,6 +899,19 @@ def main():
     validate_bitstream(args.ffprobe, args.ffmpeg, large_streaming_output)
     compare_decoded_i420(args, large_jpeg_output, large_streaming_output,
                          "output_jpeg_1440p_yuvj420p_i420_streaming_compare")
+
+    general_jpeg_input = workdir / "input_1080p_yuvj420p.jpg"
+    make_color_jpeg_sized(args, general_jpeg_input, "yuvj420p", GENERAL_WIDTH, GENERAL_HEIGHT)
+    general_outputs = {}
+    for fmt in ("i420", "nv12"):
+        general_output = workdir / f"output_jpeg_1080p_yuvj420p_{fmt}.h264"
+        encode_jpeg(args, fmt, general_jpeg_input, general_output,
+                    max_peak_bytes=FULL_COMPONENT_BYTES_GENERAL_420,
+                    expected_exact_resize_mask=0)
+        validate_bitstream(args.ffprobe, args.ffmpeg, general_output)
+        general_outputs[fmt] = general_output
+    compare_decoded_i420(args, general_outputs["i420"], general_outputs["nv12"],
+                         "output_jpeg_1080p_yuvj420p_i420_nv12_compare")
 
     downscale_jpeg_input = workdir / "input_2880p_yuvj420p.jpg"
     make_color_jpeg_sized(args, downscale_jpeg_input, "yuvj420p", DOWNSCALE_WIDTH, DOWNSCALE_HEIGHT)


### PR DESCRIPTION
## Summary
- Apply the row-level general bilinear x-loop structure to JPEG MCU-row streaming component scaling.
- Add a component-pair-to-NV12 general row helper for retained Cb/Cr rows without persistent x-map storage or slice-work growth.
- Add compressed 1920x1080 -> 2560x1440 JPEG integration coverage for I420/NV12 general-ratio output.
- Update Cortex-M/JPEG docs for the general-ratio streaming path status.

Refs #146

## Validation
- `cmake -S . -B build-issue146`
- `cmake --build build-issue146`
- `ctest --test-dir build-issue146 -R sh264e_ffmpeg_integration --output-on-failure`
- `ctest --test-dir build-issue146 --output-on-failure`
- `cmake -S . -B build-qemu-issue146 -DSH264E_BUILD_QEMU_TESTS=ON`
- `cmake --build build-qemu-issue146`
- `ctest --test-dir build-qemu-issue146 -R 'sh264e_qemu_(scaler|jpeg)' --output-on-failure` found no firmware tests locally because this host reports `Skipping QEMU firmware tests: arm-none-eabi-gcc cannot compile <stdlib.h>`.
- `python3 tests/run_qemu_proxy_timing.py --build-dir build-qemu-issue146 --repeat 5` could not run locally because the QEMU benchmark ELF files were not generated under this incomplete Cortex-M toolchain.
- `git diff --check`